### PR TITLE
fix(auth): place Authorization header before User-Agent

### DIFF
--- a/crates/liburlx/src/easy.rs
+++ b/crates/liburlx/src/easy.rs
@@ -2810,9 +2810,12 @@ async fn perform_transfer(
                     .unwrap_or("")
                     .eq_ignore_ascii_case(current_url.host_str().unwrap_or(""));
                 if (same_host || unrestricted_auth)
-                    && !request_headers.iter().any(|(k, _)| k.eq_ignore_ascii_case("authorization"))
+                    && !request_headers.iter().any(|(k, _)| {
+                        k.eq_ignore_ascii_case("authorization")
+                            || k.eq_ignore_ascii_case("_auto_authorization")
+                    })
                 {
-                    request_headers.push(("Authorization".to_string(), basic_hdr.clone()));
+                    request_headers.push(("_auto_Authorization".to_string(), basic_hdr.clone()));
                 }
             }
         }
@@ -2858,7 +2861,7 @@ async fn perform_transfer(
                     *nc,
                     cnonce,
                 );
-                request_headers.push(("Authorization".to_string(), auth_header));
+                request_headers.push(("_auto_Authorization".to_string(), auth_header));
             }
         }
 
@@ -2889,7 +2892,7 @@ async fn perform_transfer(
         if let Some(auth) = auth_credentials {
             if auth.method == AuthMethod::Ntlm {
                 let type1 = crate::auth::ntlm::create_type1_message();
-                request_headers.push(("Authorization".to_string(), format!("NTLM {type1}")));
+                request_headers.push(("_auto_Authorization".to_string(), format!("NTLM {type1}")));
             }
         }
 
@@ -3028,7 +3031,10 @@ async fn perform_transfer(
                     // Re-send without auth headers (server didn't ask for any)
                     let mut retry_headers = request_headers.clone();
                     // Remove any auth headers added by the probe
-                    retry_headers.retain(|(k, _)| !k.eq_ignore_ascii_case("authorization"));
+                    retry_headers.retain(|(k, _)| {
+                        !k.eq_ignore_ascii_case("authorization")
+                            && !k.eq_ignore_ascii_case("_auto_authorization")
+                    });
                     response = Box::pin(do_single_request(
                         &current_url,
                         &current_method,
@@ -3184,7 +3190,7 @@ async fn perform_transfer(
                             digest_state = Some((challenge, cnonce.clone(), 1));
 
                             let mut auth_headers = request_headers.clone();
-                            auth_headers.push(("Authorization".to_string(), auth_header));
+                            auth_headers.push(("_auto_Authorization".to_string(), auth_header));
 
                             response = Box::pin(do_single_request(
                                 &current_url,
@@ -3293,7 +3299,8 @@ async fn perform_transfer(
                                     // Update Digest state with new nonce
                                     digest_state = Some((new_challenge, cnonce.clone(), 1));
                                     let mut stale_headers = request_headers.clone();
-                                    stale_headers.push(("Authorization".to_string(), auth_header));
+                                    stale_headers
+                                        .push(("_auto_Authorization".to_string(), auth_header));
                                     response = Box::pin(do_single_request(
                                         &current_url,
                                         &current_method,
@@ -3382,13 +3389,19 @@ async fn perform_transfer(
                             let type1 = crate::auth::ntlm::create_type1_message();
                             let mut type1_headers = request_headers.clone();
                             type1_headers
-                                .push(("Authorization".to_string(), format!("NTLM {type1}")));
+                                .push(("_auto_Authorization".to_string(), format!("NTLM {type1}")));
+                            // Suppress body during NTLM Type 1 probe (Content-Length: 0)
+                            // curl compat: test 155
+                            type1_headers
+                                .retain(|(k, _)| !k.eq_ignore_ascii_case("content-length"));
+                            let type1_body =
+                                if current_body.is_some() { Some(&[] as &[u8]) } else { None };
 
                             response = Box::pin(do_single_request(
                                 &current_url,
                                 &current_method,
                                 &type1_headers,
-                                current_body.as_deref(),
+                                type1_body,
                                 verbose,
                                 accept_encoding,
                                 connect_timeout,
@@ -3477,7 +3490,7 @@ async fn perform_transfer(
 
                                     let mut type3_headers = request_headers.clone();
                                     type3_headers.push((
-                                        "Authorization".to_string(),
+                                        "_auto_Authorization".to_string(),
                                         format!("NTLM {type3}"),
                                     ));
 
@@ -3570,7 +3583,7 @@ async fn perform_transfer(
                         basic_resp.set_body(Vec::new());
                         redirect_chain.push(basic_resp);
                         let mut auth_headers = request_headers.clone();
-                        auth_headers.push(("Authorization".to_string(), basic_val));
+                        auth_headers.push(("_auto_Authorization".to_string(), basic_val));
                         response = Box::pin(do_single_request(
                             &current_url,
                             &current_method,
@@ -4213,6 +4226,7 @@ async fn perform_transfer(
                                 auth_headers.retain(|(k, _)| {
                                     !k.eq_ignore_ascii_case("proxy-authorization")
                                         && !k.eq_ignore_ascii_case("authorization")
+                                        && !k.eq_ignore_ascii_case("_auto_authorization")
                                 });
                                 if let Some(ref pa) = saved_proxy_auth {
                                     // Only re-send Proxy-Authorization for Digest (not NTLM)
@@ -4220,7 +4234,7 @@ async fn perform_transfer(
                                         auth_headers.push(pa.clone());
                                     }
                                 }
-                                auth_headers.push(("Authorization".to_string(), auth_value));
+                                auth_headers.push(("_auto_Authorization".to_string(), auth_value));
                                 response = Box::pin(do_single_request(
                                     &current_url,
                                     &current_method,


### PR DESCRIPTION
## Summary

- Move all auto-generated `Authorization` headers (Digest, NTLM, Basic from auth retry flows) to use the `_auto_Authorization` internal marker so they are emitted **before** `User-Agent` in the HTTP request, matching curl's header ordering
- Suppress request body during NTLM Type 1 probe in `--anyauth` flow, sending `Content-Length: 0` instead of the full body (curl compat: test 155)
- Update all `retain()` calls that strip `Authorization` headers to also handle the `_auto_Authorization` variant

Passes 19 curl tests that previously failed due to incorrect header ordering: 64, 65, 67, 68, 69, 70, 72, 76, 88, 89, 90, 91, 150, 154, 176, 245, 246, 267, 273.

Two tests remain failing (pre-existing issues outside scope):
- Test 153: Multi-URL Digest state not carried forward between URLs
- Test 155: NTLM connection reuse after `Connection: close` (exit code 7)

## Test plan
- [x] `cargo fmt` -- passes
- [x] `cargo clippy` -- passes
- [x] `cargo test` -- all 2,600+ Rust tests pass
- [x] `cargo doc` -- passes
- [x] Pre-commit hooks pass
- [x] Curl tests 64, 65, 67, 68, 69, 70, 72, 76, 88, 89, 90, 91, 150, 154, 176, 245, 246, 267, 273 verified passing individually
- [x] Curl tests 1-20 regression check passes