### PR TITLE
fix(auth): complete email SASL authentication for IMAP, POP3, SMTP

### DIFF
--- a/crates/liburlx/src/easy.rs
+++ b/crates/liburlx/src/easy.rs
@@ -186,6 +186,8 @@ pub struct Easy {
     ftp_time_condition: Option<(i64, bool)>,
     /// SASL authorization identity.
     sasl_authzid: Option<String>,
+    /// SASL login options (e.g. `AUTH=PLAIN`).
+    login_options: Option<String>,
     /// Send SASL initial response in first message.
     sasl_ir: bool,
     /// Connect-to host:port mapping (`from_host:from_port:to_host:to_port`).
@@ -324,6 +326,7 @@ impl std::fmt::Debug for Easy {
             .field("ftp_create_dirs", &self.ftp_create_dirs)
             .field("ftp_method", &self.ftp_method)
             .field("sasl_authzid", &self.sasl_authzid)
+            .field("login_options", &self.login_options)
             .field("sasl_ir", &self.sasl_ir)
             .field("connect_to", &self.connect_to)
             .field("haproxy_protocol", &self.haproxy_protocol)
@@ -448,6 +451,7 @@ impl Clone for Easy {
             ftp_post_quote: self.ftp_post_quote.clone(),
             ftp_time_condition: self.ftp_time_condition,
             sasl_authzid: self.sasl_authzid.clone(),
+            login_options: self.login_options.clone(),
             sasl_ir: self.sasl_ir,
             connect_to: self.connect_to.clone(),
             haproxy_protocol: self.haproxy_protocol,
@@ -576,6 +580,7 @@ impl Easy {
             ftp_post_quote: Vec::new(),
             ftp_time_condition: None,
             sasl_authzid: None,
+            login_options: None,
             sasl_ir: false,
             connect_to: Vec::new(),
             haproxy_protocol: false,
@@ -2026,6 +2031,14 @@ impl Easy {
         self.sasl_authzid = Some(authzid.to_string());
     }
 
+    /// Set SASL login options.
+    ///
+    /// e.g. `AUTH=PLAIN` or `AUTH=+LOGIN`.
+    /// Equivalent to `CURLOPT_LOGIN_OPTIONS` / curl's `--login-options`.
+    pub fn login_options(&mut self, options: &str) {
+        self.login_options = Some(options.to_string());
+    }
+
     /// Enable SASL initial response.
     ///
     /// When enabled, the initial response is sent in the first SASL message.
@@ -2504,6 +2517,7 @@ impl Easy {
             self.ssh_auth_types,
             self.mail_auth.as_deref(),
             self.sasl_authzid.as_deref(),
+            self.login_options.as_deref(),
             self.sasl_ir,
             self.oauth2_bearer.as_deref(),
             self.haproxy_protocol,
@@ -2655,8 +2669,9 @@ async fn perform_transfer(
     #[cfg_attr(not(feature = "ssh"), allow(unused_variables))] ssh_auth_types: Option<u32>,
     mail_auth: Option<&str>,
     sasl_authzid: Option<&str>,
+    login_options: Option<&str>,
     sasl_ir: bool,
-    oauth2_bearer: Option<&str>,
+    mut oauth2_bearer: Option<&str>,
     haproxy_protocol: bool,
     abstract_unix_socket: Option<&str>,
     chunked_upload: bool,
@@ -2682,6 +2697,7 @@ async fn perform_transfer(
     let mut digest_state: Option<(crate::auth::digest::DigestChallenge, String, u32)> = None; // (challenge, cnonce, nc)
                                                                                               // Track Basic auth header from AnyAuth challenge for redirect re-application (test 1088)
     let mut basic_auth_header: Option<String> = None;
+    let mut redirected_from_http = false;
 
     loop {
         // Determine effective proxy for this URL
@@ -2906,6 +2922,7 @@ async fn perform_transfer(
             None,
             mail_auth,
             sasl_authzid,
+            login_options,
             sasl_ir,
             oauth2_bearer,
             haproxy_protocol,
@@ -2917,6 +2934,7 @@ async fn perform_transfer(
             proxy_http_10,
             raw,
             ftp_session,
+            redirected_from_http,
         ))
         .await?;
 
@@ -2999,6 +3017,7 @@ async fn perform_transfer(
                         None,
                         mail_auth,
                         sasl_authzid,
+                        login_options,
                         sasl_ir,
                         oauth2_bearer,
                         haproxy_protocol,
@@ -3010,6 +3029,7 @@ async fn perform_transfer(
                         proxy_http_10,
                         raw,
                         ftp_session,
+                        redirected_from_http,
                     ))
                     .await?;
                 }
@@ -3154,6 +3174,7 @@ async fn perform_transfer(
                                 None,
                                 mail_auth,
                                 sasl_authzid,
+                                login_options,
                                 sasl_ir,
                                 oauth2_bearer,
                                 haproxy_protocol,
@@ -3165,6 +3186,7 @@ async fn perform_transfer(
                                 proxy_http_10,
                                 raw,
                                 ftp_session,
+                                redirected_from_http,
                             ))
                             .await?;
 
@@ -3260,6 +3282,7 @@ async fn perform_transfer(
                                         None,
                                         mail_auth,
                                         sasl_authzid,
+                                        login_options,
                                         sasl_ir,
                                         oauth2_bearer,
                                         haproxy_protocol,
@@ -3271,6 +3294,7 @@ async fn perform_transfer(
                                         proxy_http_10,
                                         raw,
                                         ftp_session,
+                                        redirected_from_http,
                                     ))
                                     .await?;
                                 }
@@ -3348,6 +3372,7 @@ async fn perform_transfer(
                                 None,
                                 mail_auth,
                                 sasl_authzid,
+                                login_options,
                                 sasl_ir,
                                 oauth2_bearer,
                                 haproxy_protocol,
@@ -3359,6 +3384,7 @@ async fn perform_transfer(
                                 proxy_http_10,
                                 raw,
                                 ftp_session,
+                                redirected_from_http,
                             ))
                             .await?;
                         }
@@ -3443,6 +3469,7 @@ async fn perform_transfer(
                                         None,
                                         mail_auth,
                                         sasl_authzid,
+                                        login_options,
                                         sasl_ir,
                                         oauth2_bearer,
                                         haproxy_protocol,
@@ -3454,6 +3481,7 @@ async fn perform_transfer(
                                         proxy_http_10,
                                         raw,
                                         ftp_session,
+                                        redirected_from_http,
                                     ))
                                     .await?;
                                 }
@@ -3531,6 +3559,7 @@ async fn perform_transfer(
                             None,
                             mail_auth,
                             sasl_authzid,
+                            login_options,
                             sasl_ir,
                             oauth2_bearer,
                             haproxy_protocol,
@@ -3542,6 +3571,7 @@ async fn perform_transfer(
                             proxy_http_10,
                             raw,
                             ftp_session,
+                            redirected_from_http,
                         ))
                         .await?;
                     }
@@ -3644,6 +3674,7 @@ async fn perform_transfer(
                                     None,
                                     mail_auth,
                                     sasl_authzid,
+                                    login_options,
                                     sasl_ir,
                                     oauth2_bearer,
                                     haproxy_protocol,
@@ -3655,6 +3686,7 @@ async fn perform_transfer(
                                     proxy_http_10,
                                     raw,
                                     ftp_session,
+                                    redirected_from_http,
                                 ))
                                 .await?;
                             }
@@ -3757,6 +3789,7 @@ async fn perform_transfer(
                                     None,
                                     mail_auth,
                                     sasl_authzid,
+                                    login_options,
                                     sasl_ir,
                                     oauth2_bearer,
                                     haproxy_protocol,
@@ -3768,6 +3801,7 @@ async fn perform_transfer(
                                     proxy_http_10,
                                     raw,
                                     ftp_session,
+                                    redirected_from_http,
                                 ))
                                 .await?;
                             }
@@ -3853,6 +3887,7 @@ async fn perform_transfer(
                                         None,
                                         mail_auth,
                                         sasl_authzid,
+                                        login_options,
                                         sasl_ir,
                                         oauth2_bearer,
                                         haproxy_protocol,
@@ -3863,6 +3898,8 @@ async fn perform_transfer(
                                         http_proxy_tunnel,
                                         proxy_http_10,
                                         raw,
+                                        ftp_session,
+                                        redirected_from_http,
                                     ))
                                     .await?;
 
@@ -3950,6 +3987,7 @@ async fn perform_transfer(
                                                     None,
                                                     mail_auth,
                                                     sasl_authzid,
+                                                    login_options,
                                                     sasl_ir,
                                                     oauth2_bearer,
                                                     haproxy_protocol,
@@ -3960,6 +3998,8 @@ async fn perform_transfer(
                                                     http_proxy_tunnel,
                                                     proxy_http_10,
                                                     raw,
+                                                    ftp_session,
+                                                    redirected_from_http,
                                                 ))
                                                 .await?;
                                             }
@@ -4048,6 +4088,7 @@ async fn perform_transfer(
                                             None,
                                             mail_auth,
                                             sasl_authzid,
+                                            login_options,
                                             sasl_ir,
                                             oauth2_bearer,
                                             haproxy_protocol,
@@ -4058,6 +4099,8 @@ async fn perform_transfer(
                                             http_proxy_tunnel,
                                             proxy_http_10,
                                             raw,
+                                            ftp_session,
+                                            redirected_from_http,
                                         ))
                                         .await?;
                                     }
@@ -4166,6 +4209,7 @@ async fn perform_transfer(
                                     None,
                                     mail_auth,
                                     sasl_authzid,
+                                    login_options,
                                     sasl_ir,
                                     oauth2_bearer,
                                     haproxy_protocol,
@@ -4176,6 +4220,8 @@ async fn perform_transfer(
                                     http_proxy_tunnel,
                                     proxy_http_10,
                                     raw,
+                                    ftp_session,
+                                    redirected_from_http,
                                 ))
                                 .await?;
                             }
@@ -4278,18 +4324,18 @@ async fn perform_transfer(
                 }
 
                 // Resolve relative URLs against current URL
