### PR TITLE
fix(http): multipart form upload fixes for 9 curl tests

### DIFF
--- a/crates/liburlx/src/easy.rs
+++ b/crates/liburlx/src/easy.rs
@@ -1123,6 +1123,36 @@ impl Easy {
         );
     }
 
+    /// Add file data with filename but no content type to the multipart form.
+    pub fn form_file_no_type(&mut self, name: &str, filename: &str, data: &[u8]) {
+        self.multipart
+            .get_or_insert_with(MultipartForm::new)
+            .file_data_no_type(name, filename, data);
+    }
+
+    /// Add a multi-file part to the multipart form.
+    ///
+    /// Creates a `multipart/mixed` sub-boundary with multiple files.
+    /// Each tuple is `(filename, content_type, data)`.
+    pub fn form_multi_file(&mut self, name: &str, files: Vec<(String, String, Vec<u8>)>) {
+        self.multipart.get_or_insert_with(MultipartForm::new).multi_file(name, files);
+    }
+
+    /// Set the multipart filename escape mode.
+    pub fn set_form_escape_mode(&mut self, mode: crate::FilenameEscapeMode) {
+        self.multipart.get_or_insert_with(MultipartForm::new).set_escape_mode(mode);
+    }
+
+    /// Set whether multipart should use "attachment" disposition.
+    pub fn set_form_use_attachment(&mut self, val: bool) {
+        self.multipart.get_or_insert_with(MultipartForm::new).set_use_attachment(val);
+    }
+
+    /// Set whether multipart should use SMTP MIME mode.
+    pub fn set_form_smtp_mode(&mut self, val: bool) {
+        self.multipart.get_or_insert_with(MultipartForm::new).set_smtp_mode(val);
+    }
+
     /// Set a byte range for the request.
     ///
     /// Sends a `Range: bytes=<range>` header. Format examples:
