### PR TITLE
fix(ftp): preserve FTP session across per-URL Easy handle switches

### DIFF
--- a/crates/liburlx/src/easy.rs
+++ b/crates/liburlx/src/easy.rs
@@ -620,6 +620,15 @@ impl Easy {
         self.ftp_session = None;
     }
 
+    /// Transfer the FTP session from another Easy handle into this one.
+    ///
+    /// Used in multi-URL mode when switching between per-URL Easy handles
+    /// (e.g., `--next` groups) to preserve FTP connection reuse. The session
+    /// is moved, leaving the source handle with no session.
+    pub fn take_ftp_session_from(&mut self, other: &mut Self) {
+        self.ftp_session = other.ftp_session.take();
+    }
+
     /// Set the URL to transfer.
     ///
     /// # Errors

--- a/crates/urlx-cli/src/transfer.rs
+++ b/crates/urlx-cli/src/transfer.rs
@@ -2019,7 +2019,10 @@ pub fn run_multi(
     for (i, url) in urls.iter().enumerate() {
         // Use per-URL Easy handle if available (from --next groups, curl compat: tests 430-432)
         if let Some(Some(per_easy)) = per_url_easy.get(i) {
-            easy = per_easy.clone();
+            let mut new_easy = per_easy.clone();
+            // Preserve FTP session for connection reuse across URLs (curl compat: tests 146, 210, 698)
+            new_easy.take_ftp_session_from(&mut easy);
+            easy = new_easy;
         }
 
         // -T upload: for HTTP, only the first URL gets PUT with the upload body;


### PR DESCRIPTION
## Summary
- Fix FTP connection reuse so multiple FTP URLs reuse the control connection instead of QUIT+reconnect
- Add `Easy::take_ftp_session_from()` to transfer FTP sessions between Easy handles
- Call it in `run_multi()` when switching per-URL Easy handles to preserve the FTP control connection

## Root Cause
In multi-URL mode, `args.rs` assigns each URL a cloned Easy handle (`per_url_easy`). In `run_multi()`, each iteration replaces the active Easy handle with a fresh clone. Since `ftp_session` is connection state and intentionally not cloned, every URL started with `ftp_session: None`, causing a full QUIT+reconnect cycle.

## Test plan
- [x] All 11 curl FTP connection reuse tests pass: 146, 149, 210, 211, 212, 215, 216, 698, 1010, 1096, 1149
- [x] No regressions in FTP tests 100-130 (all 30 pass)
- [x] `cargo fmt`, `cargo clippy`, `cargo test` all pass
- [x] Pre-commit hooks pass