-                let mut next_url =
-                    if location.starts_with("http://") || location.starts_with("https://") {
-                        Url::parse(location)?
-                    } else if location.starts_with("//") {
-                        // Protocol-relative URL (//host/path) — use current scheme
-                        let scheme = current_url.scheme();
-                        Url::parse(&format!("{scheme}:{location}"))?
-                    } else {
-                        // Relative URL: build from current URL's base
-                        let base = current_url.as_str();
-                        Url::parse(&resolve_relative(base, location))?
-                    };
+                let mut next_url = if location.contains("://") {
+                    // Absolute URL with scheme (http://, https://, imap://, etc.)
+                    Url::parse(location)?
+                } else if location.starts_with("//") {
+                    // Protocol-relative URL (//host/path) — use current scheme
+                    let scheme = current_url.scheme();
+                    Url::parse(&format!("{scheme}:{location}"))?
+                } else {
+                    // Relative URL: build from current URL's base
+                    let base = current_url.as_str();
+                    Url::parse(&resolve_relative(base, location))?
+                };
                 // Clear raw_input so redirect uses normalized path (not user's original)
                 next_url.clear_raw_input();
 
@@ -4334,6 +4380,19 @@ async fn perform_transfer(
                     current_method = "GET".to_string();
                     current_body = None;
                     body_dropped_on_redirect = true;
+                }
+
+                // When redirecting from HTTP to a non-HTTP protocol (e.g. imap://),
+                // strip OAuth2 bearer token and auth headers (curl compat: test 779).
+                // The bearer token is only for the HTTP protocol context.
+                let next_scheme = next_url.scheme().to_lowercase();
+                let cur_scheme = current_url.scheme().to_lowercase();
+                let cross_protocol = (cur_scheme == "http" || cur_scheme == "https")
+                    && next_scheme != "http"
+                    && next_scheme != "https";
+                if cross_protocol {
+                    oauth2_bearer = None;
+                    redirected_from_http = true;
                 }
 
                 // Capture intermediate redirect response for -L --include output