@@ -2356,21 +2386,32 @@ impl Easy {
 
         let (effective_method, effective_body);
 
-        if let Some(ref multipart) = self.multipart {
-            // Multipart form: encode body and set content-type header
-            effective_body = Some(multipart.encode());
+        if let Some(ref mut multipart) = self.multipart {
+            let is_smtp = url.scheme() == "smtp" || url.scheme() == "smtps";
+
+            // For SMTP, enable smtp_mode so the MIME headers are in the body
+            if is_smtp {
+                multipart.set_smtp_mode(true);
+            }
+
+            // Check if user provided a custom Content-Type (use "attachment" disposition)
             let ct_idx = headers.iter().position(|(k, _)| k.eq_ignore_ascii_case("content-type"));
             if let Some(idx) = ct_idx {
-                // User provided Content-Type: extract value, remove it, and re-add
-                // with proper casing and boundary appended (curl compat: test 669)
+                // User provided Content-Type — use "attachment" disposition (curl compat: test 277)
+                if !is_smtp {
+                    multipart.set_use_attachment(true);
+                }
                 let mut ct_value = headers.remove(idx).1;
                 if !ct_value.contains("boundary=") {
                     ct_value = format!("{ct_value}; boundary={}", multipart.boundary());
                 }
                 headers.push(("Content-Type".to_string(), ct_value));
-            } else {
+            } else if !is_smtp {
                 headers.push(("Content-Type".to_string(), multipart.content_type()));
             }
+
+            // Multipart form: encode body and set content-type header
+            effective_body = Some(multipart.encode());
             // Default to POST for multipart
             effective_method = self.method.clone().unwrap_or_else(|| "POST".to_string());
         } else {

--- a/crates/liburlx/src/lib.rs
+++ b/crates/liburlx/src/lib.rs
@@ -39,7 +39,9 @@ pub use error::Error;
 pub use hsts::HstsCache;
 pub use multi::{Multi, PipeliningMode};
 pub use progress::{make_progress_callback, ProgressCallback, ProgressInfo};
-pub use protocol::http::multipart::{guess_content_type as guess_form_content_type, MultipartForm};
+pub use protocol::http::multipart::{
+    guess_content_type as guess_form_content_type, FilenameEscapeMode, MultipartForm,
+};
 pub use protocol::http::response::{PushedResponse, Response, ResponseHttpVersion, TransferInfo};
 pub use share::{Share, ShareType};
 pub use throttle::SpeedLimits;

--- a/crates/liburlx/src/protocol/http/h1.rs
+++ b/crates/liburlx/src/protocol/http/h1.rs
@@ -426,11 +426,28 @@ where
     while (100..200).contains(&ph.status) {
         // Preserve this 1xx response's raw headers (already includes trailing blank line)
         informational_prefix.extend_from_slice(&header_bytes);
-        // The body_prefix may contain the start of the next response
-        let next = read_response_headers_with_prefix(stream, body_prefix).await?;
-        header_bytes = next.0;
-        body_prefix = next.1;
-        ph = parse_headers(&header_bytes)?;
+        // The body_prefix may contain the start of the next response.
+        // If the server closes after 1xx (e.g., only sent 100 Continue), output the
+        // 1xx headers as the response body and return CURLE_GOT_NOTHING (52).
+        if let Ok(next) = read_response_headers_with_prefix(stream, body_prefix).await {
+            header_bytes = next.0;
+            body_prefix = next.1;
+            ph = parse_headers(&header_bytes)?;
+        } else {
+            // Server closed after 1xx — return the 1xx headers as raw_headers
+            // so --include outputs them. Body is empty. (curl compat: test 158)
+            let resp_ph = parse_headers(&informational_prefix)?;
+            let mut resp =
+                Response::new(resp_ph.status, resp_ph.headers, Vec::new(), url.to_string());
+            resp.set_raw_headers(informational_prefix);
+            resp.set_status_reason(resp_ph.reason);
+            resp.set_uses_crlf(resp_ph.uses_crlf);
+            resp.set_http_version(resp_ph.version);
+            resp.set_header_original_names(resp_ph.original_names);
+            resp.set_headers_ordered(resp_ph.headers_ordered);
+            resp.set_body_error(Some("empty response".to_string()));
+            return Ok((resp, false));
+        }
     }
 
     // Validate Content-Length header (curl returns CURLE_WEIRD_SERVER_REPLY = 8).

--- a/crates/liburlx/src/protocol/http/multipart.rs
+++ b/crates/liburlx/src/protocol/http/multipart.rs
@@ -1,17 +1,33 @@
 //! Multipart form-data request body builder.
 //!
 //! Implements RFC 2046 multipart/form-data encoding for file uploads
-//! and form field submissions.
+//! and form field submissions. Also supports SMTP multipart/mixed MIME.
 
 use std::path::Path;
 
 use crate::error::Error;
+
+/// Controls how double-quote characters in filenames are escaped.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum FilenameEscapeMode {
+    /// Percent-encode `"` as `%22` (curl's default).
+    #[default]
+    PercentEncode,
+    /// Backslash-escape `"` as `\"` (curl's `--form-escape`).
+    BackslashEscape,
+}
 
 /// A multipart form builder that produces `multipart/form-data` request bodies.
 #[derive(Debug, Clone)]
 pub struct MultipartForm {
     boundary: String,
     parts: Vec<Part>,
+    /// Whether user overrode the Content-Type (use "attachment" instead of "form-data").
+    use_attachment: bool,
+    /// Whether this is an SMTP MIME body (multipart/mixed, different formatting).
+    smtp_mode: bool,
+    /// Filename escape mode.
+    escape_mode: FilenameEscapeMode,
 }
 
 /// A single part in a multipart form.
@@ -21,19 +37,60 @@ struct Part {
     filename: Option<String>,
     content_type: Option<String>,
     data: Vec<u8>,
+    /// Sub-files for multipart/mixed (multi-file upload).
+    sub_files: Vec<SubFile>,
+    /// Whether the content type was explicitly set (vs guessed from filename).
+    explicit_type: bool,
+}
+
+/// A file within a multipart/mixed sub-part.
+#[derive(Debug, Clone)]
+struct SubFile {
+    filename: String,
+    content_type: String,
+    data: Vec<u8>,
 }
 
 impl MultipartForm {
     /// Create a new multipart form with a random boundary.
     #[must_use]
     pub fn new() -> Self {
-        Self { boundary: generate_boundary(), parts: Vec::new() }
+        Self {
+            boundary: generate_boundary(),
+            parts: Vec::new(),
+            use_attachment: false,
+            smtp_mode: false,
+            escape_mode: FilenameEscapeMode::default(),
+        }
     }
 
     /// Create a new multipart form with a specific boundary (for testing).
     #[must_use]
     pub fn with_boundary(boundary: &str) -> Self {
-        Self { boundary: boundary.to_string(), parts: Vec::new() }
+        Self {
+            boundary: boundary.to_string(),
+            parts: Vec::new(),
+            use_attachment: false,
+            smtp_mode: false,
+            escape_mode: FilenameEscapeMode::default(),
+        }
+    }
+
+    /// Set whether to use "attachment" disposition instead of "form-data".
+    ///
+    /// curl uses "attachment" when the user overrides `Content-Type` with `-H`.
+    pub const fn set_use_attachment(&mut self, val: bool) {
+        self.use_attachment = val;
+    }
+
+    /// Set SMTP MIME mode (multipart/mixed with Mime-Version header).
+    pub const fn set_smtp_mode(&mut self, val: bool) {
+        self.smtp_mode = val;
+    }
+
+    /// Set the filename escape mode.
+    pub const fn set_escape_mode(&mut self, mode: FilenameEscapeMode) {
+        self.escape_mode = mode;
     }
 
     /// Add a text field to the form.
@@ -43,6 +100,8 @@ impl MultipartForm {
             filename: None,
             content_type: None,
             data: value.as_bytes().to_vec(),
+            sub_files: Vec::new(),
+            explicit_type: false,
         });
     }
 
@@ -53,6 +112,8 @@ impl MultipartForm {
             filename: None,
             content_type: Some(content_type.to_string()),
             data: value.as_bytes().to_vec(),
+            sub_files: Vec::new(),
+            explicit_type: true,
         });
     }
 
