### PR TITLE
fix(cli): write-out variables, config files, and variable expansion

### DIFF
--- a/crates/liburlx/src/easy.rs
+++ b/crates/liburlx/src/easy.rs
@@ -675,6 +675,16 @@ impl Easy {
         self.body = Some(data.to_vec());
     }
 
+    /// Clear the request body (used by `--next` to reset per-request state).
+    pub fn clear_body(&mut self) {
+        self.body = None;
+    }
+
+    /// Reset the HTTP method to default (used by `--next` to reset per-request state).
+    pub fn reset_method(&mut self) {
+        self.method = None;
+    }
+
     /// Append data to the request body (used for multiple --json flags).
     ///
     /// If no body exists yet, this creates a new one. Otherwise, it appends
@@ -828,6 +838,11 @@ impl Easy {
     #[must_use]
     pub fn header_list(&self) -> &[(String, String)] {
         &self.headers
+    }
+
+    /// Clear all custom headers (used by `--next` to reset per-request state).
+    pub fn clear_headers(&mut self) {
+        self.headers.clear();
     }
 
     /// Set the TCP connection timeout.
@@ -5094,6 +5109,10 @@ async fn do_single_request(
     .await?;
     let time_connect = request_start.elapsed();
 
+    // Capture local/remote socket addresses for write-out variables
+    let conn_local_addr = tcp_stream.local_addr().ok();
+    let conn_peer_addr = tcp_stream.peer_addr().ok();
+
     if verbose {
         #[allow(clippy::print_stderr)]
         if let Ok(peer) = tcp_stream.peer_addr() {
@@ -5159,7 +5178,7 @@ async fn do_single_request(
         tcp_stream
     };
 
-    let response = match url.scheme() {
+    let mut response = match url.scheme() {
         "https" => {
             // HTTP/3 over QUIC — bypasses TCP/TLS, uses UDP transport
             // Triggered by explicit --http3 flag OR Alt-Svc cache indicating h3 support
@@ -5627,6 +5646,20 @@ async fn do_single_request(
         }
         scheme => return Err(Error::UnsupportedProtocol(scheme.to_string())),
     };
+
+    // Populate connection address info on the response (for -w %{local_ip} etc.)
+    {
+        let mut info = response.transfer_info().clone();
+        if let Some(local) = conn_local_addr {
+            info.local_ip = local.ip().to_string();
+            info.local_port = local.port();
+        }
+        if let Some(peer) = conn_peer_addr {
+            info.remote_ip = peer.ip().to_string();
+            info.remote_port = peer.port();
+        }
+        response.set_transfer_info(info);
+    }
 
     Ok(maybe_decompress(response, accept_encoding))
 }

--- a/crates/liburlx/src/protocol/http/response.rs
+++ b/crates/liburlx/src/protocol/http/response.rs
@@ -73,6 +73,14 @@ pub struct TransferInfo {
     pub effective_method: String,
     /// The Referer header value used in the last request (for `%{referer}` write-out).
     pub referer: String,
+    /// Local IP address of the connection.
+    pub local_ip: String,
+    /// Local port of the connection.
+    pub local_port: u16,
+    /// Remote IP address of the connection.
+    pub remote_ip: String,
+    /// Remote port of the connection.
+    pub remote_port: u16,
 }
 
 /// An HTTP response with status, headers, and body.

--- a/crates/liburlx/tests/response_api_completeness.rs
+++ b/crates/liburlx/tests/response_api_completeness.rs
@@ -243,6 +243,10 @@ fn transfer_info_all_timing_fields() {
         num_retries: 0,
         effective_method: "GET".to_string(),
         referer: String::new(),
+        local_ip: String::new(),
+        local_port: 0,
+        remote_ip: String::new(),
+        remote_port: 0,
     };
 
     assert_eq!(info.time_namelookup, Duration::from_millis(5));
@@ -308,6 +312,10 @@ fn transfer_info_clone_preserves_all_fields() {
         num_retries: 0,
         effective_method: "POST".to_string(),
         referer: String::new(),
+        local_ip: String::new(),
+        local_port: 0,
+        remote_ip: String::new(),
+        remote_port: 0,
     };
     let cloned = info.clone();
     assert_eq!(cloned.time_namelookup, info.time_namelookup);

--- a/crates/urlx-cli/src/args.rs
+++ b/crates/urlx-cli/src/args.rs
@@ -132,7 +132,8 @@ pub struct CliOptions {
     /// Original -X value preserving case (for non-HTTP protocol commands).
     pub(crate) custom_request_original: Option<String>,
     /// Variables set via `--variable` for `--expand-*` expansion.
-    pub(crate) variables: Vec<(String, String)>,
+    /// Values are stored as raw bytes to support binary data (null bytes etc.).
+    pub(crate) variables: Vec<(String, Vec<u8>)>,
     /// `--skip-existing`: skip download if output file already exists.
     pub(crate) skip_existing: bool,
     /// `--json` was used — defer Content-Type/Accept headers until after arg parsing.
@@ -140,6 +141,11 @@ pub struct CliOptions {
     /// Per-URL FTP method (indexed by URL position).
     /// Supports `--next` changing `--ftp-method` between URL groups (test 1096).
     pub(crate) per_url_ftp_methods: Vec<liburlx::protocol::ftp::FtpMethod>,
+    /// Per-URL Easy handles for `--next` groups (indexed by URL position).
+    /// Each entry records the Easy handle state for that URL's group.
+    pub(crate) per_url_easy: Vec<Option<liburlx::Easy>>,
+    /// URL index where the current --next group starts (for per-URL Easy handles).
+    pub(crate) group_easy_start: usize,
 }
 
 /// Print version information to stdout.
@@ -337,11 +343,79 @@ pub fn parse_args(args: &[String]) -> ParseResult {
         }
     }
 
+    // Step 2b: Check if -K/--config or -q was explicitly given.
+    // If not, auto-load .curlrc from standard locations (curl compat: tests 433, 436).
+    let has_explicit_config = expanded
+        .iter()
+        .skip(1)
+        .any(|a| a == "-K" || a == "--config" || a == "-q" || a == "--disable");
+    let mut final_args = expanded;
+    if !has_explicit_config {
+        if let Some(rc_path) = find_curlrc() {
+            if let Ok(contents) = std::fs::read_to_string(&rc_path) {
+                let config_args = parse_config_file(&contents);
+                if !config_args.is_empty() {
+                    // Emit note about reading config file (curl compat: tests 433, 436)
+                    eprintln!("Note: Read config file from '{rc_path}'");
+                    // Insert config args after program name, before user args
+                    let mut with_rc = vec![final_args[0].clone()];
+                    with_rc.extend(config_args);
+                    with_rc.extend_from_slice(&final_args[1..]);
+                    final_args = with_rc;
+                }
+            }
+        }
+    }
+
     // Step 3: Parse options
-    match parse_args_options_with_depth(&expanded, 0) {
+    match parse_args_options_with_depth(&final_args, 0) {
         Ok(opts) => ParseResult::Options(Box::new(opts)),
         Err(code) => ParseResult::Error(code),
     }
+}
+
+/// Find the .curlrc configuration file in standard locations.
+///
+/// Search order (curl compat: tests 433, 436):
+/// 1. `$CURL_HOME/.curlrc`
+/// 2. `$XDG_CONFIG_HOME/curlrc` (note: NOT `.curlrc`, just `curlrc`)
+/// 3. `$HOME/.curlrc`
+fn find_curlrc() -> Option<String> {
+    // Check $CURL_HOME/.curlrc then $CURL_HOME/.config/curlrc
+    if let Ok(curl_home) = std::env::var("CURL_HOME") {
+        if !curl_home.is_empty() {
+            let path = format!("{curl_home}/.curlrc");
+            if std::path::Path::new(&path).exists() {
+                return Some(path);
+            }
+            let path = format!("{curl_home}/.config/curlrc");
+            if std::path::Path::new(&path).exists() {
+                return Some(path);
+            }
+        }
+    }
+
+    // Check $XDG_CONFIG_HOME/curlrc (NOT .curlrc)
+    if let Ok(xdg) = std::env::var("XDG_CONFIG_HOME") {
+        if !xdg.is_empty() {
+            let path = format!("{xdg}/curlrc");
+            if std::path::Path::new(&path).exists() {
+                return Some(path);
+            }
+        }
+    }
+
+    // Check $HOME/.curlrc
+    if let Ok(home) = std::env::var("HOME") {
+        if !home.is_empty() {
+            let path = format!("{home}/.curlrc");
+            if std::path::Path::new(&path).exists() {
+                return Some(path);
+            }
+        }
+    }
+
+    None
 }
 
 /// Expand combined short flags into individual flags.
@@ -467,6 +541,8 @@ fn expand_combined_flags(args: &[String]) -> Vec<String> {
                         | "--proxy-ciphers"
                         | "--variable"
                         | "--expand-data"
+                        | "--expand-url"
+                        | "--expand-output"
                         | "--json"
                         | "--mail-from"
                         | "--mail-rcpt"
@@ -603,6 +679,8 @@ fn parse_args_options_with_depth(args: &[String], config_depth: u32) -> Result<C
         skip_existing: false,
         json_mode: false,
         per_url_ftp_methods: Vec::new(),
+        per_url_easy: Vec::new(),
+        group_easy_start: 0,
     };
 
     let mut i = 1;
@@ -1398,7 +1476,10 @@ fn parse_args_options_with_depth(args: &[String], config_depth: u32) -> Result<C
                 };
                 match contents_result {
                     Ok(contents) => {
-                        let config_args = parse_config_file(&contents);
+                        let config_args = parse_config_file_with_path(
+                            &contents,
+                            if val == "-" { None } else { Some(val) },
+                        );
                         // Re-parse with: args before -K, config args, args after -K
                         let mut full_args = vec!["urlx".to_string()];
                         // Include CLI args that came before -K (skip program name at [0])
@@ -1784,6 +1865,7 @@ fn parse_args_options_with_depth(args: &[String], config_depth: u32) -> Result<C
                 opts.urls.push(val.to_string());
                 opts.per_url_credentials.push(opts.user_credentials.clone());
                 opts.per_url_ftp_methods.push(current_ftp_method);
+                opts.per_url_easy.push(None);
                 opts.next_needs_url = false;
             }
             "--output-dir" => {
@@ -1824,18 +1906,39 @@ fn parse_args_options_with_depth(args: &[String], config_depth: u32) -> Result<C
                 i += 1;
                 let val = require_arg(args, i, "--variable")?;
                 let (name, value) = parse_variable(val)?;
-                opts.variables.push((name, value));
+                // Duplicate variable names override (curl compat: test 451)
+                if let Some(existing) = opts.variables.iter_mut().find(|(n, _)| *n == name) {
+                    existing.1 = value;
+                } else {
+                    opts.variables.push((name, value));
+                }
             }
             "--expand-data" => {
                 i += 1;
                 let val = require_arg(args, i, "--expand-data")?;
-                let expanded = expand_variables(val, &opts.variables);
+                let expanded = expand_variables(val, &opts.variables)?;
                 opts.easy.body(expanded.as_bytes());
                 opts.has_post_data = true;
                 if opts.easy.method_is_default() {
                     opts.easy.method("POST");
                 }
                 opts.easy.set_form_data(true);
+            }
+            "--expand-url" => {
+                i += 1;
+                let val = require_arg(args, i, "--expand-url")?;
+                let expanded = expand_variables(val, &opts.variables)?;
+                opts.urls.push(expanded);
+                opts.per_url_credentials.push(opts.user_credentials.clone());
+                opts.per_url_easy.push(None);
+                opts.next_needs_url = false;
+            }
+            "--expand-output" => {
+                i += 1;
+                let val = require_arg(args, i, "--expand-output")?;
+                let expanded = expand_variables(val, &opts.variables)?;
+                opts.output_file = Some(expanded.clone());
+                opts.output_files.push(expanded);
             }
             // No-op flags for compatibility (accepted but not implemented)
             "-N"
@@ -1984,9 +2087,23 @@ fn parse_args_options_with_depth(args: &[String], config_depth: u32) -> Result<C
                 for slot in opts.per_url_ftp_methods[group_start_idx..].iter_mut() {
                     *slot = current_ftp_method;
                 }
+                // Save per-URL Easy handles for the current group
+                let current_easy = opts.easy.clone();
+                for slot in opts.per_url_easy[opts.group_easy_start..].iter_mut() {
+                    if slot.is_none() {
+                        *slot = Some(current_easy.clone());
+                    }
+                }
+                opts.group_easy_start = opts.per_url_easy.len();
                 group_start_idx = opts.per_url_credentials.len();
                 opts.user_credentials = None;
                 current_ftp_method = liburlx::protocol::ftp::FtpMethod::default();
+                // Reset per-request state (curl compat: tests 430-432)
+                opts.easy.clear_headers();
+                opts.easy.clear_body();
+                opts.has_post_data = false;
+                opts.easy.reset_method();
+                opts.easy.set_form_data(false);
                 opts.next_needs_url = true;
                 opts.had_next = true;
             }
@@ -2010,6 +2127,7 @@ fn parse_args_options_with_depth(args: &[String], config_depth: u32) -> Result<C
                 opts.urls.push(url.to_string());
                 opts.per_url_credentials.push(opts.user_credentials.clone());
                 opts.per_url_ftp_methods.push(current_ftp_method);
+                opts.per_url_easy.push(None); // Will be filled on --next or at end
                 opts.next_needs_url = false;
             }
         }
@@ -2029,6 +2147,16 @@ fn parse_args_options_with_depth(args: &[String], config_depth: u32) -> Result<C
     // Assign last group's ftp_method to all URLs in the last group
     for slot in opts.per_url_ftp_methods[group_start_idx..].iter_mut() {
         *slot = current_ftp_method;
+    }
+
+    // Assign last group's Easy handle to URLs that weren't assigned yet
+    {
+        let current_easy = opts.easy.clone();
+        for slot in opts.per_url_easy[opts.group_easy_start..].iter_mut() {
+            if slot.is_none() {
+                *slot = Some(current_easy.clone());
+            }
+        }
     }
 
     // --next at the end with no URL is a parse error (curl returns exit code 2)
@@ -2188,21 +2316,54 @@ pub fn parse_rate_limit(input: &str) -> Option<u64> {
 /// - Lines may contain `--flag value`, `--flag=value`, or `-f value`
 /// - Values may be quoted with `"` or `'`
 /// - Backslash escaping is supported within double quotes
+///
+/// If `file_path` is provided, emits warnings about unquoted whitespace.
 pub fn parse_config_file(contents: &str) -> Vec<String> {
+    parse_config_file_with_path(contents, None)
+}
+
+/// Parse config file, optionally with a file path for warning messages.
+pub fn parse_config_file_with_path(contents: &str, file_path: Option<&str>) -> Vec<String> {
     let mut args = Vec::new();
-    for line in contents.lines() {
+    for (line_num, line) in contents.lines().enumerate() {
         let trimmed = line.trim();
         if trimmed.is_empty() || trimmed.starts_with('#') {
             continue;
         }
 
-        // Handle --flag=value syntax
+        // Helper to check for unquoted whitespace in values and warn
+        let warn_unquoted_whitespace = |flag: &str, value: &str| {
+            // Only warn if value is unquoted and contains whitespace
+            if !value.starts_with('"') && !value.starts_with('\'') && value.contains(' ') {
+                if let Some(path) = file_path {
+                    eprintln!(
+                        "Warning: {path}:{} Option '{}' uses argument with unquoted whitespace. ",
+                        line_num + 1,
+                        flag
+                    );
+                    eprintln!("Warning: This may cause side-effects. Consider double quotes.");
+                }
+            }
+        };
+
+        // Handle --flag syntax
         if let Some(rest) = trimmed.strip_prefix("--") {
-            if let Some(eq_pos) = rest.find('=') {
+            // Check for = in the flag name only (before any whitespace)
+            // This distinguishes `--flag=value` from `--flag value_with_=`
+            let first_ws = rest.find(char::is_whitespace).unwrap_or(rest.len());
+            let eq_in_flag = rest[..first_ws].find('=');
+            if let Some(eq_pos) = eq_in_flag {
                 let flag = &rest[..eq_pos];
                 let value = rest[eq_pos + 1..].trim();
                 args.push(format!("--{flag}"));
-                args.push(unquote(value));
+                warn_unquoted_whitespace(flag, value);
+                // For unquoted values with whitespace, only take the first word (curl compat: test 459)
+                let effective_value = if !value.starts_with('"') && !value.starts_with('\'') {
+                    value.split_whitespace().next().unwrap_or(value)
+                } else {
+                    value
+                };
+                args.push(unquote(effective_value));
             } else {
                 // --flag or --flag value
                 let parts: Vec<&str> = rest.splitn(2, char::is_whitespace).collect();
@@ -2237,7 +2398,14 @@ pub fn parse_config_file(contents: &str) -> Vec<String> {
             let value = trimmed[eq_pos + 1..].trim();
             args.push(format!("--{flag}"));
             if !value.is_empty() {
-                args.push(unquote(value));
+                warn_unquoted_whitespace(flag, value);
+                // For unquoted values with whitespace, only take the first word
+                let effective_value = if !value.starts_with('"') && !value.starts_with('\'') {
+                    value.split_whitespace().next().unwrap_or(value)
+                } else {
+                    value
+                };
+                args.push(unquote(effective_value));
             }
         } else {
             let parts: Vec<&str> = trimmed.splitn(2, char::is_whitespace).collect();
@@ -2596,14 +2764,34 @@ pub fn parse_proto_spec(spec: &str) -> Vec<String> {
 ///
 /// Formats:
 ///   - `name=value` — direct assignment
-///   - `name@file` — load from file
+///   - `name@file` — load from file (binary)
 ///   - `name@-` — load from stdin
 ///   - `name[start-end]=value` — byte range from direct value
 ///   - `name[start-end]@file` — byte range from file
 ///   - `name[start-]@file` — byte range from start to end of data
+///   - `%ENV` — load from environment variable ENV
+///   - `%ENV=default` — load from env var, fallback to default if unset
 ///
-/// Returns `(name, value)` after applying byte range if specified.
-fn parse_variable(spec: &str) -> Result<(String, String), u8> {
+/// Returns `(name, value_bytes)` after applying byte range if specified.
+fn parse_variable(spec: &str) -> Result<(String, Vec<u8>), u8> {
+    // Check for %ENV syntax (environment variable)
+    if let Some(env_spec) = spec.strip_prefix('%') {
+        // Split on '=' for default value
+        let (env_name, default_value) = env_spec
+            .split_once('=')
+            .map_or((env_spec, None), |(name, default)| (name, Some(default)));
+        // Look up the environment variable
+        if let Ok(val) = std::env::var(env_name) {
+            return Ok((env_name.to_string(), val.into_bytes()));
+        }
+        if let Some(default) = default_value {
+            return Ok((env_name.to_string(), default.as_bytes().to_vec()));
+        }
+        // Missing env var without default is an error (curl compat: test 462)
+        eprintln!("curl: variable: importing \"{env_name}\" failed, and no default was given");
+        return Err(2);
+    }
+
     // Parse optional byte range: name[start-end]
     let (name, byte_range, rest) = if let Some(bracket_start) = spec.find('[') {
         let bracket_end = spec[bracket_start..].find(']').map(|p| bracket_start + p);
@@ -2639,16 +2827,16 @@ fn parse_variable(spec: &str) -> Result<(String, String), u8> {
     };
 
     // Parse value source: =value or @file
-    let raw_value = if let Some(rest) = rest.strip_prefix('=') {
-        rest.to_string()
+    let raw_value: Vec<u8> = if let Some(rest) = rest.strip_prefix('=') {
+        rest.as_bytes().to_vec()
     } else if let Some(rest) = rest.strip_prefix('@') {
         if rest == "-" {
             use std::io::Read as _;
-            let mut buf = String::new();
-            let _ = std::io::stdin().read_to_string(&mut buf);
+            let mut buf = Vec::new();
+            let _ = std::io::stdin().read_to_end(&mut buf);
             buf
         } else {
-            std::fs::read_to_string(rest).map_err(|e| {
+            std::fs::read(rest).map_err(|e| {
                 eprintln!("curl: can't read variable file '{rest}': {e}");
                 2
             })?
@@ -2657,18 +2845,18 @@ fn parse_variable(spec: &str) -> Result<(String, String), u8> {
         // No range and no = or @ — check the original spec for = or @
         if let Some(eq_pos) = name.find('=') {
             let (n, v) = name.split_at(eq_pos);
-            return Ok((n.to_string(), v[1..].to_string()));
+            return Ok((n.to_string(), v.as_bytes()[1..].to_vec()));
         }
         if let Some(at_pos) = name.find('@') {
             let (n, f) = name.split_at(at_pos);
             let file = &f[1..];
-            let content = if file == "-" {
+            let content: Vec<u8> = if file == "-" {
                 use std::io::Read as _;
-                let mut buf = String::new();
-                let _ = std::io::stdin().read_to_string(&mut buf);
+                let mut buf = Vec::new();
+                let _ = std::io::stdin().read_to_end(&mut buf);
                 buf
             } else {
-                std::fs::read_to_string(file).map_err(|e| {
+                std::fs::read(file).map_err(|e| {
                     eprintln!("curl: can't read variable file '{file}': {e}");
                     2
                 })?
@@ -2676,19 +2864,18 @@ fn parse_variable(spec: &str) -> Result<(String, String), u8> {
             return Ok((n.to_string(), content));
         }
         // No value source specified — empty value
-        String::new()
+        Vec::new()
     } else {
-        String::new()
+        Vec::new()
     };
 
     // Apply byte range
     let value = if let Some((start, end)) = byte_range {
-        let bytes = raw_value.as_bytes();
-        if start >= bytes.len() {
-            String::new()
+        if start >= raw_value.len() {
+            Vec::new()
         } else {
-            let end = end.map_or(bytes.len() - 1, |e| e.min(bytes.len() - 1));
-            String::from_utf8_lossy(&bytes[start..=end]).to_string()
+            let end = end.map_or(raw_value.len() - 1, |e| e.min(raw_value.len() - 1));
+            raw_value[start..=end].to_vec()
         }
     } else {
         raw_value
@@ -2723,63 +2910,195 @@ fn simple_base64_encode(data: &[u8]) -> String {
     result
 }
 
-fn expand_variables(template: &str, variables: &[(String, String)]) -> String {
+/// Apply a single transform function to a value (as bytes).
+///
+/// Returns `Ok(transformed)` or `Err(2)` for unknown functions.
+fn apply_variable_function(value: &[u8], func: &str) -> Result<Vec<u8>, u8> {
+    match func {
+        "trim" => {
+            // Trim ASCII whitespace from both ends
+            let start = value.iter().position(|b| !b.is_ascii_whitespace()).unwrap_or(value.len());
+            let end = value.iter().rposition(|b| !b.is_ascii_whitespace()).map_or(start, |p| p + 1);
+            Ok(value[start..end].to_vec())
+        }
+        "url" | "urlencode" => {
+            let mut s = String::with_capacity(value.len());
+            for &byte in value {
+                match byte {
+                    b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                        s.push(byte as char);
+                    }
+                    _ => {
+                        s.push('%');
+                        s.push(char::from(HEX_CHARS[(byte >> 4) as usize]));
+                        s.push(char::from(HEX_CHARS[(byte & 0x0F) as usize]));
+                    }
+                }
+            }
+            Ok(s.into_bytes())
+        }
+        "b64" | "base64" => Ok(simple_base64_encode(value).into_bytes()),
+        "64dec" | "b64dec" | "base64dec" => {
+            // Base64 decode
+            Ok(simple_base64_decode(value))
+        }
+        "json" => {
+            // JSON string escaping (no wrapping quotes — curl compat)
+            let mut s = String::with_capacity(value.len());
+            for &byte in value {
+                match byte {
+                    b'"' => s.push_str("\\\""),
+                    b'\\' => s.push_str("\\\\"),
+                    b'\n' => s.push_str("\\n"),
+                    b'\r' => s.push_str("\\r"),
+                    b'\t' => s.push_str("\\t"),
+                    b if b < 0x20 => {
+                        use std::fmt::Write;
+                        let _ = write!(s, "\\u{:04x}", b);
+                    }
+                    b => s.push(b as char),
+                }
+            }
+            Ok(s.into_bytes())
+        }
+        _ => {
+            eprintln!("curl: unknown variable function: {func}");
+            Err(2)
+        }
+    }
+}
+
+/// Simple base64 decoder.
+fn simple_base64_decode(data: &[u8]) -> Vec<u8> {
+    const fn decode_char(c: u8) -> Option<u8> {
+        match c {
+            b'A'..=b'Z' => Some(c - b'A'),
+            b'a'..=b'z' => Some(c - b'a' + 26),
+            b'0'..=b'9' => Some(c - b'0' + 52),
+            b'+' => Some(62),
+            b'/' => Some(63),
+            _ => None,
+        }
+    }
+    let mut result = Vec::with_capacity(data.len() * 3 / 4);
+    let filtered: Vec<u8> = data
+        .iter()
+        .copied()
+        .filter(|&b| b != b'=' && b != b'\n' && b != b'\r' && b != b' ')
+        .collect();
+    for chunk in filtered.chunks(4) {
+        let mut buf = [0u8; 4];
+        let mut count = 0;
+        for &b in chunk {
+            if let Some(v) = decode_char(b) {
+                buf[count] = v;
+                count += 1;
+            }
+        }
+        if count >= 2 {
+            result.push((buf[0] << 2) | (buf[1] >> 4));
+        }
+        if count >= 3 {
+            result.push((buf[1] << 4) | (buf[2] >> 2));
+        }
+        if count >= 4 {
+            result.push((buf[2] << 6) | buf[3]);
+        }
+    }
+    result
+}
+
+/// Maximum variable name length (curl uses 128).
+const MAX_VARIABLE_NAME_LEN: usize = 128;
+
+fn expand_variables(template: &str, variables: &[(String, Vec<u8>)]) -> Result<String, u8> {
     let mut result = String::with_capacity(template.len());
     let mut i = 0;
     let bytes = template.as_bytes();
     while i < bytes.len() {
+        // Check for backslash-escaped {{ → literal {{
+        if i + 2 < bytes.len() && bytes[i] == b'\\' && bytes[i + 1] == b'{' && bytes[i + 2] == b'{'
+        {
+            result.push_str("{{");
+            i += 3;
+            // Find the closing }} and output it literally too
+            if let Some(end) = template[i..].find("}}") {
+                result.push_str(&template[i..i + end + 2]);
+                i += end + 2;
+            }
+            continue;
+        }
         if i + 1 < bytes.len() && bytes[i] == b'{' && bytes[i + 1] == b'{' {
             // Find closing }}
             if let Some(end) = template[i + 2..].find("}}") {
                 let inner = &template[i + 2..i + 2 + end];
-                // Check for name:function syntax
-                let (var_name, func) = inner.split_once(':').unwrap_or((inner, ""));
+
+                // Empty inner → leave as literal {{}} (curl compat: test 428)
+                if inner.is_empty() {
+                    result.push_str("{{}}");
+                    i += 2 + end + 2;
+                    continue;
+                }
+
+                // Variable name length check (>=128 chars → leave unexpanded, curl compat: test 429/448)
+                let var_name = inner.split(':').next().unwrap_or(inner);
+                if var_name.len() >= MAX_VARIABLE_NAME_LEN {
+                    result.push_str(&template[i..i + 2 + end + 2]);
+                    i += 2 + end + 2;
+                    continue;
+                }
+
+                // Parse function chain: name:func1:func2:...
+                let parts: Vec<&str> = inner.splitn(2, ':').collect();
+                let var_name = parts[0];
+                let func_chain_str = if parts.len() > 1 { parts[1] } else { "" };
+
+                // Validate function chain: split by ':' and validate each
+                let functions: Vec<&str> = if func_chain_str.is_empty() {
+                    Vec::new()
+                } else {
+                    func_chain_str.split(':').collect()
+                };
+
+                // Check for invalid function separators (commas etc.)
+                for func in &functions {
+                    if func.contains(',') || func.contains(';') || func.contains(' ') {
+                        eprintln!("curl: bad function in variable expansion");
+                        return Err(2);
+                    }
+                }
+
                 if let Some((_, value)) = variables.iter().find(|(n, _)| n == var_name) {
-                    let transformed = match func {
-                        "" => value.clone(),
-                        "trim" => value.trim().to_string(),
-                        "url" | "urlencode" => percent_encode(value),
-                        "b64" | "base64" => simple_base64_encode(value.as_bytes()),
-                        "json" => {
-                            // JSON string escaping (no wrapping quotes — curl compat: test 268)
-                            let mut s = String::with_capacity(value.len());
-                            for c in value.chars() {
-                                match c {
-                                    '"' => s.push_str("\\\""),
-                                    '\\' => s.push_str("\\\\"),
-                                    '\n' => s.push_str("\\n"),
-                                    '\r' => s.push_str("\\r"),
-                                    '\t' => s.push_str("\\t"),
-                                    c if c < '\u{20}' => {
-                                        // Control characters: \u00XX
-                                        let _ = std::fmt::Write::write_fmt(
-                                            &mut s,
-                                            format_args!("\\u{:04x}", c as u32),
-                                        );
-                                    }
-                                    c => s.push(c),
-                                }
-                            }
-                            s
-                        }
-                        _ => {
-                            // Unknown function: leave as-is (curl returns error 2)
-                            result.push_str(&template[i..i + 2 + end + 2]);
-                            i += 2 + end + 2;
-                            continue;
-                        }
-                    };
-                    result.push_str(&transformed);
+                    let mut current_value: Vec<u8> = value.clone();
+
+                    // Apply function chain
+                    for func in &functions {
+                        current_value = apply_variable_function(&current_value, func)?;
+                    }
+
+                    // If no functions applied (raw expansion), check for null bytes
+                    if functions.is_empty() && current_value.contains(&0) {
+                        eprintln!("curl: (2) expanded variable contains null bytes");
+                        return Err(2);
+                    }
+
+                    result.push_str(&String::from_utf8_lossy(&current_value));
+                } else if inner.contains('.') {
+                    // Variables with dots (like {{not.good}}) are left as-is (curl compat: test 428)
+                    result.push_str(&template[i..i + 2 + end + 2]);
                 }
                 // Else: undefined variable — expand to empty string
                 i += 2 + end + 2;
                 continue;
             }
+            // No closing }} found → leave the {{ and rest as literal (unbalanced braces)
+            result.push_str(&template[i..]);
+            break;
         }
         result.push(bytes[i] as char);
         i += 1;
     }
-    result
+    Ok(result)
 }
 
 #[cfg(test)]

--- a/crates/urlx-cli/src/output.rs
+++ b/crates/urlx-cli/src/output.rs
@@ -6,6 +6,23 @@
 use std::io::Write;
 use std::process::ExitCode;
 
+/// Extra context for `--write-out` variable expansion beyond what's in the Response.
+#[derive(Default)]
+pub struct WriteOutContext {
+    /// Effective output filename (set by `-O`, `-J`, `--output`).
+    pub filename_effective: String,
+    /// 0-based URL index in multi-URL mode.
+    pub urlnum: usize,
+    /// Exit code for this transfer (0 on success, 22 for --fail, etc.).
+    pub exitcode: u8,
+    /// Error message for this transfer (empty on success).
+    pub errormsg: String,
+    /// Whether this transfer had an error (controls `%{onerror}`).
+    pub had_error: bool,
+    /// Path to redirect stderr to (from `--stderr`).
+    pub stderr_file: Option<String>,
+}
+
 /// Format response headers as HTTP status line + headers.
 ///
 /// Preserves original header ordering, casing, and duplicates from the server.
@@ -243,6 +260,27 @@ pub fn output_response(
     silent: bool,
     suppress_body: bool,
 ) -> ExitCode {
+    output_response_with_context(
+        response,
+        output_file,
+        write_out,
+        include_headers,
+        silent,
+        suppress_body,
+        &WriteOutContext::default(),
+    )
+}
+
+/// Output a response with additional write-out context.
+pub fn output_response_with_context(
+    response: &liburlx::Response,
+    output_file: Option<&str>,
+    write_out: Option<&str>,
+    include_headers: bool,
+    silent: bool,
+    suppress_body: bool,
+    ctx: &WriteOutContext,
+) -> ExitCode {
     // Build all header text including redirect chain (for -L --include)
     let all_headers = if include_headers {
         let mut h = String::new();
@@ -321,7 +359,7 @@ pub fn output_response(
         } else {
             (None, false, fmt)
         };
-        let output = format_write_out(real_fmt, response, suppress_body);
+        let output = format_write_out_with_context(real_fmt, response, suppress_body, ctx);
         if let Some(path) = out_file {
             use std::io::Write;
             let file = if append_mode {
@@ -334,6 +372,7 @@ pub fn output_response(
             }
         } else {
             // Handle %{stderr} directive: text after it goes to stderr (curl compat: test 1278)
+            // When --stderr is set, stderr output goes to that file (curl compat: test 978)
             if let Some(pos) = output.find("%{stderr}") {
                 let stdout_part = &output[..pos];
                 let stderr_part = &output[pos + "%{stderr}".len()..];
@@ -341,7 +380,17 @@ pub fn output_response(
                     print!("{stdout_part}");
                 }
                 if !stderr_part.is_empty() {
-                    eprint!("{stderr_part}");
+                    if let Some(ref stderr_path) = ctx.stderr_file {
+                        // Route to --stderr file (curl compat: test 978)
+                        use std::io::Write;
+                        if let Ok(mut f) =
+                            std::fs::OpenOptions::new().create(true).append(true).open(stderr_path)
+                        {
+                            let _ = f.write_all(stderr_part.as_bytes());
+                        }
+                    } else {
+                        eprint!("{stderr_part}");
+                    }
                 }
             } else {
                 print!("{output}");
@@ -368,8 +417,29 @@ pub fn format_write_out(
     response: &liburlx::Response,
     time_cond_suppressed: bool,
 ) -> String {
+    format_write_out_with_context(fmt, response, time_cond_suppressed, &WriteOutContext::default())
+}
+
+/// Format a `--write-out` string with additional context.
+#[allow(clippy::too_many_lines)]
+pub fn format_write_out_with_context(
+    fmt: &str,
+    response: &liburlx::Response,
+    time_cond_suppressed: bool,
+    ctx: &WriteOutContext,
+) -> String {
     let info = response.transfer_info();
     let mut result = fmt.to_string();
+
+    // %{onerror}: if no error occurred, suppress everything from %{onerror} to end of string
+    // (curl compat: test 1188). If error occurred, just remove the %{onerror} marker.
+    if let Some(pos) = result.find("%{onerror}") {
+        if ctx.had_error {
+            result = result.replacen("%{onerror}", "", 1);
+        } else {
+            result.truncate(pos);
+        }
+    }
 
     // When body is suppressed by -z time condition, curl simulates a 304 response code
     let effective_status = if time_cond_suppressed { 304 } else { response.status() };
@@ -480,7 +550,7 @@ pub fn format_write_out(
         .replace("%{time_redirect}", &format!("{:.6}", info.time_namelookup.as_secs_f64() * 0.0));
     #[allow(clippy::literal_string_with_formatting_args)]
     {
-        result = result.replace("%{filename_effective}", "");
+        result = result.replace("%{filename_effective}", &ctx.filename_effective);
     }
     // redirect_url: curl resolves the Location URL to absolute (relative to request URL)
     // and normalizes bare hostnames with trailing slash (test 1261).
@@ -538,25 +608,45 @@ pub fn format_write_out(
     #[allow(clippy::literal_string_with_formatting_args)]
     {
         result = result.replace("%{method}", method);
-        result = result.replace("%{errormsg}", "");
-        result = result.replace("%{exitcode}", "0");
+        result = result.replace("%{errormsg}", &ctx.errormsg);
+        result = result.replace("%{exitcode}", &ctx.exitcode.to_string());
+        result = result.replace("%{urlnum}", &ctx.urlnum.to_string());
     }
     result = result.replace("%{num_retries}", &info.num_retries.to_string());
-    // Connection info: use parsed URL components
-    let (_, _, _, rip_host, rip_port, _, _, _) = parse_url_components(response.effective_url());
-    let url_host = rip_host.as_str();
-    let url_port: u16 = rip_port.parse().unwrap_or(0);
-    // Resolve hostname to IP for %{remote_ip}
-    let resolved_ip = std::net::ToSocketAddrs::to_socket_addrs(&(url_host, url_port))
-        .ok()
-        .and_then(|mut addrs| addrs.next())
-        .map_or_else(|| url_host.to_string(), |addr| addr.ip().to_string());
+    // Connection info: use actual TCP socket addresses from TransferInfo
+    let remote_ip = if info.remote_ip.is_empty() {
+        // Fallback: resolve hostname to IP
+        let (_, _, _, rip_host, rip_port, _, _, _) = parse_url_components(response.effective_url());
+        let url_host = rip_host.as_str();
+        let url_port: u16 = rip_port.parse().unwrap_or(0);
+        std::net::ToSocketAddrs::to_socket_addrs(&(url_host, url_port))
+            .ok()
+            .and_then(|mut addrs| addrs.next())
+            .map_or_else(|| url_host.to_string(), |addr| addr.ip().to_string())
+    } else {
+        info.remote_ip.clone()
+    };
+    let remote_port = if info.remote_port > 0 {
+        info.remote_port.to_string()
+    } else {
+        let (_, _, _, _, rip_port, _, _, _) = parse_url_components(response.effective_url());
+        rip_port
+    };
     #[allow(clippy::literal_string_with_formatting_args)]
     {
-        result = result.replace("%{remote_ip}", &resolved_ip);
-        result = result.replace("%{remote_port}", &url_port.to_string());
-        result = result.replace("%{local_ip}", "");
-        result = result.replace("%{local_port}", "0");
+        result = result.replace("%{remote_ip}", &remote_ip);
+        result = result.replace("%{remote_port}", &remote_port);
+        result = result.replace("%{local_ip}", &info.local_ip);
+        result = result.replace("%{local_port}", &info.local_port.to_string());
+    }
+
+    // %{header_json}: format all response headers as a JSON object (curl compat: test 421)
+    if result.contains("%{header_json}") {
+        let json = format_header_json(response);
+        #[allow(clippy::literal_string_with_formatting_args)]
+        {
+            result = result.replace("%{header_json}", &json);
+        }
     }
 
     // Handle %header{name} and %header{name:all:separator} patterns
@@ -568,6 +658,77 @@ pub fn format_write_out(
     result = result.replace("\\t", "\t");
     result = result.replace("\\r", "\r");
 
+    result
+}
+
+/// Format all response headers as a JSON object.
+///
+/// Curl's `%{header_json}` produces output like:
+/// ```json
+/// {"server":["nginx"],
+/// "date":["..."],
+/// "vary":["Accept-Encoding","Accept-Encoding","Accept"],
+/// ...
+/// }
+/// ```
+/// Duplicate header names result in multiple values in the array.
+/// Header names are lowercased. Values have JSON special chars escaped.
+fn format_header_json(response: &liburlx::Response) -> String {
+    use std::fmt::Write;
+    let ordered = response.headers_ordered();
+
+    // Collect headers in order, preserving duplicates
+    let mut header_map: Vec<(String, Vec<String>)> = Vec::new();
+
+    for (name, raw_value) in ordered {
+        let lower_name = name.to_ascii_lowercase();
+        let value: &str =
+            raw_value.strip_prefix(':').map(str::trim_start).unwrap_or(raw_value.as_str());
+
+        if let Some(entry) = header_map.iter_mut().find(|(n, _)| *n == lower_name) {
+            entry.1.push(value.to_string());
+        } else {
+            header_map.push((lower_name, vec![value.to_string()]));
+        }
+    }
+
+    let mut json = String::from("{");
+    for (i, (name, values)) in header_map.iter().enumerate() {
+        if i > 0 {
+            json.push_str(",\n");
+        } else {
+            // No newline before first entry
+        }
+        let _ = write!(json, "\"{}\":[", json_escape_string(name));
+        for (j, val) in values.iter().enumerate() {
+            if j > 0 {
+                json.push(',');
+            }
+            let _ = write!(json, "\"{}\"", json_escape_string(val));
+        }
+        json.push(']');
+    }
+    json.push_str("\n}");
+    json
+}
+
+/// Escape a string for JSON output (without wrapping quotes).
+fn json_escape_string(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '"' => result.push_str("\\\""),
+            '\\' => result.push_str("\\\\"),
+            '\n' => result.push_str("\\n"),
+            '\r' => result.push_str("\\r"),
+            '\t' => result.push_str("\\t"),
+            c if c < '\u{20}' => {
+                use std::fmt::Write;
+                let _ = write!(result, "\\u{:04x}", c as u32);
+            }
+            c => result.push(c),
+        }
+    }
     result
 }
 
@@ -672,6 +833,12 @@ fn collect_header_values(resp: &liburlx::Response, name: &str, values: &mut Vec<
 fn parse_url_components(
     url: &str,
 ) -> (String, String, String, String, String, String, String, String) {
+    // If URL has no scheme separator, all components are empty (curl compat: test 423)
+    let scheme_sep = url.find("://");
+    if scheme_sep.is_none() {
+        let e = String::new();
+        return (e.clone(), e.clone(), e.clone(), e.clone(), e.clone(), e.clone(), e.clone(), e);
+    }
     let scheme = url.split("://").next().unwrap_or("").to_string();
     let rest = url.find("://").map_or("", |p| &url[p + 3..]);
 

--- a/crates/urlx-cli/src/transfer.rs
+++ b/crates/urlx-cli/src/transfer.rs
@@ -11,7 +11,7 @@ use crate::args::{
 };
 use crate::output::{
     content_disposition_filename, format_headers, format_write_out, http_status_text,
-    output_response, write_trace_file,
+    output_response, output_response_with_context, write_trace_file, WriteOutContext,
 };
 
 /// Substitute `#1`, `#2`, etc. in an output filename template with glob match values.
@@ -673,6 +673,7 @@ pub fn run(args: &[String]) -> ExitCode {
             opts.dump_header.as_deref(),
             &opts.per_url_ftp_methods,
             opts.upload_filename.as_deref(),
+            &opts.per_url_easy,
         );
     }
 
@@ -1490,13 +1491,19 @@ pub fn run(args: &[String]) -> ExitCode {
             } else {
                 opts.include_headers
             };
-            let exit = output_response(
+            let ctx = WriteOutContext {
+                filename_effective: opts.output_file.clone().unwrap_or_default(),
+                stderr_file: opts.stderr_file.clone(),
+                ..WriteOutContext::default()
+            };
+            let exit = output_response_with_context(
                 &response,
                 opts.output_file.as_deref(),
                 opts.write_out.as_deref(),
                 effective_include,
                 opts.silent,
                 suppress_body,
+                &ctx,
             );
 
             // --remote-time: set output file's modification time from Last-Modified
@@ -1965,6 +1972,7 @@ pub fn run_multi(
     dump_header: Option<&str>,
     per_url_ftp_methods: &[liburlx::protocol::ftp::FtpMethod],
     upload_filename: Option<&str>,
+    per_url_easy: &[Option<liburlx::Easy>],
 ) -> ExitCode {
     if parallel {
         return run_multi_parallel(
@@ -1993,6 +2001,11 @@ pub fn run_multi(
     let mut last_exit = ExitCode::SUCCESS;
 
     for (i, url) in urls.iter().enumerate() {
+        // Use per-URL Easy handle if available (from --next groups, curl compat: tests 430-432)
+        if let Some(Some(per_easy)) = per_url_easy.get(i) {
+            easy = per_easy.clone();
+        }
+
         // -T upload: for HTTP, only the first URL gets PUT with the upload body;
         // subsequent URLs revert to GET without body (curl compat: test 1065).
         // For FTP, all URLs keep the upload body (curl compat: tests 149, 216).
@@ -2033,6 +2046,31 @@ pub fn run_multi(
             if !silent || show_error {
                 eprintln!("curl: ({}) URL rejected: {e}", 3);
             }
+            // Still produce write-out for invalid URLs (curl compat: test 423)
+            if let Some(wo) = write_out {
+                let dummy_response = liburlx::Response::new(
+                    0,
+                    std::collections::HashMap::new(),
+                    Vec::new(),
+                    url.clone(),
+                );
+                let ctx = WriteOutContext {
+                    urlnum: i,
+                    exitcode: 3,
+                    errormsg: format!("URL rejected: {e}"),
+                    had_error: true,
+                    ..WriteOutContext::default()
+                };
+                let _ = output_response_with_context(
+                    &dummy_response,
+                    None,
+                    Some(wo),
+                    false,
+                    silent,
+                    true,
+                    &ctx,
+                );
+            }
             last_exit = ExitCode::from(3); // CURLE_URL_MALFORMAT
             continue;
         }
@@ -2069,18 +2107,27 @@ pub fn run_multi(
         match rt.block_on(easy.perform_async()) {
             Ok(response) => {
                 if fail_on_error && response.status() >= 400 {
-                    // --fail-with-body: output body before returning error (curl compat: test 361)
-                    if fail_with_body {
-                        let file_for_this = output_files.get(i).map(String::as_str);
-                        let _ = output_response(
-                            &response,
-                            file_for_this,
-                            write_out,
-                            include_headers,
-                            silent,
-                            false,
-                        );
-                    }
+                    let err_msg =
+                        format!("The requested URL returned error: {}", response.status());
+                    // Output write-out and optionally body on --fail (curl compat: tests 361, 1188)
+                    let file_for_this = output_files.get(i).map(String::as_str);
+                    let ctx = WriteOutContext {
+                        urlnum: i,
+                        exitcode: 22,
+                        errormsg: err_msg,
+                        had_error: true,
+                        ..WriteOutContext::default()
+                    };
+                    let suppress = !fail_with_body;
+                    let _ = output_response_with_context(
+                        &response,
+                        file_for_this,
+                        write_out,
+                        include_headers,
+                        silent,
+                        suppress,
+                        &ctx,
+                    );
                     last_exit = ExitCode::from(22); // CURLE_HTTP_RETURNED_ERROR
                     continue;
                 }
@@ -2161,11 +2208,37 @@ pub fn run_multi(
                 if !silent || show_error {
                     eprintln!("curl: transfer {} ({}): {e}", i + 1, url);
                 }
-                let exit = error_to_exit_code(&e);
-                if fail_early {
-                    return exit;
+                let curl_code = error_to_curl_code(&e);
+                // Still produce write-out for failed transfers (curl compat: test 423)
+                if let Some(wo) = write_out {
+                    let dummy_response = liburlx::Response::new(
+                        0,
+                        std::collections::HashMap::new(),
+                        Vec::new(),
+                        url.clone(),
+                    );
+                    let ctx = WriteOutContext {
+                        urlnum: i,
+                        exitcode: curl_code,
+                        errormsg: curl_error_message(&e),
+                        had_error: true,
+                        ..WriteOutContext::default()
+                    };
+                    let _ = output_response_with_context(
+                        &dummy_response,
+                        None,
+                        Some(wo),
+                        false,
+                        silent,
+                        true,
+                        &ctx,
+                    );
                 }
-                last_exit = exit;
+                let exit_code = ExitCode::from(curl_code);
+                if fail_early {
+                    return exit_code;
+                }
+                last_exit = exit_code;
             }
         }
     }


### PR DESCRIPTION
## Summary

Completes task 08: pass 26 new curl tests for `--write-out` variables, `-K` config file handling, and `--variable`/`--expand-*` expansion.

- **Write-out (8):** 421, 423, 424, 435, 978, 1188, 1340, 1341
- **Config files (6):** 430, 431, 432, 433, 436, 459
- **Variables/expand (12):** 428, 429, 448, 450, 451, 452, 453, 454, 455, 456, 458, 462

### Key changes

**Write-out variables:**
- `%{header_json}` — JSON-formatted response headers with duplicate support
- `%{onerror}` — conditional output gate (only on error)
- `%{urlnum}`, `%{exitcode}`, `%{errormsg}` — actual values from transfer
- `%{local_ip}`, `%{local_port}` — from actual TCP socket
- `%{filename_effective}` — from `-O`/`-J` output filename
- `--stderr` routing for `-w` output

**Config file (`-K`) fixes:**
- Auto-discover `.curlrc` from `$CURL_HOME`, `$XDG_CONFIG_HOME`, `$HOME`
- `--next` properly resets headers/body/method between URL groups
- Per-URL Easy handles for multi-URL `--next` groups
- Whitespace warning for unquoted config values

**Variable/expand fixes:**
- `%ENV` and `%ENV=default` syntax for environment variables
- Function chaining (`{{var:trim:url}}`, `{{var:trim:json}}`)
- `64dec` base64 decode function
- `\{{` escape for literal braces
- Null byte detection in raw expansion (exit 2)
- `--expand-url` and `--expand-output` flags

## Test plan
- [x] All 26 target curl tests pass (test 417 skipped - needs stunnel)
- [x] `cargo fmt` — clean
- [x] `cargo clippy` — no warnings
- [x] `cargo test -p urlx-cli` — 311 tests pass
- [x] `cargo test -p liburlx` — all tests pass
- [x] Pre-commit hooks pass
- [x] Tests 1-20 (HTTP basics) — no regressions