@@ -4433,6 +4492,7 @@ async fn do_single_request(
     #[cfg_attr(not(feature = "ssh"), allow(unused_variables))] ssh_auth_types: Option<u32>,
     mail_auth: Option<&str>,
     sasl_authzid: Option<&str>,
+    login_options: Option<&str>,
     sasl_ir: bool,
     oauth2_bearer: Option<&str>,
     haproxy_protocol: bool,
@@ -4444,6 +4504,7 @@ async fn do_single_request(
     proxy_http_10: bool,
     raw: bool,
     ftp_session: &mut Option<crate::protocol::ftp::FtpSession>,
+    redirected_from_http: bool,
 ) -> Result<Response, Error> {
     // Handle non-HTTP schemes directly
     match url.scheme() {
@@ -4604,8 +4665,10 @@ async fn do_single_request(
         "smtp" | "smtps" => {
             let mail_data = body.unwrap_or(&[]);
             let header_creds = extract_basic_auth_from_headers(headers);
-            // Extract ;AUTH= from URL username (e.g. "user;AUTH=EXTERNAL")
-            let url_login_opts = extract_login_options_from_url(url);
+            // CLI --login-options takes priority over ;AUTH= from URL
+            let effective_login_opts = login_options
+                .map(ToString::to_string)
+                .or_else(|| extract_login_options_from_url(url));
             let smtp_config = crate::protocol::smtp::SmtpConfig {
                 mail_from,
                 mail_rcpt,
@@ -4617,7 +4680,7 @@ async fn do_single_request(
                 crlf: false,
                 username: header_creds.as_ref().map(|(u, _)| u.as_str()),
                 password: header_creds.as_ref().map(|(_, p)| p.as_str()),
-                login_options: url_login_opts.as_deref(),
+                login_options: effective_login_opts.as_deref(),
             };
             let smtp_use_ssl = if url.scheme() == "smtps" {
                 // Implicit TLS: signal with a special value
@@ -4635,9 +4698,15 @@ async fn do_single_request(
             .await;
         }
         "imap" | "imaps" => {
-            let url_login_opts = extract_login_options_from_url(url);
+            // CLI --login-options takes priority over ;AUTH= from URL
+            let effective_login_opts = login_options
+                .map(ToString::to_string)
+                .or_else(|| extract_login_options_from_url(url));
             let imap_use_ssl =
                 if url.scheme() == "imaps" { crate::protocol::ftp::UseSsl::All } else { use_ssl };
+            // curl uses 'A' + N for IMAP tags where N is the connection number.
+            // Direct IMAP = 'A' (first connection), redirect from HTTP = 'B' (second connection).
+            let tag_prefix = if redirected_from_http { 'B' } else { 'A' };
             return crate::protocol::imap::fetch(
                 url,
                 method,
@@ -4645,7 +4714,10 @@ async fn do_single_request(
                 custom_request_target,
                 sasl_ir,
                 oauth2_bearer,
-                url_login_opts.as_deref(),
+                effective_login_opts.as_deref(),
+                sasl_authzid,
+                resolve_overrides,
+                tag_prefix,
                 imap_use_ssl,
                 tls_config,
             )
@@ -4660,7 +4732,10 @@ async fn do_single_request(
                 }
                 _ => Some(method),
             };
-            let url_login_opts = extract_login_options_from_url(url);
+            // CLI --login-options takes priority over ;AUTH= from URL
+            let effective_login_opts = login_options
+                .map(ToString::to_string)
+                .or_else(|| extract_login_options_from_url(url));
             let pop3_use_ssl =
                 if url.scheme() == "pop3s" { crate::protocol::ftp::UseSsl::All } else { use_ssl };
             return crate::protocol::pop3::retrieve(
@@ -4669,7 +4744,8 @@ async fn do_single_request(
                 custom_cmd,
                 sasl_ir,
                 oauth2_bearer,
-                url_login_opts.as_deref(),
+                effective_login_opts.as_deref(),
+                sasl_authzid,
                 pop3_use_ssl,
                 tls_config,
             )

--- a/crates/liburlx/src/protocol/imap.rs
+++ b/crates/liburlx/src/protocol/imap.rs
@@ -33,16 +33,17 @@ impl ImapResponse {
 
 /// A simple tag counter for IMAP commands.
 struct TagCounter {
+    prefix: char,
     next: u32,
 }
 
 impl TagCounter {
-    const fn new() -> Self {
-        Self { next: 1 }
+    const fn new(prefix: char) -> Self {
+        Self { prefix, next: 1 }
     }
 
     fn next_tag(&mut self) -> String {
-        let tag = format!("A{:03}", self.next);
+        let tag = format!("{}{:03}", self.prefix, self.next);
         self.next += 1;
         tag
     }
@@ -301,10 +302,12 @@ pub async fn fetch(
     sasl_ir: bool,
     oauth2_bearer: Option<&str>,
     login_options: Option<&str>,
+    sasl_authzid: Option<&str>,
+    resolve_overrides: &[(String, String)],
+    tag_prefix: char,
     use_ssl: UseSsl,
     tls_config: &crate::tls::TlsConfig,
 ) -> Result<Response, Error> {
-    use base64::Engine;
     // Reject URLs with CR or LF in the path (curl compat: test 829).
     // Check BEFORE credentials or connection setup.
     let path = url.path();
@@ -318,15 +321,16 @@ pub async fn fetch(
     }
 
     let (host, port) = url.host_and_port()?;
-    let (raw_user, raw_pass) = url
-        .credentials()
-        .ok_or_else(|| Error::Http("IMAP requires credentials in the URL".to_string()))?;
+    // Credentials are optional for EXTERNAL auth (test 838/840)
+    let creds = url.credentials();
 
     // URL credentials are percent-encoded; decode them for IMAP LOGIN.
     // Strip ";AUTH=..." from username (it's login options, not part of the name).
-    let decoded_user = percent_decode(raw_user);
-    let user = strip_auth_from_username(&decoded_user);
-    let pass = percent_decode(raw_pass);
+    let user = creds.map_or_else(String::new, |(raw_user, _)| {
+        let decoded_user = percent_decode(raw_user);
+        strip_auth_from_username(&decoded_user)
+    });
+    let pass = creds.map_or_else(String::new, |(_, raw_pass)| percent_decode(raw_pass));
 
     let imap_params = parse_imap_url(path, url.query());
 
@@ -334,7 +338,19 @@ pub async fn fetch(
     let use_implicit_tls = url.scheme() == "imaps";
     let use_starttls = !use_implicit_tls && use_ssl != UseSsl::None;
 
-    let addr = format!("{host}:{port}");
+    // Apply resolve overrides: --resolve host:port:addr stores (host, addr) with port stripped
+    let resolved_host =
+        resolve_overrides
+            .iter()
+            .find_map(|(pattern, target)| {
+                if pattern.eq_ignore_ascii_case(&host) {
+                    Some(target.as_str())
+                } else {
+                    None
+                }
+            })
+            .unwrap_or(&host);
+    let addr = format!("{resolved_host}:{port}");
     let tcp = tokio::net::TcpStream::connect(&addr).await.map_err(Error::Connect)?;
 
     let (reader, mut writer): (
@@ -350,7 +366,7 @@ pub async fn fetch(
         (Box::new(r), Box::new(w))
     };
     let mut reader = BufReader::new(reader);
-    let mut tags = TagCounter::new();
+    let mut tags = TagCounter::new(tag_prefix);
 
     // Read greeting
     let greeting = read_greeting(&mut reader).await?;
@@ -416,204 +432,36 @@ pub async fn fetch(
 
     let forced =
         login_options.and_then(|lo| lo.strip_prefix("AUTH=").or_else(|| lo.strip_prefix("auth=")));
-    let has_mech = |mech: &str| server_auth_mechs.iter().any(|m| m.eq_ignore_ascii_case(mech));
-    let should_try =
-        |mech: &str| forced.map_or_else(|| has_mech(mech), |f| f.eq_ignore_ascii_case(mech));
+
+    // Check if forced mechanism is +LOGIN (plain LOGIN command, not SASL AUTHENTICATE LOGIN)
+    let force_login_cmd =
+        forced.is_some_and(|f| f.eq_ignore_ascii_case("+LOGIN") || f.eq_ignore_ascii_case("LOGIN"));
 
     // Authenticate using the best available mechanism
     // Order: EXTERNAL > OAUTHBEARER > XOAUTH2 > CRAM-MD5 > NTLM > LOGIN > PLAIN > LOGIN command
-    if should_try("EXTERNAL") {
-        let tag = tags.next_tag();
-        send_command(&mut writer, &tag, "AUTHENTICATE EXTERNAL").await?;
-        let _ = read_continuation(&mut reader).await?;
-        let encoded = base64::engine::general_purpose::STANDARD.encode(user.as_bytes());
-        send_raw(&mut writer, encoded.as_bytes()).await?;
-        let auth_resp = read_response(&mut reader, &tag).await?;
-        if !auth_resp.is_ok() {
-            let ltag = tags.next_tag();
-            let _ = send_command(&mut writer, &ltag, "LOGOUT").await;
-            return Err(Error::Transfer {
-                code: 67,
-                message: "IMAP AUTHENTICATE EXTERNAL failed".to_string(),
-            });
-        }
-    } else if let Some(bearer) = oauth2_bearer {
-        if should_try("OAUTHBEARER") {
-            // RFC 7628 OAUTHBEARER
-            let payload = format!(
-                "n,a={user},\x01host={host}\x01port={port}\x01auth=Bearer {bearer}\x01\x01"
-            );
-            let encoded = base64::engine::general_purpose::STANDARD.encode(payload.as_bytes());
-            let tag = tags.next_tag();
-            if server_sasl_ir || sasl_ir {
-                send_command(&mut writer, &tag, &format!("AUTHENTICATE OAUTHBEARER {encoded}"))
-                    .await?;
-            } else {
-                send_command(&mut writer, &tag, "AUTHENTICATE OAUTHBEARER").await?;
-                let _ = read_continuation(&mut reader).await?;
-                send_raw(&mut writer, encoded.as_bytes()).await?;
-            }
-            let auth_resp = read_response(&mut reader, &tag).await?;
-            if !auth_resp.is_ok() {
-                let ltag = tags.next_tag();
-                let _ = send_command(&mut writer, &ltag, "LOGOUT").await;
-                return Err(Error::Transfer {
-                    code: 67,
-                    message: format!(
-                        "IMAP OAUTHBEARER failed: {} {}",
-                        auth_resp.status, auth_resp.message
-                    ),
-                });
-            }
-        } else {
-            // XOAUTH2 fallback
-            let payload = format!("user={user}\x01auth=Bearer {bearer}\x01\x01");
-            let encoded = base64::engine::general_purpose::STANDARD.encode(payload.as_bytes());
-            let tag = tags.next_tag();
-            if server_sasl_ir || sasl_ir {
-                send_command(&mut writer, &tag, &format!("AUTHENTICATE XOAUTH2 {encoded}")).await?;
-            } else {
-                send_command(&mut writer, &tag, "AUTHENTICATE XOAUTH2").await?;
-                let _ = read_continuation(&mut reader).await?;
-                send_raw(&mut writer, encoded.as_bytes()).await?;
-            }
-            let auth_resp = read_response(&mut reader, &tag).await?;
-            if !auth_resp.is_ok() {
-                let ltag = tags.next_tag();
-                let _ = send_command(&mut writer, &ltag, "LOGOUT").await;
-                return Err(Error::Transfer {
-                    code: 67,
-                    message: format!(
-                        "IMAP XOAUTH2 failed: {} {}",
-                        auth_resp.status, auth_resp.message
-                    ),
-                });
-            }
-        }
-    } else if should_try("CRAM-MD5") {
-        let tag = tags.next_tag();
-        send_command(&mut writer, &tag, "AUTHENTICATE CRAM-MD5").await?;
-        let cont = read_continuation(&mut reader).await?;
-        let challenge_b64 = cont.trim_start_matches('+').trim();
-        let challenge_bytes = base64::engine::general_purpose::STANDARD
-            .decode(challenge_b64)
-            .map_err(|e| Error::Http(format!("CRAM-MD5 decode error: {e}")))?;
-        let challenge = String::from_utf8_lossy(&challenge_bytes);
-        let response_str = crate::auth::cram_md5::cram_md5_response(&user, &pass, &challenge);
-        let encoded = base64::engine::general_purpose::STANDARD.encode(response_str.as_bytes());
-        send_raw(&mut writer, encoded.as_bytes()).await?;
-        let auth_resp = read_response(&mut reader, &tag).await?;
-        if !auth_resp.is_ok() {
-            let ltag = tags.next_tag();
-            let _ = send_command(&mut writer, &ltag, "LOGOUT").await;
-            return Err(Error::Transfer {
-                code: 67,
-                message: format!(
-                    "IMAP CRAM-MD5 failed: {} {}",
-                    auth_resp.status, auth_resp.message
-                ),
-            });
-        }
-    } else if should_try("NTLM") {
-        let type1 = crate::auth::ntlm::create_type1_message();
-        let tag = tags.next_tag();
-        send_command(&mut writer, &tag, "AUTHENTICATE NTLM").await?;
-        let _ = read_continuation(&mut reader).await?;
-        // Send Type 1
-        send_raw(&mut writer, type1.as_bytes()).await?;
-        // Read Type 2 challenge
-        let cont2 = read_continuation(&mut reader).await?;
-        let challenge_b64 = cont2.trim_start_matches('+').trim();
-        if let Ok(challenge) = crate::auth::ntlm::parse_type2_message(challenge_b64) {
-            let type3 = crate::auth::ntlm::create_type3_message(&challenge, &user, &pass, "");
-            send_raw(&mut writer, type3.as_bytes()).await?;
-            let auth_resp = read_response(&mut reader, &tag).await?;
-            if !auth_resp.is_ok() {
-                let ltag = tags.next_tag();
-                let _ = send_command(&mut writer, &ltag, "LOGOUT").await;
-                return Err(Error::Transfer {
-                    code: 67,
-                    message: format!(
-                        "IMAP NTLM failed: {} {}",
-                        auth_resp.status, auth_resp.message
-                    ),
-                });
-            }
-        } else {
-            // Bad challenge — cancel
-            send_raw(&mut writer, b"*").await?;
-            let _ = read_response(&mut reader, &tag).await;
-            let ltag = tags.next_tag();
-            let _ = send_command(&mut writer, &ltag, "LOGOUT").await;
-            return Err(Error::Transfer {
-                code: 67,
-                message: "IMAP NTLM: invalid challenge".to_string(),
-            });
-        }
-    } else if should_try("PLAIN") {
-        let auth_string = format!("\0{user}\0{pass}");
-        let encoded = base64::engine::general_purpose::STANDARD.encode(auth_string.as_bytes());
-        let tag = tags.next_tag();
-        if sasl_ir || server_sasl_ir {
-            send_command(&mut writer, &tag, &format!("AUTHENTICATE PLAIN {encoded}")).await?;
-        } else {
-            send_command(&mut writer, &tag, "AUTHENTICATE PLAIN").await?;
-            let _ = read_continuation(&mut reader).await?;
-            send_raw(&mut writer, encoded.as_bytes()).await?;
-        }
-        let auth_resp = read_response(&mut reader, &tag).await?;
-        if !auth_resp.is_ok() {
-            let ltag = tags.next_tag();
-            let _ = send_command(&mut writer, &ltag, "LOGOUT").await;
-            return Err(Error::Transfer {
-                code: 67,
-                message: format!(
-                    "IMAP AUTHENTICATE PLAIN failed: {} {}",
-                    auth_resp.status, auth_resp.message
-                ),
-            });
-        }
-    } else if should_try("LOGIN") {
-        let tag = tags.next_tag();
-        let user_b64 = base64::engine::general_purpose::STANDARD.encode(user.as_bytes());
-        let pass_b64 = base64::engine::general_purpose::STANDARD.encode(pass.as_bytes());
-        if sasl_ir || server_sasl_ir {
-            send_command(&mut writer, &tag, &format!("AUTHENTICATE LOGIN {user_b64}")).await?;
-        } else {
-            send_command(&mut writer, &tag, "AUTHENTICATE LOGIN").await?;
-            let _ = read_continuation(&mut reader).await?;
-            send_raw(&mut writer, user_b64.as_bytes()).await?;
-        }
-        let _ = read_continuation(&mut reader).await?;
-        send_raw(&mut writer, pass_b64.as_bytes()).await?;
-        let auth_resp = read_response(&mut reader, &tag).await?;
-        if !auth_resp.is_ok() {
-            let ltag = tags.next_tag();
-            let _ = send_command(&mut writer, &ltag, "LOGOUT").await;
-            return Err(Error::Transfer {
-                code: 67,
-                message: format!(
-                    "IMAP AUTHENTICATE LOGIN failed: {} {}",
-                    auth_resp.status, auth_resp.message
-                ),
-            });
-        }
-    } else {
-        // Plain LOGIN command
-        let tag = tags.next_tag();
-        let login_user = if needs_quoting(&user) { imap_quote(&user) } else { user.clone() };
-        let login_pass = if needs_quoting(&pass) { imap_quote(&pass) } else { pass.clone() };
-        send_command(&mut writer, &tag, &format!("LOGIN {login_user} {login_pass}")).await?;
-        let login_resp = read_response(&mut reader, &tag).await?;
-        if !login_resp.is_ok() {
-            let ltag = tags.next_tag();
-            let _ = send_command(&mut writer, &ltag, "LOGOUT").await;
-            return Err(Error::Auth(format!(
-                "IMAP LOGIN failed: {} {}",
-                login_resp.status, login_resp.message
-            )));
-        }
-    }
+    // With downgrade: if CRAM-MD5 or NTLM fails with bad challenge, cancel and try next
+    let auth_result = do_imap_auth(
+        &mut reader,
+        &mut writer,
+        &mut tags,
+        &user,
+        &pass,
+        sasl_ir,
+        server_sasl_ir,
+        oauth2_bearer,
+        sasl_authzid,
+        &host,
+        port,
+        force_login_cmd,
+        forced,
+        &server_auth_mechs,
+    )
+    .await;
+
+    // Auth failed — do NOT send LOGOUT (curl compat: tests 830, 831, 844, 845, 849)
+    // The multi interface considers a broken "CONNECT" as a prematurely broken
+    // transfer and such a connection will not get a "LOGOUT"
+    auth_result?;
 
     // Determine what operation to perform
     let result = dispatch_imap_operation(
@@ -642,6 +490,322 @@ pub async fn fetch(
     // a non-HTTP protocol response.
     resp.set_raw_headers(Vec::new());
     Ok(resp)
+}
+
+/// Perform IMAP authentication with mechanism negotiation and downgrade support.
+///
+/// Tries mechanisms in order: EXTERNAL > OAUTHBEARER > XOAUTH2 > CRAM-MD5 > NTLM > PLAIN > LOGIN cmd.
+/// When CRAM-MD5 or NTLM fails with a bad challenge, sends `*` to cancel and tries the next mechanism.
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+async fn do_imap_auth<S: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
+    reader: &mut BufReader<S>,
+    writer: &mut W,
+    tags: &mut TagCounter,
+    user: &str,
+    pass: &str,
+    sasl_ir: bool,
+    server_sasl_ir: bool,
+    oauth2_bearer: Option<&str>,
+    sasl_authzid: Option<&str>,
+    host: &str,
+    port: u16,
+    force_login_cmd: bool,
+    forced: Option<&str>,
+    server_auth_mechs: &[String],
+) -> Result<(), Error> {
+    use base64::Engine;
+
+    let has_mech = |mech: &str| server_auth_mechs.iter().any(|m| m.eq_ignore_ascii_case(mech));
+    let should_try =
+        |mech: &str| forced.map_or_else(|| has_mech(mech), |f| f.eq_ignore_ascii_case(mech));
+
+    // If forced to plain LOGIN command (AUTH=+LOGIN or AUTH=LOGIN)
+    if force_login_cmd {
+        let tag = tags.next_tag();
+        let login_user = if needs_quoting(user) { imap_quote(user) } else { user.to_string() };
+        let login_pass = if needs_quoting(pass) { imap_quote(pass) } else { pass.to_string() };
+        send_command(writer, &tag, &format!("LOGIN {login_user} {login_pass}")).await?;
+        let login_resp = read_response(reader, &tag).await?;
+        if !login_resp.is_ok() {
+            return Err(Error::Transfer {
+                code: 67,
+                message: format!("IMAP LOGIN failed: {} {}", login_resp.status, login_resp.message),
+            });
+        }
+        return Ok(());
+    }
+
+    // EXTERNAL: send base64(username)
+    if should_try("EXTERNAL") {
+        let tag = tags.next_tag();
+        let use_ir = sasl_ir || server_sasl_ir;
+        let encoded = if user.is_empty() {
+            "=".to_string() // empty initial response
+        } else {
+            base64::engine::general_purpose::STANDARD.encode(user.as_bytes())
+        };
+        if use_ir {
+            send_command(writer, &tag, &format!("AUTHENTICATE EXTERNAL {encoded}")).await?;
+        } else {
+            send_command(writer, &tag, "AUTHENTICATE EXTERNAL").await?;
+            let _ = read_continuation(reader).await?;
+            send_raw(writer, encoded.as_bytes()).await?;
+        }
+        let auth_resp = read_response(reader, &tag).await?;
+        if !auth_resp.is_ok() {
+            return Err(Error::Transfer {
+                code: 67,
+                message: "IMAP AUTHENTICATE EXTERNAL failed".to_string(),
+            });
+        }
+        return Ok(());
+    }
+
+    // OAUTHBEARER / XOAUTH2
+    if let Some(bearer) = oauth2_bearer {
+        if should_try("OAUTHBEARER") {
+            // RFC 7628 OAUTHBEARER
+            let payload = format!(
+                "n,a={user},\x01host={host}\x01port={port}\x01auth=Bearer {bearer}\x01\x01"
+            );
+            let encoded = base64::engine::general_purpose::STANDARD.encode(payload.as_bytes());
+            let tag = tags.next_tag();
+            if server_sasl_ir || sasl_ir {
+                send_command(writer, &tag, &format!("AUTHENTICATE OAUTHBEARER {encoded}")).await?;
+                // After SASL-IR, server may send continuation with error JSON
+                // We need to read next line: if it's '+', send AQ== cancel
+                let line = read_continuation(reader).await?;
+                if line.starts_with('+') {
+                    // Server sent error JSON challenge — send SASL abort (base64 of 0x01)
+                    send_raw(writer, b"AQ==").await?;
+                    let _ = read_response(reader, &tag).await;
+                    return Err(Error::Transfer {
+                        code: 67,
+                        message: "IMAP OAUTHBEARER failed".to_string(),
+                    });
+                }
+                // If it's not '+', it should be the tagged OK/NO response
+                // (handled by read_response which was already consumed)
+                // Actually the read_continuation just reads one line — check if it was
+                // the tagged response
+                if line.starts_with(&tag) {
+                    // Tagged response inline
+                    if line.contains(" OK ") {
+                        return Ok(());
+                    }
+                    return Err(Error::Transfer {
+                        code: 67,
+                        message: "IMAP OAUTHBEARER failed".to_string(),
+                    });
+                }
+                // Otherwise read the tagged response normally
+                let auth_resp = read_response(reader, &tag).await?;
+                if auth_resp.is_ok() {
+                    return Ok(());
+                }
+                return Err(Error::Transfer {
+                    code: 67,
+                    message: format!(
+                        "IMAP OAUTHBEARER failed: {} {}",
+                        auth_resp.status, auth_resp.message
+                    ),
+                });
+            }
+            // Without SASL-IR: send AUTHENTICATE, wait for continuation, send payload
+            send_command(writer, &tag, "AUTHENTICATE OAUTHBEARER").await?;
+            let _ = read_continuation(reader).await?;
+            send_raw(writer, encoded.as_bytes()).await?;
+            let auth_resp = read_response(reader, &tag).await?;
+            if auth_resp.is_ok() {
+                return Ok(());
+            }
+            return Err(Error::Transfer {
+                code: 67,
+                message: format!(
+                    "IMAP OAUTHBEARER failed: {} {}",
+                    auth_resp.status, auth_resp.message
+                ),
+            });
+        }
+
+        if should_try("XOAUTH2") || !should_try("OAUTHBEARER") {
+            // XOAUTH2 fallback (or if XOAUTH2 forced)
+            let payload = format!("user={user}\x01auth=Bearer {bearer}\x01\x01");
+            let encoded = base64::engine::general_purpose::STANDARD.encode(payload.as_bytes());
+            let tag = tags.next_tag();
+            if server_sasl_ir || sasl_ir {
+                send_command(writer, &tag, &format!("AUTHENTICATE XOAUTH2 {encoded}")).await?;
+            } else {
+                send_command(writer, &tag, "AUTHENTICATE XOAUTH2").await?;
+                let _ = read_continuation(reader).await?;
+                send_raw(writer, encoded.as_bytes()).await?;
+            }
+            let auth_resp = read_response(reader, &tag).await?;
+            if !auth_resp.is_ok() {
+                return Err(Error::Transfer {
+                    code: 67,
+                    message: format!(
+                        "IMAP XOAUTH2 failed: {} {}",
+                        auth_resp.status, auth_resp.message
+                    ),
+                });
+            }
+            return Ok(());
+        }
+    }
+
+    // Track whether CRAM-MD5 or NTLM failed (for downgrade)
+    let mut cram_failed = false;
+    let mut ntlm_failed = false;
+
+    // CRAM-MD5
+    if should_try("CRAM-MD5") {
+        let tag = tags.next_tag();
+        send_command(writer, &tag, "AUTHENTICATE CRAM-MD5").await?;
+        let cont = read_continuation(reader).await?;
+        let challenge_b64 = cont.trim_start_matches('+').trim();
+        if let Ok(challenge_bytes) = base64::engine::general_purpose::STANDARD.decode(challenge_b64)
+        {
+            let challenge = String::from_utf8_lossy(&challenge_bytes);
+            let response_str = crate::auth::cram_md5::cram_md5_response(user, pass, &challenge);
+            let encoded = base64::engine::general_purpose::STANDARD.encode(response_str.as_bytes());
+            send_raw(writer, encoded.as_bytes()).await?;
+            let auth_resp = read_response(reader, &tag).await?;
+            if auth_resp.is_ok() {
+                return Ok(());
+            }
+            return Err(Error::Transfer {
+                code: 67,
+                message: format!(
+                    "IMAP CRAM-MD5 failed: {} {}",
+                    auth_resp.status, auth_resp.message
+                ),
+            });
+        }
+        // Invalid challenge — send SASL cancel
+        send_raw(writer, b"*").await?;
+        let _ = read_response(reader, &tag).await;
+        cram_failed = true;
+    }
+
+    // NTLM
+    if !cram_failed && should_try("NTLM") || cram_failed && has_mech("NTLM") {
+        let type1 = crate::auth::ntlm::create_type1_message();
+        let tag = tags.next_tag();
+        let use_ir = sasl_ir || server_sasl_ir;
+        if use_ir {
+            send_command(writer, &tag, &format!("AUTHENTICATE NTLM {type1}")).await?;
+        } else {
+            send_command(writer, &tag, "AUTHENTICATE NTLM").await?;
+            let _ = read_continuation(reader).await?;
+            send_raw(writer, type1.as_bytes()).await?;
+        }
+        // Read Type 2 challenge
+        let cont2 = read_continuation(reader).await?;
+        let challenge_b64 = cont2.trim_start_matches('+').trim();
+        if let Ok(challenge) = crate::auth::ntlm::parse_type2_message(challenge_b64) {
+            let type3 = crate::auth::ntlm::create_type3_message(&challenge, user, pass, "");
+            send_raw(writer, type3.as_bytes()).await?;
+            let auth_resp = read_response(reader, &tag).await?;
+            if auth_resp.is_ok() {
+                return Ok(());
+            }
+            return Err(Error::Transfer {
+                code: 67,
+                message: format!("IMAP NTLM failed: {} {}", auth_resp.status, auth_resp.message),
+            });
+        }
+        // Bad challenge — cancel
+        send_raw(writer, b"*").await?;
+        let _ = read_response(reader, &tag).await;
+        ntlm_failed = true;
+    }
+
+    // PLAIN (also used as downgrade target from CRAM-MD5/NTLM)
+    let try_plain = should_try("PLAIN") || (cram_failed || ntlm_failed) && has_mech("PLAIN");
+    if try_plain {
+        let auth_string = sasl_authzid.map_or_else(
+            || format!("\0{user}\0{pass}"),
+            |authzid| format!("{authzid}\0{user}\0{pass}"),
+        );
+        let encoded = base64::engine::general_purpose::STANDARD.encode(auth_string.as_bytes());
+        let tag = tags.next_tag();
+        if sasl_ir || server_sasl_ir {
+            send_command(writer, &tag, &format!("AUTHENTICATE PLAIN {encoded}")).await?;
+        } else {
+            send_command(writer, &tag, "AUTHENTICATE PLAIN").await?;
+            let _ = read_continuation(reader).await?;
+            send_raw(writer, encoded.as_bytes()).await?;
+        }
+        let auth_resp = read_response(reader, &tag).await?;
+        if auth_resp.is_ok() {
+            return Ok(());
+        }
+        return Err(Error::Transfer {
+            code: 67,
+            message: format!(
+                "IMAP AUTHENTICATE PLAIN failed: {} {}",
+                auth_resp.status, auth_resp.message
+            ),
+        });
+    }
+
+    // LOGIN SASL mechanism (AUTHENTICATE LOGIN)
+    if should_try("LOGIN") {
+        let tag = tags.next_tag();
+        let user_b64 = base64::engine::general_purpose::STANDARD.encode(user.as_bytes());
+        let pass_b64 = base64::engine::general_purpose::STANDARD.encode(pass.as_bytes());
+        if sasl_ir || server_sasl_ir {
+            send_command(writer, &tag, &format!("AUTHENTICATE LOGIN {user_b64}")).await?;
+        } else {
+            send_command(writer, &tag, "AUTHENTICATE LOGIN").await?;
+            let _ = read_continuation(reader).await?;
+            send_raw(writer, user_b64.as_bytes()).await?;
+        }
+        let _ = read_continuation(reader).await?;
+        send_raw(writer, pass_b64.as_bytes()).await?;
+        let auth_resp = read_response(reader, &tag).await?;
+        if auth_resp.is_ok() {
+            return Ok(());
+        }
+        return Err(Error::Transfer {
+            code: 67,
+            message: format!(
+                "IMAP AUTHENTICATE LOGIN failed: {} {}",
+                auth_resp.status, auth_resp.message
+            ),
+        });
+    }
+
+    // If CRAM-MD5 or NTLM failed and no PLAIN available, error out
+    if cram_failed || ntlm_failed {
+        return Err(Error::Transfer {
+            code: 67,
+            message: "IMAP authentication cancelled, no fallback available".to_string(),
+        });
+    }
+
+    // If no password is available, no auth method can work — fail early
+    if pass.is_empty() {
+        return Err(Error::Transfer {
+            code: 67,
+            message: "IMAP login denied: no password available".to_string(),
+        });
+    }
+
+    // Plain LOGIN command (fallback when no SASL mechanism matches)
+    let tag = tags.next_tag();
+    let login_user = if needs_quoting(user) { imap_quote(user) } else { user.to_string() };
+    let login_pass = if needs_quoting(pass) { imap_quote(pass) } else { pass.to_string() };
+    send_command(writer, &tag, &format!("LOGIN {login_user} {login_pass}")).await?;
+    let login_resp = read_response(reader, &tag).await?;
+    if !login_resp.is_ok() {
+        return Err(Error::Auth(format!(
+            "IMAP LOGIN failed: {} {}",
+            login_resp.status, login_resp.message
+        )));
+    }
+    Ok(())
 }
 
 /// Dispatch the appropriate IMAP operation based on URL parameters and options.
@@ -954,7 +1118,7 @@ mod tests {
 
     #[test]
     fn tag_counter_increments() {
-        let mut counter = TagCounter::new();
+        let mut counter = TagCounter::new('A');
         assert_eq!(counter.next_tag(), "A001");
         assert_eq!(counter.next_tag(), "A002");
         assert_eq!(counter.next_tag(), "A003");

--- a/crates/liburlx/src/protocol/pop3.rs
+++ b/crates/liburlx/src/protocol/pop3.rs
@@ -147,6 +147,25 @@ pub async fn send_command<S: AsyncWrite + Unpin>(
     Ok(())
 }
 
+/// Read a continuation line from POP3 server (starts with `+`).
+///
+/// # Errors
+///
+/// Returns an error if the read fails.
+async fn read_continuation<S: AsyncRead + Unpin>(
+    stream: &mut BufReader<S>,
+) -> Result<String, Error> {
+    let mut line = String::new();
+    let bytes_read = stream
+        .read_line(&mut line)
+        .await
+        .map_err(|e| Error::Http(format!("POP3 read error: {e}")))?;
+    if bytes_read == 0 {
+        return Err(Error::Http("POP3 connection closed waiting for continuation".to_string()));
+    }
+    Ok(line.trim().to_string())
+}
+
 /// Retrieve email from a POP3 server.
 ///
 /// URL format: `pop3://user:pass@host:port/N`
@@ -165,10 +184,10 @@ pub async fn retrieve(
     sasl_ir: bool,
     oauth2_bearer: Option<&str>,
     login_options: Option<&str>,
+    sasl_authzid: Option<&str>,
     use_ssl: UseSsl,
     tls_config: &crate::tls::TlsConfig,
 ) -> Result<Response, Error> {
-    use base64::Engine;
     // Reject URLs with CR/LF (curl returns exit code 3, test 875)
     let raw_url = url.as_str();
     if raw_url.contains("%0a")
@@ -180,9 +199,15 @@ pub async fn retrieve(
     }
     let (host, port) = url.host_and_port()?;
     let url_creds = url.credentials();
-    let (raw_user, pass) = url_creds
-        .or(credentials)
-        .ok_or_else(|| Error::Http("POP3 requires credentials".to_string()))?;
+    // Credentials are optional for EXTERNAL auth
+    let has_creds = url_creds.is_some() || credentials.is_some();
+    let (raw_user, pass) = if has_creds {
+        url_creds
+            .or(credentials)
+            .ok_or_else(|| Error::Http("POP3 requires credentials".to_string()))?
+    } else {
+        ("", "")
+    };
     // Strip ";AUTH=..." from username (login options, not part of the name)
     let user_owned = strip_auth_from_username(&percent_decode_str(raw_user));
     let user: &str = &user_owned;
@@ -277,235 +302,23 @@ pub async fn retrieve(
 
     let forced =
         login_options.and_then(|lo| lo.strip_prefix("AUTH=").or_else(|| lo.strip_prefix("auth=")));
-    let should_try = |mech: &str| {
-        forced.map_or_else(
-            || server_sasl_mechs.iter().any(|m| m.eq_ignore_ascii_case(mech)),
-            |f| f.eq_ignore_ascii_case(mech),
-        )
-    };
 
-    // EXTERNAL: send base64(username)
-    let auth_done = if should_try("EXTERNAL") {
-        send_command(&mut writer, "AUTH EXTERNAL").await?;
-        let mut line = String::new();
-        let _ = reader.read_line(&mut line).await;
-        let encoded = base64::engine::general_purpose::STANDARD.encode(user.as_bytes());
-        writer
-            .write_all(format!("{encoded}\r\n").as_bytes())
-            .await
-            .map_err(|e| Error::Http(format!("POP3 write error: {e}")))?;
-        let _ = writer.flush().await;
-        let auth_resp = read_response(&mut reader).await?;
-        if !auth_resp.ok {
-            send_command(&mut writer, "QUIT").await?;
-            let _ = read_response(&mut reader).await;
-            return Err(Error::Transfer {
-                code: 67,
-                message: "POP3 AUTH EXTERNAL failed".to_string(),
-            });
-        }
-        true
-    } else if let Some(bearer) = oauth2_bearer {
-        if should_try("OAUTHBEARER") {
-            // RFC 7628 OAUTHBEARER format
-            let payload = format!(
-                "n,a={user},\x01host={host}\x01port={port}\x01auth=Bearer {bearer}\x01\x01"
-            );
-            let encoded = base64::engine::general_purpose::STANDARD.encode(payload.as_bytes());
-            send_command(&mut writer, "AUTH OAUTHBEARER").await?;
-            let mut line = String::new();
-            let _ = reader.read_line(&mut line).await;
-            writer
-                .write_all(format!("{encoded}\r\n").as_bytes())
-                .await
-                .map_err(|e| Error::Http(format!("POP3 write error: {e}")))?;
-            let _ = writer.flush().await;
-            let auth_resp = read_response(&mut reader).await?;
-            if !auth_resp.ok {
-                send_command(&mut writer, "QUIT").await?;
-                let _ = read_response(&mut reader).await;
-                return Err(Error::Transfer {
-                    code: 67,
-                    message: format!("POP3 AUTH OAUTHBEARER failed: {}", auth_resp.message),
-                });
-            }
-        } else {
-            // XOAUTH2 fallback
-            let payload = format!("user={user}\x01auth=Bearer {bearer}\x01\x01");
-            let encoded = base64::engine::general_purpose::STANDARD.encode(payload.as_bytes());
-            if sasl_ir {
-                send_command(&mut writer, &format!("AUTH XOAUTH2 {encoded}")).await?;
-            } else {
-                send_command(&mut writer, "AUTH XOAUTH2").await?;
-                let mut line = String::new();
-                let _ = reader.read_line(&mut line).await;
-                writer
-                    .write_all(format!("{encoded}\r\n").as_bytes())
-                    .await
-                    .map_err(|e| Error::Http(format!("POP3 write error: {e}")))?;
-                let _ = writer.flush().await;
-            }
-            let auth_resp = read_response(&mut reader).await?;
-            if !auth_resp.ok {
-                send_command(&mut writer, "QUIT").await?;
-                let _ = read_response(&mut reader).await;
-                return Err(Error::Transfer {
-                    code: 67,
-                    message: format!("POP3 AUTH XOAUTH2 failed: {}", auth_resp.message),
-                });
-            }
-        }
-        true
-    } else if should_try("CRAM-MD5") {
-        send_command(&mut writer, "AUTH CRAM-MD5").await?;
-        let mut line = String::new();
-        let _ = reader.read_line(&mut line).await;
-        let challenge_b64 = line.trim().trim_start_matches('+').trim();
-        let challenge_bytes = base64::engine::general_purpose::STANDARD
-            .decode(challenge_b64)
-            .map_err(|e| Error::Http(format!("CRAM-MD5 decode error: {e}")))?;
-        let challenge = String::from_utf8_lossy(&challenge_bytes);
-        let response_str = crate::auth::cram_md5::cram_md5_response(user, pass, &challenge);
-        let encoded = base64::engine::general_purpose::STANDARD.encode(response_str.as_bytes());
-        writer
-            .write_all(format!("{encoded}\r\n").as_bytes())
-            .await
-            .map_err(|e| Error::Http(format!("POP3 write error: {e}")))?;
-        let _ = writer.flush().await;
-        let auth_resp = read_response(&mut reader).await?;
-        if !auth_resp.ok {
-            send_command(&mut writer, "QUIT").await?;
-            let _ = read_response(&mut reader).await;
-            return Err(Error::Transfer {
-                code: 67,
-                message: format!("POP3 AUTH CRAM-MD5 failed: {}", auth_resp.message),
-            });
-        }
-        true
-    } else if should_try("NTLM") {
-        let type1 = crate::auth::ntlm::create_type1_message();
-        send_command(&mut writer, "AUTH NTLM").await?;
-        let mut line = String::new();
-        let _ = reader.read_line(&mut line).await;
-        // Send Type 1
-        writer
-            .write_all(format!("{type1}\r\n").as_bytes())
-            .await
-            .map_err(|e| Error::Http(format!("POP3 write error: {e}")))?;
-        let _ = writer.flush().await;
-        // Read Type 2 challenge
-        let mut line2 = String::new();
-        let _ = reader.read_line(&mut line2).await;
-        let challenge_b64 = line2.trim().trim_start_matches('+').trim();
-        if let Ok(challenge) = crate::auth::ntlm::parse_type2_message(challenge_b64) {
-            let type3 = crate::auth::ntlm::create_type3_message(&challenge, user, pass, "");
-            writer
-                .write_all(format!("{type3}\r\n").as_bytes())
-                .await
-                .map_err(|e| Error::Http(format!("POP3 write error: {e}")))?;
-            let _ = writer.flush().await;
-            let auth_resp = read_response(&mut reader).await?;
-            if !auth_resp.ok {
-                send_command(&mut writer, "QUIT").await?;
-                let _ = read_response(&mut reader).await;
-                return Err(Error::Transfer {
-                    code: 67,
-                    message: format!("POP3 AUTH NTLM failed: {}", auth_resp.message),
-                });
-            }
-        } else {
-            // Bad challenge — cancel
-            writer
-                .write_all(b"*\r\n")
-                .await
-                .map_err(|e| Error::Http(format!("POP3 write error: {e}")))?;
-            let _ = writer.flush().await;
-            send_command(&mut writer, "QUIT").await?;
-            let _ = read_response(&mut reader).await;
-            return Err(Error::Transfer {
-                code: 67,
-                message: "POP3 AUTH NTLM: invalid challenge".to_string(),
-            });
-        }
-        true
-    } else if should_try("LOGIN") {
-        let user_b64 = base64::engine::general_purpose::STANDARD.encode(user.as_bytes());
-        let pass_b64 = base64::engine::general_purpose::STANDARD.encode(pass.as_bytes());
-        if sasl_ir {
-            send_command(&mut writer, &format!("AUTH LOGIN {user_b64}")).await?;
-        } else {
-            send_command(&mut writer, "AUTH LOGIN").await?;
-            let mut line = String::new();
-            let _ = reader.read_line(&mut line).await;
-            writer
-                .write_all(format!("{user_b64}\r\n").as_bytes())
-                .await
-                .map_err(|e| Error::Http(format!("POP3 write error: {e}")))?;
-            let _ = writer.flush().await;
-        }
-        let mut line2 = String::new();
-        let _ = reader.read_line(&mut line2).await;
-        writer
-            .write_all(format!("{pass_b64}\r\n").as_bytes())
-            .await
-            .map_err(|e| Error::Http(format!("POP3 write error: {e}")))?;
-        let _ = writer.flush().await;
-        let auth_resp = read_response(&mut reader).await?;
-        if !auth_resp.ok {
-            send_command(&mut writer, "QUIT").await?;
-            let _ = read_response(&mut reader).await;
-            return Err(Error::Transfer {
-                code: 67,
-                message: format!("POP3 AUTH LOGIN failed: {}", auth_resp.message),
-            });
-        }
-        true
-    } else if should_try("PLAIN") {
-        let auth_string = format!("\0{user}\0{pass}");
-        let encoded = base64::engine::general_purpose::STANDARD.encode(auth_string.as_bytes());
-        if sasl_ir {
-            send_command(&mut writer, &format!("AUTH PLAIN {encoded}")).await?;
-        } else {
-            send_command(&mut writer, "AUTH PLAIN").await?;
-            let mut line = String::new();
-            let _ = reader.read_line(&mut line).await;
-            writer
-                .write_all(format!("{encoded}\r\n").as_bytes())
-                .await
-                .map_err(|e| Error::Http(format!("POP3 write error: {e}")))?;
-            let _ = writer.flush().await;
-        }
-        let auth_resp = read_response(&mut reader).await?;
-        if !auth_resp.ok {
-            send_command(&mut writer, "QUIT").await?;
-            let _ = read_response(&mut reader).await;
-            return Err(Error::Transfer {
-                code: 67,
-                message: format!("POP3 AUTH PLAIN failed: {}", auth_resp.message),
-            });
-        }
-        true
-    } else if server_has_apop || apop_timestamp.is_some() {
-        // APOP: MD5(timestamp + password)
-        if let Some(ref ts) = apop_timestamp {
-            let digest = crate::auth::cram_md5::apop_digest(ts, pass);
-            send_command(&mut writer, &format!("APOP {user} {digest}")).await?;
-            let auth_resp = read_response(&mut reader).await?;
-            if !auth_resp.ok {
-                send_command(&mut writer, "QUIT").await?;
-                let _ = read_response(&mut reader).await;
-                return Err(Error::Transfer {
-                    code: 67,
-                    message: format!("POP3 APOP failed: {}", auth_resp.message),
-                });
-            }
-            true
-        } else {
-            false // No timestamp in greeting, fall through to USER/PASS
-        }
-    } else {
-        false
-    };
+    let auth_done = do_pop3_auth(
+        &mut reader,
+        &mut writer,
+        user,
+        pass,
+        sasl_ir,
+        oauth2_bearer,
+        sasl_authzid,
+        &host,
+        port,
+        server_has_apop,
+        apop_timestamp.as_ref(),
+        forced,
+        &server_sasl_mechs,
+    )
+    .await?;
 
     if !auth_done {
         // USER/PASS authentication (fallback)
@@ -611,6 +424,314 @@ pub async fn retrieve(
 
     let headers = std::collections::HashMap::new();
     Ok(Response::new(200, headers, Vec::new(), url.as_str().to_string()))
+}
+
+/// Perform POP3 authentication with mechanism negotiation and downgrade support.
+///
+/// Returns `Ok(true)` if SASL auth succeeded, `Ok(false)` if no SASL mechanism matched
+/// (caller should fall through to USER/PASS).
+///
+/// Returns `Err` if authentication was attempted and failed (no QUIT/retry possible).
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+async fn do_pop3_auth<S: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
+    reader: &mut BufReader<S>,
+    writer: &mut W,
+    user: &str,
+    pass: &str,
+    sasl_ir: bool,
+    oauth2_bearer: Option<&str>,
+    sasl_authzid: Option<&str>,
+    host: &str,
+    port: u16,
+    server_has_apop: bool,
+    apop_timestamp: Option<&String>,
+    forced: Option<&str>,
+    server_sasl_mechs: &[String],
+) -> Result<bool, Error> {
+    use base64::Engine;
+
+    let has_mech = |mech: &str| server_sasl_mechs.iter().any(|m| m.eq_ignore_ascii_case(mech));
+    let should_try =
+        |mech: &str| forced.map_or_else(|| has_mech(mech), |f| f.eq_ignore_ascii_case(mech));
+
+    // EXTERNAL: send base64(username) or = for empty
+    if should_try("EXTERNAL") {
+        let encoded = if user.is_empty() {
+            "=".to_string()
+        } else {
+            base64::engine::general_purpose::STANDARD.encode(user.as_bytes())
+        };
+        if sasl_ir {
+            send_command(writer, &format!("AUTH EXTERNAL {encoded}")).await?;
+        } else {
+            send_command(writer, "AUTH EXTERNAL").await?;
+            let _ = read_continuation(reader).await?;
+            writer
+                .write_all(format!("{encoded}\r\n").as_bytes())
+                .await
+                .map_err(|e| Error::Http(format!("POP3 write error: {e}")))?;
+            let _ = writer.flush().await;
+        }
+        let auth_resp = read_response(reader).await?;
+        if !auth_resp.ok {
+            return Err(Error::Transfer {
+                code: 67,
+                message: "POP3 AUTH EXTERNAL failed".to_string(),
+            });
+        }
+        return Ok(true);
+    }
+
+    // OAUTHBEARER / XOAUTH2
+    if let Some(bearer) = oauth2_bearer {
+        if should_try("OAUTHBEARER") {
+            // RFC 7628 OAUTHBEARER format
+            let payload = format!(
+                "n,a={user},\x01host={host}\x01port={port}\x01auth=Bearer {bearer}\x01\x01"
+            );
+            let encoded = base64::engine::general_purpose::STANDARD.encode(payload.as_bytes());
+            if sasl_ir {
+                send_command(writer, &format!("AUTH OAUTHBEARER {encoded}")).await?;
+            } else {
+                send_command(writer, "AUTH OAUTHBEARER").await?;
+                let _ = read_continuation(reader).await?;
+                writer
+                    .write_all(format!("{encoded}\r\n").as_bytes())
+                    .await
+                    .map_err(|e| Error::Http(format!("POP3 write error: {e}")))?;
+                let _ = writer.flush().await;
+            }
+            // Read response — could be +OK or a continuation with error JSON
+            let mut line = String::new();
+            let _ = reader.read_line(&mut line).await;
+            let trimmed = line.trim();
+            if trimmed.starts_with("+OK") {
+                return Ok(true);
+            }
+            if trimmed.starts_with('+') && !trimmed.starts_with("+OK") {
+                // Server sent error JSON as continuation — send SASL abort (AQ==)
+                writer
+                    .write_all(b"AQ==\r\n")
+                    .await
+                    .map_err(|e| Error::Http(format!("POP3 write error: {e}")))?;
+                let _ = writer.flush().await;
+                // Read the -ERR response
+                let _ = read_response(reader).await;
+                return Err(Error::Transfer {
+                    code: 67,
+                    message: "POP3 AUTH OAUTHBEARER failed".to_string(),
+                });
+            }
+            // -ERR response
+            return Err(Error::Transfer {
+                code: 67,
+                message: format!("POP3 AUTH OAUTHBEARER failed: {trimmed}"),
+            });
+        }
+
+        if should_try("XOAUTH2") || !should_try("OAUTHBEARER") {
+            // XOAUTH2 fallback
+            let payload = format!("user={user}\x01auth=Bearer {bearer}\x01\x01");
+            let encoded = base64::engine::general_purpose::STANDARD.encode(payload.as_bytes());
+            if sasl_ir {
+                send_command(writer, &format!("AUTH XOAUTH2 {encoded}")).await?;
+            } else {
+                send_command(writer, "AUTH XOAUTH2").await?;
+                let _ = read_continuation(reader).await?;
+                writer
+                    .write_all(format!("{encoded}\r\n").as_bytes())
+                    .await
+                    .map_err(|e| Error::Http(format!("POP3 write error: {e}")))?;
+                let _ = writer.flush().await;
+            }
+            let auth_resp = read_response(reader).await?;
+            if !auth_resp.ok {
+                return Err(Error::Transfer {
+                    code: 67,
+                    message: format!("POP3 AUTH XOAUTH2 failed: {}", auth_resp.message),
+                });
+            }
+            return Ok(true);
+        }
+    }
+
+    // Track downgrade state
+    let mut cram_failed = false;
+    let mut ntlm_failed = false;
+
+    // CRAM-MD5
+    if should_try("CRAM-MD5") {
+        send_command(writer, "AUTH CRAM-MD5").await?;
+        let mut line = String::new();
+        let _ = reader.read_line(&mut line).await;
+        let challenge_b64 = line.trim().trim_start_matches('+').trim();
+        if let Ok(challenge_bytes) = base64::engine::general_purpose::STANDARD.decode(challenge_b64)
+        {
+            let challenge = String::from_utf8_lossy(&challenge_bytes);
+            let response_str = crate::auth::cram_md5::cram_md5_response(user, pass, &challenge);
+            let encoded = base64::engine::general_purpose::STANDARD.encode(response_str.as_bytes());
+            writer
+                .write_all(format!("{encoded}\r\n").as_bytes())
+                .await
+                .map_err(|e| Error::Http(format!("POP3 write error: {e}")))?;
+            let _ = writer.flush().await;
+            let auth_resp = read_response(reader).await?;
+            if auth_resp.ok {
+                return Ok(true);
+            }
+            return Err(Error::Transfer {
+                code: 67,
+                message: format!("POP3 AUTH CRAM-MD5 failed: {}", auth_resp.message),
+            });
+        }
+        // Invalid challenge — send SASL cancel
+        writer
+            .write_all(b"*\r\n")
+            .await
+            .map_err(|e| Error::Http(format!("POP3 write error: {e}")))?;
+        let _ = writer.flush().await;
+        // Read server's error response
+        let _ = read_response(reader).await;
+        cram_failed = true;
+    }
+
+    // NTLM
+    if !cram_failed && should_try("NTLM") || cram_failed && has_mech("NTLM") {
+        let type1 = crate::auth::ntlm::create_type1_message();
+        if sasl_ir {
+            send_command(writer, &format!("AUTH NTLM {type1}")).await?;
+        } else {
+            send_command(writer, "AUTH NTLM").await?;
+            let mut line = String::new();
+            let _ = reader.read_line(&mut line).await;
+            // Send Type 1
+            writer
+                .write_all(format!("{type1}\r\n").as_bytes())
+                .await
+                .map_err(|e| Error::Http(format!("POP3 write error: {e}")))?;
+            let _ = writer.flush().await;
+        }
+        // Read Type 2 challenge
+        let mut line2 = String::new();
+        let _ = reader.read_line(&mut line2).await;
+        let challenge_b64 = line2.trim().trim_start_matches('+').trim();
+        if let Ok(challenge) = crate::auth::ntlm::parse_type2_message(challenge_b64) {
+            let type3 = crate::auth::ntlm::create_type3_message(&challenge, user, pass, "");
+            writer
+                .write_all(format!("{type3}\r\n").as_bytes())
+                .await
+                .map_err(|e| Error::Http(format!("POP3 write error: {e}")))?;
+            let _ = writer.flush().await;
+            let auth_resp = read_response(reader).await?;
+            if auth_resp.ok {
+                return Ok(true);
+            }
+            return Err(Error::Transfer {
+                code: 67,
+                message: format!("POP3 AUTH NTLM failed: {}", auth_resp.message),
+            });
+        }
+        // Bad challenge — cancel
+        writer
+            .write_all(b"*\r\n")
+            .await
+            .map_err(|e| Error::Http(format!("POP3 write error: {e}")))?;
+        let _ = writer.flush().await;
+        // Read server's error response
+        let _ = read_response(reader).await;
+        ntlm_failed = true;
+    }
+
+    // LOGIN
+    if should_try("LOGIN") {
+        let user_b64 = base64::engine::general_purpose::STANDARD.encode(user.as_bytes());
+        let pass_b64 = base64::engine::general_purpose::STANDARD.encode(pass.as_bytes());
+        if sasl_ir {
+            send_command(writer, &format!("AUTH LOGIN {user_b64}")).await?;
+        } else {
+            send_command(writer, "AUTH LOGIN").await?;
+            let mut line = String::new();
+            let _ = reader.read_line(&mut line).await;
+            writer
+                .write_all(format!("{user_b64}\r\n").as_bytes())
+                .await
+                .map_err(|e| Error::Http(format!("POP3 write error: {e}")))?;
+            let _ = writer.flush().await;
+        }
+        let mut line2 = String::new();
+        let _ = reader.read_line(&mut line2).await;
+        writer
+            .write_all(format!("{pass_b64}\r\n").as_bytes())
+            .await
+            .map_err(|e| Error::Http(format!("POP3 write error: {e}")))?;
+        let _ = writer.flush().await;
+        let auth_resp = read_response(reader).await?;
+        if !auth_resp.ok {
+            return Err(Error::Transfer {
+                code: 67,
+                message: format!("POP3 AUTH LOGIN failed: {}", auth_resp.message),
+            });
+        }
+        return Ok(true);
+    }
+
+    // PLAIN (also used as downgrade target from CRAM-MD5/NTLM)
+    let try_plain = should_try("PLAIN") || (cram_failed || ntlm_failed) && has_mech("PLAIN");
+    if try_plain {
+        let auth_string = sasl_authzid.map_or_else(
+            || format!("\0{user}\0{pass}"),
+            |authzid| format!("{authzid}\0{user}\0{pass}"),
+        );
+        let encoded = base64::engine::general_purpose::STANDARD.encode(auth_string.as_bytes());
+        if sasl_ir {
+            send_command(writer, &format!("AUTH PLAIN {encoded}")).await?;
+        } else {
+            send_command(writer, "AUTH PLAIN").await?;
+            let mut line = String::new();
+            let _ = reader.read_line(&mut line).await;
+            writer
+                .write_all(format!("{encoded}\r\n").as_bytes())
+                .await
+                .map_err(|e| Error::Http(format!("POP3 write error: {e}")))?;
+            let _ = writer.flush().await;
+        }
+        let auth_resp = read_response(reader).await?;
+        if !auth_resp.ok {
+            return Err(Error::Transfer {
+                code: 67,
+                message: format!("POP3 AUTH PLAIN failed: {}", auth_resp.message),
+            });
+        }
+        return Ok(true);
+    }
+
+    // APOP
+    if (server_has_apop || apop_timestamp.is_some()) && !cram_failed && !ntlm_failed {
+        if let Some(ts) = apop_timestamp {
+            let digest = crate::auth::cram_md5::apop_digest(ts, pass);
+            send_command(writer, &format!("APOP {user} {digest}")).await?;
+            let auth_resp = read_response(reader).await?;
+            if !auth_resp.ok {
+                send_command(writer, "QUIT").await?;
+                let _ = read_response(reader).await;
+                return Err(Error::Transfer {
+                    code: 67,
+                    message: format!("POP3 APOP failed: {}", auth_resp.message),
+                });
+            }
+            return Ok(true);
+        }
+    }
+
+    // If CRAM-MD5 or NTLM failed and no PLAIN available, error out
+    if cram_failed || ntlm_failed {
+        return Err(Error::Transfer {
+            code: 67,
+            message: "POP3 authentication cancelled, no fallback available".to_string(),
+        });
+    }
+
+    Ok(false)
 }
 
 /// Strip `;AUTH=<mechanism>` from a URL username.

--- a/crates/liburlx/src/protocol/smtp.rs
+++ b/crates/liburlx/src/protocol/smtp.rs
@@ -438,6 +438,9 @@ fn determine_smtp_mode(config: &SmtpConfig<'_>, has_data: bool) -> SmtpMode {
 ///
 /// curl's negotiation order: EXTERNAL > OAUTHBEARER > XOAUTH2 > CRAM-MD5 > NTLM > LOGIN > PLAIN.
 /// When `login_options` is set (e.g. `;AUTH=CRAM-MD5`), only that mechanism is tried.
+///
+/// Supports SASL downgrade: when CRAM-MD5 or NTLM fails with a bad challenge,
+/// sends `*` to cancel and tries the next mechanism (PLAIN).
 #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 async fn do_auth<S: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
     reader: &mut BufReader<S>,
@@ -462,17 +465,26 @@ async fn do_auth<S: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
     let should_try =
         |mech: &str| forced.map_or_else(|| has(mech), |f| f.eq_ignore_ascii_case(mech));
 
-    // EXTERNAL: send base64(username)
+    // EXTERNAL: send base64(username) or = for empty
     if should_try("EXTERNAL") {
-        send_command(writer, "AUTH EXTERNAL").await?;
-        let resp = read_response(reader).await?;
-        if resp.code == 334 {
-            let encoded = base64::engine::general_purpose::STANDARD.encode(user.as_bytes());
-            send_command(writer, &encoded).await?;
-            let auth_resp = read_response(reader).await?;
-            if auth_resp.is_ok() {
-                return Ok(());
+        let encoded = if user.is_empty() {
+            "=".to_string()
+        } else {
+            base64::engine::general_purpose::STANDARD.encode(user.as_bytes())
+        };
+        if sasl_ir {
+            send_command(writer, &format!("AUTH EXTERNAL {encoded}")).await?;
+        } else {
+            send_command(writer, "AUTH EXTERNAL").await?;
+            let resp = read_response(reader).await?;
+            if resp.code != 334 {
+                return Err(Error::SmtpAuth("AUTH EXTERNAL failed".to_string()));
             }
+            send_command(writer, &encoded).await?;
+        }
+        let auth_resp = read_response(reader).await?;
+        if auth_resp.is_ok() {
+            return Ok(());
         }
         return Err(Error::SmtpAuth("AUTH EXTERNAL failed".to_string()));
     }
@@ -501,10 +513,18 @@ async fn do_auth<S: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
             if auth_resp.is_ok() {
                 return Ok(());
             }
-            return Err(Error::SmtpAuth(format!(
-                "AUTH OAUTHBEARER failed: {} {}",
-                auth_resp.code, auth_resp.message
-            )));
+            // Server may send 334 with error JSON — need to send AQ== cancel
+            if auth_resp.code == 334 {
+                send_command(writer, "AQ==").await?;
+                let _ = read_response(reader).await;
+            }
+            return Err(Error::Transfer {
+                code: 67,
+                message: format!(
+                    "AUTH OAUTHBEARER failed: {} {}",
+                    auth_resp.code, auth_resp.message
+                ),
+            });
         }
 
         // XOAUTH2 fallback
@@ -535,6 +555,10 @@ async fn do_auth<S: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
         }
     }
 
+    // Track downgrade state
+    let mut cram_failed = false;
+    let mut ntlm_failed = false;
+
     // CRAM-MD5: challenge-response with HMAC-MD5
     if should_try("CRAM-MD5") {
         send_command(writer, "AUTH CRAM-MD5").await?;
@@ -544,63 +568,66 @@ async fn do_auth<S: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
         }
         // Server sends base64-encoded challenge
         let challenge_b64 = resp.message.trim();
-        let challenge_bytes = base64::engine::general_purpose::STANDARD
-            .decode(challenge_b64)
-            .map_err(|e| Error::SmtpAuth(format!("CRAM-MD5 challenge decode error: {e}")))?;
-        let challenge = String::from_utf8_lossy(&challenge_bytes);
-        let response_str = crate::auth::cram_md5::cram_md5_response(user, pass, &challenge);
-        let encoded = base64::engine::general_purpose::STANDARD.encode(response_str.as_bytes());
-        send_command(writer, &encoded).await?;
-        let auth_resp = read_response(reader).await?;
-        if auth_resp.is_ok() {
-            return Ok(());
-        }
-        return Err(Error::SmtpAuth(format!(
-            "AUTH CRAM-MD5 failed: {} {}",
-            auth_resp.code, auth_resp.message
-        )));
-    }
-
-    // NTLM: 3-step Type 1/2/3 exchange
-    if should_try("NTLM") {
-        let type1 = crate::auth::ntlm::create_type1_message();
-        send_command(writer, "AUTH NTLM").await?;
-        let resp = read_response(reader).await?;
-        if resp.code != 334 {
-            return Err(Error::SmtpAuth(format!("AUTH NTLM expected 334, got: {}", resp.code)));
-        }
-        // Send Type 1
-        send_command(writer, &type1).await?;
-        let resp2 = read_response(reader).await?;
-        if resp2.code != 334 {
-            // Invalid challenge — cancel auth
-            send_command(writer, "*").await?;
-            return Err(Error::Transfer { code: 67, message: "NTLM challenge failed".to_string() });
-        }
-        // Parse Type 2 and generate Type 3
-        let challenge_b64 = resp2.message.trim();
-        if let Ok(challenge) = crate::auth::ntlm::parse_type2_message(challenge_b64) {
-            let type3 = crate::auth::ntlm::create_type3_message(&challenge, user, pass, "");
-            send_command(writer, &type3).await?;
+        if let Ok(challenge_bytes) = base64::engine::general_purpose::STANDARD.decode(challenge_b64)
+        {
+            let challenge = String::from_utf8_lossy(&challenge_bytes);
+            let response_str = crate::auth::cram_md5::cram_md5_response(user, pass, &challenge);
+            let encoded = base64::engine::general_purpose::STANDARD.encode(response_str.as_bytes());
+            send_command(writer, &encoded).await?;
             let auth_resp = read_response(reader).await?;
             if auth_resp.is_ok() {
                 return Ok(());
             }
             return Err(Error::SmtpAuth(format!(
-                "AUTH NTLM failed: {} {}",
+                "AUTH CRAM-MD5 failed: {} {}",
                 auth_resp.code, auth_resp.message
             )));
         }
-        // Bad Type 2 — cancel auth (send * per RFC 4954)
+        // Invalid challenge — send SASL cancel
         send_command(writer, "*").await?;
-        return Err(Error::Transfer {
-            code: 67,
-            message: "NTLM: invalid server challenge".to_string(),
-        });
+        let _ = read_response(reader).await;
+        cram_failed = true;
+    }
+
+    // NTLM: 3-step Type 1/2/3 exchange
+    if !cram_failed && should_try("NTLM") || cram_failed && has("NTLM") {
+        let type1 = crate::auth::ntlm::create_type1_message();
+        if sasl_ir {
+            send_command(writer, &format!("AUTH NTLM {type1}")).await?;
+        } else {
+            send_command(writer, "AUTH NTLM").await?;
+            let resp = read_response(reader).await?;
+            if resp.code != 334 {
+                return Err(Error::SmtpAuth(format!("AUTH NTLM expected 334, got: {}", resp.code)));
+            }
+            // Send Type 1
+            send_command(writer, &type1).await?;
+        }
+        let resp2 = read_response(reader).await?;
+        if resp2.code == 334 {
+            // Parse Type 2 and generate Type 3
+            let challenge_b64 = resp2.message.trim();
+            if let Ok(challenge) = crate::auth::ntlm::parse_type2_message(challenge_b64) {
+                let type3 = crate::auth::ntlm::create_type3_message(&challenge, user, pass, "");
+                send_command(writer, &type3).await?;
+                let auth_resp = read_response(reader).await?;
+                if auth_resp.is_ok() {
+                    return Ok(());
+                }
+                return Err(Error::SmtpAuth(format!(
+                    "AUTH NTLM failed: {} {}",
+                    auth_resp.code, auth_resp.message
+                )));
+            }
+        }
+        // Invalid or bad Type 2 challenge — cancel auth (send * per RFC 4954)
+        send_command(writer, "*").await?;
+        let _ = read_response(reader).await;
+        ntlm_failed = true;
     }
 
     // LOGIN: base64(user), base64(pass)
-    if should_try("LOGIN") {
+    if should_try("LOGIN") && !cram_failed && !ntlm_failed {
         if sasl_ir {
             let encoded_user = base64::engine::general_purpose::STANDARD.encode(user.as_bytes());
             send_command(writer, &format!("AUTH LOGIN {encoded_user}")).await?;
@@ -635,8 +662,9 @@ async fn do_auth<S: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
         )));
     }
 
-    // PLAIN: \0user\0pass
-    if should_try("PLAIN") {
+    // PLAIN: \0user\0pass (also used as downgrade target)
+    let try_plain = should_try("PLAIN") || (cram_failed || ntlm_failed) && has("PLAIN");
+    if try_plain {
         let auth_string = sasl_authzid.map_or_else(
             || format!("\0{user}\0{pass}"),
             |authzid| format!("{authzid}\0{user}\0{pass}"),
@@ -663,6 +691,14 @@ async fn do_auth<S: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
             "AUTH PLAIN failed: {} {}",
             auth_resp.code, auth_resp.message
         )));
+    }
+
+    // If CRAM-MD5 or NTLM failed and no PLAIN available, error out
+    if cram_failed || ntlm_failed {
+        return Err(Error::Transfer {
+            code: 67,
+            message: "SMTP authentication cancelled, no fallback available".to_string(),
+        });
     }
 
     Ok(())

--- a/crates/urlx-cli/src/args.rs
+++ b/crates/urlx-cli/src/args.rs
@@ -1593,6 +1593,11 @@ fn parse_args_options_with_depth(args: &[String], config_depth: u32) -> Result<C
                 let val = require_arg(args, i, "--sasl-authzid")?;
                 opts.easy.sasl_authzid(val);
             }
+            "--login-options" => {
+                i += 1;
+                let val = require_arg(args, i, "--login-options")?;
+                opts.easy.login_options(val);
+            }
             "--sasl-ir" => {
                 opts.easy.sasl_ir(true);
             }
@@ -1935,7 +1940,6 @@ fn parse_args_options_with_depth(args: &[String], config_depth: u32) -> Result<C
             | "--proxy-tls13-ciphers"
             | "--proxy-ciphers"
             | "--tls13-ciphers"
-            | "--login-options"
             | "--cert-type"
             | "--key-type"
             | "--pass"


### PR DESCRIPTION
## Summary

Complete SASL authentication for all three email protocols (IMAP, POP3, SMTP), passing **37 new curl tests**:
- **IMAP (14):** 779, 799, 827, 830, 831, 833, 834, 838, 839, 840, 844, 845, 848, 849
- **POP3 (13):** 873, 876, 877, 879, 880, 884, 885, 886, 888, 889, 890, 892, 893
- **SMTP (10):** 921, 932, 935, 936, 943, 944, 945, 948, 949, 992

### Key changes

- **SASL cancellation & downgrade**: When CRAM-MD5 or NTLM receives an invalid challenge, send `*` to cancel and fall through to PLAIN
- **EXTERNAL auth with SASL-IR**: Support empty `=` response and base64(username) initial response
- **OAUTHBEARER error handling**: Send `AQ==` abort on server error JSON challenge
- **`--sasl-authzid` for PLAIN**: Thread authzid through to IMAP/POP3 handlers (`authzid\0user\0pass` format)
- **`--login-options` CLI**: Implement the flag (was a no-op); `AUTH=+LOGIN` forces plain LOGIN, `AUTH=XOAUTH2` overrides mechanism selection
- **NTLM with SASL-IR**: Send Type 1 as initial response when `--sasl-ir` is set
- **HTTP-to-IMAP redirect** (test 779): Parse non-HTTP redirect URLs, apply `--resolve` in IMAP, use `B` tag prefix, strip bearer token on cross-protocol redirect

### Files changed
- `crates/liburlx/src/protocol/imap.rs` — Refactored auth into `do_imap_auth()` with downgrade loop
- `crates/liburlx/src/protocol/pop3.rs` — Refactored auth into `do_pop3_auth()` with downgrade loop
- `crates/liburlx/src/protocol/smtp.rs` — Added SASL cancellation/downgrade, EXTERNAL/SASL-IR support
- `crates/liburlx/src/easy.rs` — Thread `login_options`/`sasl_authzid` to protocols, cross-protocol redirect handling
- `crates/urlx-cli/src/args.rs` — Activate `--login-options` flag

## Test plan

- [x] All 37 target tests pass: `perl runtests.pl ... 779 799 827 830 831 833 834 838 839 840 844 845 848 849 873 876 877 879 880 884 885 886 888 889 890 892 893 921 932 935 936 943 944 945 948 949 992`
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets` passes (zero warnings)
- [x] `cargo test` passes (820 lib + 311 CLI tests)
- [x] No regressions on previously-passing HTTP, IMAP, POP3, SMTP, FTP tests