@@ -79,6 +140,8 @@ impl MultipartForm {
             filename: Some(filename),
             content_type: Some(content_type),
             data,
+            sub_files: Vec::new(),
+            explicit_type: false,
         });
 
         Ok(())
@@ -91,6 +154,22 @@ impl MultipartForm {
             filename: Some(filename.to_string()),
             content_type: Some(guess_content_type(filename)),
             data: data.to_vec(),
+            sub_files: Vec::new(),
+            explicit_type: false,
+        });
+    }
+
+    /// Add data as a file part with filename but no content type.
+    ///
+    /// Used for text values with `;filename=` but no `;type=` (SMTP compat).
+    pub fn file_data_no_type(&mut self, name: &str, filename: &str, data: &[u8]) {
+        self.parts.push(Part {
+            name: name.to_string(),
+            filename: Some(filename.to_string()),
+            content_type: None,
+            data: data.to_vec(),
+            sub_files: Vec::new(),
+            explicit_type: false,
         });
     }
 
@@ -107,13 +186,37 @@ impl MultipartForm {
             filename: Some(filename.to_string()),
             content_type: Some(content_type.to_string()),
             data: data.to_vec(),
+            sub_files: Vec::new(),
+            explicit_type: true,
+        });
+    }
+
+    /// Add a multi-file part (creates a multipart/mixed sub-boundary).
+    ///
+    /// Each tuple is `(filename, content_type, data)`.
+    pub fn multi_file(&mut self, name: &str, files: Vec<(String, String, Vec<u8>)>) {
+        let sub_files: Vec<SubFile> = files
+            .into_iter()
+            .map(|(filename, content_type, data)| SubFile { filename, content_type, data })
+            .collect();
+        self.parts.push(Part {
+            name: name.to_string(),
+            filename: None,
+            content_type: None,
+            data: Vec::new(),
+            sub_files,
+            explicit_type: false,
         });
     }
 
     /// Get the `Content-Type` header value including the boundary.
     #[must_use]
     pub fn content_type(&self) -> String {
-        format!("multipart/form-data; boundary={}", self.boundary)
+        if self.smtp_mode {
+            format!("multipart/mixed; boundary={}", self.boundary)
+        } else {
+            format!("multipart/form-data; boundary={}", self.boundary)
+        }
     }
 
     /// Get the boundary string.
@@ -122,10 +225,150 @@ impl MultipartForm {
         &self.boundary
     }
 
+    /// Escape a filename for Content-Disposition header.
+    fn escape_filename(&self, filename: &str) -> String {
+        match self.escape_mode {
+            FilenameEscapeMode::PercentEncode => filename.replace('"', "%22"),
+            FilenameEscapeMode::BackslashEscape => {
+                // Backslash-escape: `\` → `\\`, `"` → `\"`
+                let mut result = String::with_capacity(filename.len());
+                for ch in filename.chars() {
+                    match ch {
+                        '"' => result.push_str("\\\""),
+                        '\\' => result.push_str("\\\\"),
+                        _ => result.push(ch),
+                    }
+                }
+                result
+            }
+        }
+    }
+
+    /// Get the disposition type string.
+    const fn disposition(&self) -> &str {
+        if self.use_attachment || self.smtp_mode {
+            "attachment"
+        } else {
+            "form-data"
+        }
+    }
+
     /// Build the encoded multipart body.
     #[must_use]
     pub fn encode(&self) -> Vec<u8> {
+        if self.smtp_mode {
+            return self.encode_smtp();
+        }
         let mut body = Vec::new();
+        let disposition = self.disposition();
+
+        for part in &self.parts {
+            // Multi-file part: emit multipart/mixed sub-boundary
+            if !part.sub_files.is_empty() {
+                let sub_boundary = generate_boundary();
+
+                // Outer part header
+                body.extend_from_slice(b"--");
+                body.extend_from_slice(self.boundary.as_bytes());
+                body.extend_from_slice(b"\r\n");
+
+                body.extend_from_slice(b"Content-Disposition: ");
+                body.extend_from_slice(disposition.as_bytes());
+                body.extend_from_slice(b"; name=\"");
+                body.extend_from_slice(part.name.as_bytes());
+                body.extend_from_slice(b"\"\r\n");
+
+                body.extend_from_slice(b"Content-Type: multipart/mixed; boundary=");
+                body.extend_from_slice(sub_boundary.as_bytes());
+                body.extend_from_slice(b"\r\n");
+                body.extend_from_slice(b"\r\n");
+
+                // Each sub-file is preceded by the inner boundary delimiter
+                for sub in &part.sub_files {
+                    // Inner boundary before each sub-file
+                    body.extend_from_slice(b"--");
+                    body.extend_from_slice(sub_boundary.as_bytes());
+                    body.extend_from_slice(b"\r\n");
+
+                    body.extend_from_slice(b"Content-Disposition: attachment; filename=\"");
+                    body.extend_from_slice(self.escape_filename(&sub.filename).as_bytes());
+                    body.extend_from_slice(b"\"\r\n");
+                    body.extend_from_slice(b"Content-Type: ");
+                    body.extend_from_slice(sub.content_type.as_bytes());
+                    body.extend_from_slice(b"\r\n\r\n");
+                    body.extend_from_slice(&sub.data);
+                    body.extend_from_slice(b"\r\n");
+                }
+
+                // Inner closing boundary
+                body.extend_from_slice(b"--");
+                body.extend_from_slice(sub_boundary.as_bytes());
+                body.extend_from_slice(b"--\r\n");
+
+                body.extend_from_slice(b"\r\n");
+                continue;
+            }
+
+            // Boundary delimiter
+            body.extend_from_slice(b"--");
+            body.extend_from_slice(self.boundary.as_bytes());
+            body.extend_from_slice(b"\r\n");
+
+            // Content-Disposition header
+            body.extend_from_slice(b"Content-Disposition: ");
+            body.extend_from_slice(disposition.as_bytes());
+
+            // Only add name if non-empty (curl compat: test 1293 `-F =` produces
+            // `Content-Disposition: form-data` without name)
+            if !part.name.is_empty() {
+                body.extend_from_slice(b"; name=\"");
+                body.extend_from_slice(part.name.as_bytes());
+                body.push(b'"');
+            }
+
+            if let Some(ref filename) = part.filename {
+                body.extend_from_slice(b"; filename=\"");
+                body.extend_from_slice(self.escape_filename(filename).as_bytes());
+                body.push(b'"');
+            }
+            body.extend_from_slice(b"\r\n");
+
+            // Content-Type header (only for file parts or explicit type)
+            if let Some(ref ct) = part.content_type {
+                body.extend_from_slice(b"Content-Type: ");
+                body.extend_from_slice(ct.as_bytes());
+                body.extend_from_slice(b"\r\n");
+            }
+
+            // Empty line separating headers from body
+            body.extend_from_slice(b"\r\n");
+
+            // Part body
+            body.extend_from_slice(&part.data);
+            body.extend_from_slice(b"\r\n");
+        }
+
+        // Closing boundary
+        body.extend_from_slice(b"--");
+        body.extend_from_slice(self.boundary.as_bytes());
+        body.extend_from_slice(b"--\r\n");
+
+        body
+    }
+
+    /// Encode as SMTP multipart/mixed MIME body.
+    ///
+    /// The body includes:
+    /// - `Content-Type: multipart/mixed; boundary=...`
+    /// - `Mime-Version: 1.0`
+    /// - Parts with `Content-Disposition: attachment` for file parts, no disposition for text parts.
+    fn encode_smtp(&self) -> Vec<u8> {
+        let mut body = Vec::new();
+
+        // MIME headers
+        body.extend_from_slice(b"Content-Type: multipart/mixed; boundary=");
+        body.extend_from_slice(self.boundary.as_bytes());
+        body.extend_from_slice(b"\r\nMime-Version: 1.0\r\n\r\n");
 
         for part in &self.parts {
             // Boundary delimiter
@@ -133,25 +376,23 @@ impl MultipartForm {
             body.extend_from_slice(self.boundary.as_bytes());
             body.extend_from_slice(b"\r\n");
 
-            // Content-Disposition header
-            body.extend_from_slice(b"Content-Disposition: form-data; name=\"");
-            body.extend_from_slice(part.name.as_bytes());
-            body.push(b'"');
-
+            // For SMTP: text parts (no filename) have no Content-Disposition.
+            // File parts have Content-Disposition: attachment; filename="..."
             if let Some(ref filename) = part.filename {
-                body.extend_from_slice(b"; filename=\"");
-                // Percent-encode double quotes in filename (curl compat)
-                let encoded = filename.replace('"', "%22");
-                body.extend_from_slice(encoded.as_bytes());
-                body.push(b'"');
+                body.extend_from_slice(b"Content-Disposition: attachment; filename=\"");
+                // SMTP always uses backslash escaping for filenames
+                let escaped = escape_filename_backslash(filename);
+                body.extend_from_slice(escaped.as_bytes());
+                body.extend_from_slice(b"\"\r\n");
             }
-            body.extend_from_slice(b"\r\n");
 
-            // Content-Type header (only for file parts)
-            if let Some(ref ct) = part.content_type {
-                body.extend_from_slice(b"Content-Type: ");
-                body.extend_from_slice(ct.as_bytes());
-                body.extend_from_slice(b"\r\n");
+            // Content-Type header only when explicitly set (not guessed)
+            if part.explicit_type {
+                if let Some(ref ct) = part.content_type {
+                    body.extend_from_slice(b"Content-Type: ");
+                    body.extend_from_slice(ct.as_bytes());
+                    body.extend_from_slice(b"\r\n");
+                }
             }
 
             // Empty line separating headers from body
@@ -175,6 +416,19 @@ impl Default for MultipartForm {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// Backslash-escape a filename (for SMTP MIME).
+fn escape_filename_backslash(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '"' => result.push_str("\\\""),
+            '\\' => result.push_str("\\\\"),
+            _ => result.push(ch),
+        }
+    }
+    result
 }
 
 /// Generate a random boundary string.
@@ -321,6 +575,72 @@ mod tests {
     fn guess_content_type_unknown() {
         assert_eq!(guess_content_type("file.xyz"), "application/octet-stream");
         assert_eq!(guess_content_type("noext"), "application/octet-stream");
+    }
+
+    #[test]
+    fn empty_name_no_name_attr() {
+        let mut form = MultipartForm::with_boundary("b");
+        form.field("", "empty");
+
+        let body = form.encode();
+        let body_str = String::from_utf8(body).unwrap();
+
+        assert!(body_str.contains("Content-Disposition: form-data\r\n"));
+        assert!(!body_str.contains("name="));
+    }
+
+    #[test]
+    fn attachment_disposition() {
+        let mut form = MultipartForm::with_boundary("b");
+        form.set_use_attachment(true);
+        form.field("name", "daniel");
+
+        let body = form.encode();
+        let body_str = String::from_utf8(body).unwrap();
+
+        assert!(body_str.contains("Content-Disposition: attachment; name=\"name\""));
+    }
+
+    #[test]
+    fn backslash_escape_mode() {
+        let mut form = MultipartForm::with_boundary("b");
+        form.set_escape_mode(FilenameEscapeMode::BackslashEscape);
+        form.file_data_with_type("f", "test\".txt", "text/plain", b"data");
+
+        let body = form.encode();
+        let body_str = String::from_utf8(body).unwrap();
+
+        assert!(body_str.contains("filename=\"test\\\".txt\""));
+    }
+
+    #[test]
+    fn percent_encode_mode() {
+        let mut form = MultipartForm::with_boundary("b");
+        form.set_escape_mode(FilenameEscapeMode::PercentEncode);
+        form.file_data_with_type("f", "test\".txt", "text/plain", b"data");
+
+        let body = form.encode();
+        let body_str = String::from_utf8(body).unwrap();
+
+        assert!(body_str.contains("filename=\"test%22.txt\""));
+    }
+
+    #[test]
+    fn smtp_mode_encoding() {
+        let mut form = MultipartForm::with_boundary("b");
+        form.set_smtp_mode(true);
+        form.field("", "Hello world");
+        form.file_data_with_type("", "file.txt", "text/plain", b"file data");
+
+        let body = form.encode();
+        let body_str = String::from_utf8(body).unwrap();
+
+        assert!(body_str.contains("Content-Type: multipart/mixed; boundary=b\r\n"));
+        assert!(body_str.contains("Mime-Version: 1.0\r\n"));
+        // Text part has no Content-Disposition
+        assert!(body_str.contains("--b\r\n\r\nHello world\r\n"));
+        // File part has attachment disposition
+        assert!(body_str.contains("Content-Disposition: attachment; filename=\"file.txt\""));
     }
 
     /// Helper: check if a byte slice contains a sub-slice.

--- a/crates/urlx-cli/src/args.rs
+++ b/crates/urlx-cli/src/args.rs
@@ -1804,6 +1804,9 @@ fn parse_args_options_with_depth(args: &[String], config_depth: u32) -> Result<C
                     return Err(1);
                 }
             }
+            "--form-escape" => {
+                opts.easy.set_form_escape_mode(liburlx::FilenameEscapeMode::BackslashEscape);
+            }
             "--request-target" => {
                 i += 1;
                 let val = require_arg(args, i, "--request-target")?;
@@ -2487,54 +2490,82 @@ fn parse_form_field(easy: &mut liburlx::Easy, val: &str) -> Result<(), String> {
 
     if let Some(rest) = value.strip_prefix('@') {
         // File upload — parse filepath and optional ;type= ;filename= modifiers
-        let (filepath, modifiers) = parse_form_file_spec(rest);
+        // Check for comma-separated multi-file syntax (commas outside quotes split files)
+        let file_specs = split_comma_file_specs(rest);
 
-        let mut custom_type: Option<String> = None;
-        let mut custom_filename: Option<String> = None;
+        if file_specs.len() > 1 {
+            // Multi-file: create a multipart/mixed sub-part
+            let mut files: Vec<(String, String, Vec<u8>)> = Vec::new();
+            for spec in file_specs {
+                let (filepath, modifiers) = parse_form_file_spec(spec);
+                let mut custom_type: Option<String> = None;
+                for modifier in modifiers {
+                    if let Some(t) = modifier.strip_prefix("type=") {
+                        custom_type = Some(t.to_string());
+                    }
+                }
+                let data = std::fs::read(&filepath)
+                    .map_err(|e| format!("error reading form file: {e}"))?;
+                let original_filename = std::path::Path::new(&filepath)
+                    .file_name()
+                    .map(|n| n.to_string_lossy().to_string())
+                    .unwrap_or_default();
+                let ct = custom_type
+                    .unwrap_or_else(|| liburlx::guess_form_content_type(&original_filename));
+                files.push((original_filename, ct, data));
+            }
+            easy.form_multi_file(name, files);
+        } else {
+            // Single file
+            let (filepath, modifiers) = parse_form_file_spec(rest);
 
-        // Parse semicolon-separated modifiers
-        for modifier in modifiers {
-            if let Some(t) = modifier.strip_prefix("type=") {
-                custom_type = Some(t.to_string());
-            } else if let Some(f) = modifier.strip_prefix("filename=") {
-                custom_filename = Some(unescape_form_filename(f));
-            } else if let Some(f) = modifier.strip_prefix("format=") {
-                // format= appends to type: e.g., type=text/x-null;format=x-curl
-                if let Some(ref mut ct) = custom_type {
-                    ct.push_str(";format=");
-                    ct.push_str(f);
+            let mut custom_type: Option<String> = None;
+            let mut custom_filename: Option<String> = None;
+
+            // Parse semicolon-separated modifiers
+            for modifier in modifiers {
+                if let Some(t) = modifier.strip_prefix("type=") {
+                    custom_type = Some(t.to_string());
+                } else if let Some(f) = modifier.strip_prefix("filename=") {
+                    custom_filename = Some(unescape_form_filename(f));
+                } else if let Some(f) = modifier.strip_prefix("format=") {
+                    // format= appends to type: e.g., type=text/x-null;format=x-curl
+                    if let Some(ref mut ct) = custom_type {
+                        ct.push_str(";format=");
+                        ct.push_str(f);
+                    }
                 }
             }
-        }
 
-        // Read the file (or stdin for @-)
-        let data = if filepath == "-" {
-            use std::io::Read as _;
-            let mut buf = Vec::new();
-            let _bytes = std::io::stdin()
-                .read_to_end(&mut buf)
-                .map_err(|e| format!("error reading stdin: {e}"))?;
-            buf
-        } else {
-            std::fs::read(&filepath).map_err(|e| format!("error reading form file: {e}"))?
-        };
+            // Read the file (or stdin for @-)
+            let data = if filepath == "-" {
+                use std::io::Read as _;
+                let mut buf = Vec::new();
+                let _bytes = std::io::stdin()
+                    .read_to_end(&mut buf)
+                    .map_err(|e| format!("error reading stdin: {e}"))?;
+                buf
+            } else {
+                std::fs::read(&filepath).map_err(|e| format!("error reading form file: {e}"))?
+            };
 
-        let original_filename = std::path::Path::new(&filepath)
-            .file_name()
-            .map(|n| n.to_string_lossy().to_string())
-            .unwrap_or_default();
-        let display_filename = custom_filename.unwrap_or_else(|| original_filename.clone());
+            let original_filename = std::path::Path::new(&filepath)
+                .file_name()
+                .map(|n| n.to_string_lossy().to_string())
+                .unwrap_or_default();
+            let display_filename = custom_filename.unwrap_or_else(|| original_filename.clone());
 
-        if let Some(ref ct) = custom_type {
-            easy.form_file_with_type(name, &display_filename, ct, &data);
-        } else {
-            // Guess content type from the original filepath, not the custom filename
-            easy.form_file_with_type(
-                name,
-                &display_filename,
-                &liburlx::guess_form_content_type(&original_filename),
-                &data,
-            );
+            if let Some(ref ct) = custom_type {
+                easy.form_file_with_type(name, &display_filename, ct, &data);
+            } else {
+                // Guess content type from the original filepath, not the custom filename
+                easy.form_file_with_type(
+                    name,
+                    &display_filename,
+                    &liburlx::guess_form_content_type(&original_filename),
+                    &data,
+                );
+            }
         }
     } else if let Some(rest) = value.strip_prefix('<') {
         // Read field value from file: name=<filepath or name=<filepath;type=mime
@@ -2556,34 +2587,207 @@ fn parse_form_field(easy: &mut liburlx::Easy, val: &str) -> Result<(), String> {
             easy.form_field(name, &data);
         }
     } else {
-        // Text field — may have ;type= modifier (curl compat: -F "name=val;type=mime")
-        // Split on ;type= to extract the Content-Type. Everything after ;type= is the type
-        // (including sub-parameters like ;charset=X).
-        if let Some(type_pos) = find_type_modifier(value) {
-            let field_value = value[..type_pos].trim_start();
-            let content_type = &value[type_pos + 6..]; // skip ";type="
-            easy.form_field_with_type(name, field_value, content_type);
+        // Text field — parse value and optional modifiers (;type=, ;filename=)
+        // The value can be quoted: "..." — in which case the closing quote ends the value
+        // and modifiers follow after a `;`.
+        let (field_value, modifiers) = parse_text_value_and_modifiers(value);
+
+        let mut custom_type: Option<String> = None;
+        let mut custom_filename: Option<String> = None;
+
+        for modifier in &modifiers {
+            let trimmed = modifier.trim();
+            if let Some(t) = trimmed.strip_prefix("type=") {
+                custom_type = Some(t.to_string());
+            } else if let Some(f) = trimmed.strip_prefix("filename=") {
+                custom_filename = Some(unescape_form_filename(f));
+            }
+        }
+
+        // Merge type sub-parameters: e.g., "type=text/foo; charset=utf-8" where
+        // charset= is a Content-Type parameter, not a form modifier.
+        // curl treats unknown modifiers after type= as Content-Type sub-params.
+        if let Some(ref mut ct) = custom_type {
+            for modifier in &modifiers {
+                let trimmed = modifier.trim();
+                if !trimmed.starts_with("type=")
+                    && !trimmed.starts_with("filename=")
+                    && !trimmed.starts_with("format=")
+                    && !trimmed.is_empty()
+                {
+                    // Unknown modifier after type — append as Content-Type sub-param
+                    ct.push_str("; ");
+                    ct.push_str(trimmed);
+                }
+            }
+        }
+
+        if let Some(ref filename) = custom_filename {
+            // Text value with filename → file-like part
+            if let Some(ref ct) = custom_type {
+                easy.form_file_with_type(name, filename, ct, field_value.as_bytes());
+            } else {
+                // No explicit type → don't set Content-Type (curl compat: SMTP test 1187)
+                easy.form_file_no_type(name, filename, field_value.as_bytes());
+            }
+        } else if let Some(ref ct) = custom_type {
+            easy.form_field_with_type(name, &field_value, ct);
         } else {
-            easy.form_field(name, value);
+            easy.form_field(name, &field_value);
         }
     }
 
     Ok(())
 }
 
-/// Find the position of `;type=` in a form field value, respecting quotes.
+/// Split comma-separated file specs, respecting quoted paths.
 ///
-/// Returns the byte offset of the `;` before `type=`, or `None` if not found.
-fn find_type_modifier(value: &str) -> Option<usize> {
-    let bytes = value.as_bytes();
+/// E.g., `"file1.txt",file2.txt;type=foo,"file3.txt"` →
+/// `["\"file1.txt\"", "file2.txt;type=foo", "\"file3.txt\""]`
+fn split_comma_file_specs(s: &str) -> Vec<&str> {
+    let mut parts = Vec::new();
+    let mut start = 0;
+    let mut in_quote = false;
+    let bytes = s.as_bytes();
     let mut i = 0;
     while i < bytes.len() {
-        if bytes[i] == b';' && value[i + 1..].starts_with("type=") {
-            return Some(i);
+        if bytes[i] == b'\\' && in_quote && i + 1 < bytes.len() {
+            i += 2;
+        } else if bytes[i] == b'"' {
+            in_quote = !in_quote;
+            i += 1;
+        } else if bytes[i] == b',' && !in_quote {
+            parts.push(&s[start..i]);
+            start = i + 1;
+            i += 1;
+        } else {
+            i += 1;
+        }
+    }
+    parts.push(&s[start..]);
+    parts
+}
+
+/// Parse a text value and its modifiers from a form field value string.
+///
+/// The value can be:
+/// - A quoted string: `"value with ;special chars"` followed by `;type=...`
+/// - An unquoted string: `value;type=...`
+///
+/// Returns `(value, modifiers)` where modifiers are the `;`-separated parts.
+fn parse_text_value_and_modifiers(s: &str) -> (String, Vec<String>) {
+    if let Some(inner) = s.strip_prefix('"') {
+        // Quoted value — find closing quote (respecting backslash escapes)
+        let mut end = 0;
+        let mut chars = inner.chars();
+        while let Some(c) = chars.next() {
+            if c == '\\' {
+                end += c.len_utf8();
+                if let Some(next) = chars.next() {
+                    end += next.len_utf8();
+                }
+            } else if c == '"' {
+                break;
+            } else {
+                end += c.len_utf8();
+            }
+        }
+        let raw_value = &inner[..end];
+        // Unescape the value
+        let value = unescape_form_value(raw_value);
+        let rest = &inner[end..];
+        let rest = rest.strip_prefix('"').unwrap_or(rest);
+        // Parse modifiers from the rest (;-separated)
+        let modifiers = if rest.is_empty() { vec![] } else { split_modifiers_owned(rest) };
+        (value, modifiers)
+    } else {
+        // Unquoted value — find first unquoted `;` followed by a known modifier
+        // (type=, filename=, format=)
+        if let Some(pos) = find_first_modifier_semicolon(s) {
+            let value = s[..pos].to_string();
+            let rest = &s[pos..]; // includes the leading `;`
+            let modifiers = split_modifiers_owned(rest);
+            (value, modifiers)
+        } else {
+            (s.to_string(), vec![])
+        }
+    }
+}
+
+/// Find the position of the first `;` that starts a known modifier (type=, filename=, format=).
+fn find_first_modifier_semicolon(s: &str) -> Option<usize> {
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b';' {
+            let rest = s[i + 1..].trim_start();
+            if rest.starts_with("type=")
+                || rest.starts_with("filename=")
+                || rest.starts_with("format=")
+            {
+                return Some(i);
+            }
         }
         i += 1;
     }
     None
+}
+
+/// Split modifiers on `;`, returning owned strings. Handles quoted values.
+fn split_modifiers_owned(s: &str) -> Vec<String> {
+    let mut parts = Vec::new();
+    let mut start = 0;
+    let mut in_quote = false;
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'\\' && in_quote && i + 1 < bytes.len() {
+            i += 2;
+        } else if bytes[i] == b'"' {
+            in_quote = !in_quote;
+            i += 1;
+        } else if bytes[i] == b';' && !in_quote {
+            let part = s[start..i].trim().to_string();
+            if !part.is_empty() {
+                parts.push(part);
+            }
+            start = i + 1;
+            i += 1;
+        } else {
+            i += 1;
+        }
+    }
+    let part = s[start..].trim().to_string();
+    if !part.is_empty() {
+        parts.push(part);
+    }
+    parts
+}
+
+/// Unescape a form value string (from inside quotes).
+fn unescape_form_value(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\\' {
+            if let Some(&next) = chars.peek() {
+                match next {
+                    '\\' | '"' => {
+                        result.push(next);
+                        let _ = chars.next();
+                    }
+                    _ => {
+                        result.push('\\');
+                    }
+                }
+            } else {
+                result.push('\\');
+            }
+        } else {
+            result.push(c);
+        }
+    }
+    result
 }
 
 /// Split a modifier string on `;` while respecting quoted values.

--- a/crates/urlx-cli/src/transfer.rs
+++ b/crates/urlx-cli/src/transfer.rs
@@ -1585,6 +1585,12 @@ pub fn run(args: &[String]) -> ExitCode {
                     }
                     return ExitCode::from(8);
                 }
+                if body_err.contains("empty response") {
+                    if !opts.silent || opts.show_error {
+                        eprintln!("curl: (52) Empty reply from server");
+                    }
+                    return ExitCode::from(52); // CURLE_GOT_NOTHING
+                }
                 if body_err.contains("timeout") {
                     if !opts.silent || opts.show_error {
                         let timeout_str = opts


### PR DESCRIPTION
## Summary

- **Filename escaping**: Added `--form-escape` flag for backslash escaping mode (`\"` instead of `%22`), matching curl's behavior for tests 1158, 1186, 1189
- **Content-Type boundary merging**: When user overrides Content-Type with `-H`, multipart uses `attachment` disposition instead of `form-data` (test 277)
- **Multi-file upload**: Support comma-separated files in `-F` creating `multipart/mixed` sub-boundaries with proper inner boundary delimiters (tests 1133, 1315)
- **Empty name handling**: `-F =` produces `Content-Disposition: form-data` without `name=""` (test 1293)
- **SMTP MIME mode**: Multipart for SMTP uses `multipart/mixed` with `Mime-Version: 1.0` header, `attachment` disposition, and backslash filename escaping (test 1187)
- **Text value parsing**: Handle quoted values with `;type=`, `;filename=`, and Content-Type sub-parameters like `charset=utf-8` (test 1133)
- **100-continue only response**: Output 1xx informational headers via `--include` and return exit code 52 when server closes after sending only 100 Continue (test 158)

## Test plan

- [x] curl tests 158, 277, 1133, 1158, 1186, 1187, 1189, 1293, 1315 all pass when run individually
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets` passes (no warnings)
- [x] `cargo test -p liburlx --lib -- multipart` passes (13 tests)
- [x] `cargo test -p urlx-cli -- form` passes (17 tests)
- [x] Pre-commit hooks pass (fmt, clippy, test, deny, doc)