### PR TITLE
fix(http): content and transfer encoding fixes

### DIFF
--- a/crates/liburlx/src/easy.rs
+++ b/crates/liburlx/src/easy.rs
@@ -2518,7 +2518,14 @@ impl Easy {
         let ssh_host_key_policy = ();
 
         let last_resp_store = std::sync::Arc::new(std::sync::Mutex::new(None::<Response>));
-        let deadline = self.timeout.map(|d| tokio::time::Instant::now() + d);
+        // Inner deadline is slightly earlier than outer timeout to allow post-processing
+        // (e.g. content decompression) before the outer timeout cancels everything.
+        // This ensures that when body reading stalls (e.g. Content-Length > actual data),
+        // we can still detect bad Content-Encoding before the outer timeout fires (test 223).
+        let deadline = self.timeout.map(|d| {
+            let buffer = std::time::Duration::from_millis(500).min(d / 10);
+            tokio::time::Instant::now() + d.saturating_sub(buffer)
+        });
         let fut = perform_transfer(
             last_resp_store.clone(),
             deadline,
@@ -4891,7 +4898,7 @@ async fn do_single_request(
                         if !forbid_reuse {
                             h2_pool.put(&host, port, h2_client);
                         }
-                        return Ok(maybe_decompress(resp, accept_encoding));
+                        return Ok(maybe_decompress_inner(resp, accept_encoding, raw));
                     }
                     Err(_) => {
                         if verbose {
@@ -4943,7 +4950,7 @@ async fn do_single_request(
                     if can_reuse && !forbid_reuse {
                         pool.put(&host, port, is_tls, stream);
                     }
-                    return Ok(maybe_decompress(response, accept_encoding));
+                    return Ok(maybe_decompress_inner(response, accept_encoding, raw));
                 }
                 Err(_) => {
                     // Pooled connection was stale — fall through to create new one
@@ -5057,7 +5064,7 @@ async fn do_single_request(
         .await?;
         let time_starttransfer = request_start.elapsed();
 
-        let mut resp = maybe_decompress(resp, accept_encoding);
+        let mut resp = maybe_decompress_inner(resp, accept_encoding, raw);
         let mut info = resp.transfer_info().clone();
         info.time_namelookup = time_namelookup;
         info.time_connect = time_connect;
@@ -5288,7 +5295,7 @@ async fn do_single_request(
                     )
                     .await?;
                     let time_starttransfer = request_start.elapsed();
-                    let mut resp = maybe_decompress(resp, accept_encoding);
+                    let mut resp = maybe_decompress_inner(resp, accept_encoding, raw);
                     let mut info = resp.transfer_info().clone();
                     info.time_namelookup = time_namelookup;
                     info.time_connect = time_connect;
@@ -5383,7 +5390,7 @@ async fn do_single_request(
                     .await?;
                     let time_starttransfer = request_start.elapsed();
 
-                    let mut resp = maybe_decompress(resp, accept_encoding);
+                    let mut resp = maybe_decompress_inner(resp, accept_encoding, raw);
                     let mut info = resp.transfer_info().clone();
                     info.time_namelookup = time_namelookup;
                     info.time_connect = time_connect;
@@ -5464,7 +5471,7 @@ async fn do_single_request(
                         h2_pool.put(&host, port, h2_client);
                     }
                     let time_starttransfer = request_start.elapsed();
-                    let mut resp = maybe_decompress(resp, accept_encoding);
+                    let mut resp = maybe_decompress_inner(resp, accept_encoding, raw);
                     let mut info = resp.transfer_info().clone();
                     info.time_namelookup = time_namelookup;
                     info.time_connect = time_connect;
@@ -5705,7 +5712,7 @@ async fn do_single_request(
         response.set_transfer_info(info);
     }
 
-    Ok(maybe_decompress(response, accept_encoding))
+    Ok(maybe_decompress_inner(response, accept_encoding, raw))
 }
 
 /// Decompress response body if Content-Encoding is present and decompression was requested.
@@ -5743,10 +5750,35 @@ const fn hex_val(b: u8) -> Option<u8> {
 /// Maximum number of content/transfer encodings allowed (curl compat: test 387).
 const MAX_ENCODING_LAYERS: usize = 5;
 
-fn maybe_decompress(mut response: Response, accept_encoding: bool) -> Response {
+/// Decompress response body if Content-Encoding or Transfer-Encoding compression is present.
+///
+/// When `raw` is true, all decompression is skipped (curl `--raw`).
+fn maybe_decompress_inner(mut response: Response, accept_encoding: bool, raw: bool) -> Response {
+    // In raw mode, skip all decompression (curl --raw: test 319)
+    if raw {
+        return response;
+    }
+
     // Transfer-Encoding decompression (hop-by-hop): always decompress regardless of
     // --compressed flag. Chunked is already handled at the framing layer; here we
     // handle gzip/deflate/br/zstd that may appear alongside chunked.
+    //
+    // Count total TE encodings across ALL Transfer-Encoding headers (wire order)
+    // to catch "more than 5" even when they appear as separate headers (test 418).
+    {
+        let mut total_te_count: usize = 0;
+        for (name, raw_val) in response.headers_ordered() {
+            if name.eq_ignore_ascii_case("Transfer-Encoding") {
+                let val = strip_raw_header_value(raw_val);
+                total_te_count += val.split(',').map(str::trim).filter(|s| !s.is_empty()).count();
+            }
+        }
+        if total_te_count > MAX_ENCODING_LAYERS {
+            response.set_body(Vec::new());
+            response.set_body_error(Some("too_many_content_encodings".to_string()));
+            return response;
+        }
+    }
     if let Some(te) = response.header("transfer-encoding") {
         if let Some(compression) = crate::protocol::http::h1::te_compression_encoding(te) {
             // Walk encodings in reverse order (outermost first, but chunked already stripped)
@@ -5755,12 +5787,6 @@ fn maybe_decompress(mut response: Response, accept_encoding: bool) -> Response {
             // like "deflate, gzip" (applied left-to-right, so decompress right-to-left).
             let parts: Vec<&str> =
                 compression.split(',').map(str::trim).filter(|s| !s.is_empty()).collect();
-            // Reject overly long encoding chains (curl compat: test 387)
-            if parts.len() > MAX_ENCODING_LAYERS {
-                response.set_body(Vec::new());
-                response.set_body_error(Some("too_many_content_encodings".to_string()));
-                return response;
-            }
             let mut ok = true;
             for enc in parts.iter().rev() {
                 if let Ok(decompressed) = crate::protocol::http::decompress::decompress(&body, enc)
@@ -5784,18 +5810,31 @@ fn maybe_decompress(mut response: Response, accept_encoding: bool) -> Response {
     if accept_encoding {
         if let Some(encoding) = response.header("content-encoding") {
             if encoding != "identity" && !encoding.eq_ignore_ascii_case("none") {
+                // Split by comma for multi-layer encoding (e.g. "deflate, identity, gzip")
+                // Applied innermost-to-outermost in the header, so decode outermost first
+                // (reverse order).  (curl compat: test 230)
+                let ce_parts: Vec<&str> =
+                    encoding.split(',').map(str::trim).filter(|s| !s.is_empty()).collect();
                 // Check encoding chain length limit (curl compat: test 387)
-                if encoding.split(',').map(str::trim).filter(|s| !s.is_empty()).count()
-                    > MAX_ENCODING_LAYERS
-                {
+                if ce_parts.len() > MAX_ENCODING_LAYERS {
                     response.set_body(Vec::new());
                     response.set_body_error(Some("too_many_content_encodings".to_string()));
                     return response;
                 }
-                if let Ok(decompressed) =
-                    crate::protocol::http::decompress::decompress(response.body(), encoding)
-                {
-                    response.set_body(decompressed);
+                let mut body = response.body().to_vec();
+                let mut ok = true;
+                for enc in ce_parts.iter().rev() {
+                    if let Ok(decompressed) =
+                        crate::protocol::http::decompress::decompress(&body, enc)
+                    {
+                        body = decompressed;
+                    } else {
+                        ok = false;
+                        break;
+                    }
+                }
+                if ok {
+                    response.set_body(body);
                 } else {
                     // Decompression failed: preserve headers, clear body,
                     // set body_error for exit code handling (curl compat).

--- a/crates/liburlx/src/protocol/http/h1.rs
+++ b/crates/liburlx/src/protocol/http/h1.rs
@@ -227,17 +227,25 @@ where
         req.push_str("Transfer-Encoding: chunked\r\n");
     }
 
+    // Check for internal _tr_encoding_connection marker (from --tr-encoding).
+    // When set, TE must be appended to the Connection header value.
+    let tr_encoding_te =
+        custom_headers.iter().any(|(k, _)| k.eq_ignore_ascii_case("_tr_encoding_connection"));
+
     // Emit remaining custom headers (non-priority, non-user-agent) in command-line order.
     // Multipart Content-Type is deferred to after Content-Length (curl header ordering).
     let mut deferred_content_type: Option<(String, String)> = None;
     let mut content_type_emitted = false;
+    let mut connection_emitted = false;
     for (i, (name, value)) in custom_headers.iter().enumerate() {
         // Skip priority headers, User-Agent, Host, and Proxy-Connection (emitted elsewhere)
         let is_priority = priority_order.iter().any(|p| name.eq_ignore_ascii_case(p));
         let is_ua = name.eq_ignore_ascii_case("user-agent");
         let is_host = name.eq_ignore_ascii_case("host");
         let is_proxy_conn = name.eq_ignore_ascii_case("proxy-connection");
-        if keep[i] && !is_priority && !is_ua && !is_host && !is_proxy_conn {
+        // Skip internal _tr_encoding_connection marker (handled below)
+        let is_tr_enc_marker = name.eq_ignore_ascii_case("_tr_encoding_connection");
+        if keep[i] && !is_priority && !is_ua && !is_host && !is_proxy_conn && !is_tr_enc_marker {
             // Defer form/multipart Content-Type to after Content-Length (curl compat)
             // Keep other Content-Types (like application/json) in place (test 383)
             if name.eq_ignore_ascii_case("content-type")
@@ -254,6 +262,20 @@ where
                     continue;
                 }
             }
+            // Connection header: merge TE value from --tr-encoding (curl compat: tests 1125, 1171)
+            if name.eq_ignore_ascii_case("connection") {
+                connection_emitted = true;
+                if tr_encoding_te {
+                    if value.is_empty() {
+                        // -H "Connection;" with --tr-encoding → "Connection: TE"
+                        let _ = write!(req, "{name}: TE\r\n");
+                    } else {
+                        // -H "Connection: close" with --tr-encoding → "Connection: close, TE"
+                        let _ = write!(req, "{name}: {value}, TE\r\n");
+                    }
+                    continue;
+                }
+            }
             if value.is_empty() {
                 // Empty value from -H "Name;" → send header with no value
                 let _ = write!(req, "{name}:\r\n");
@@ -261,6 +283,11 @@ where
                 let _ = write!(req, "{name}: {value}\r\n");
             }
         }
+    }
+
+    // If --tr-encoding was set but no user Connection header was provided, add one
+    if tr_encoding_te && !connection_emitted {
+        req.push_str("Connection: TE\r\n");
     }
 
     // Add auto Content-Length for bodies (after custom headers, before Content-Type).
@@ -1178,11 +1205,14 @@ where
 /// Read exactly `content_length` bytes of body, using any already-read prefix.
 ///
 /// When a rate limiter is active, reads in chunks with throttling.
+/// When a `deadline` is provided, respects it and returns partial body on timeout
+/// (curl compat: test 223 — broken deflate detected via partial body).
 async fn read_exact_body<S>(
     stream: &mut S,
     content_length: usize,
     prefix: Vec<u8>,
     limiter: &mut RateLimiter,
+    deadline: Option<tokio::time::Instant>,
 ) -> Result<Vec<u8>, Error>
 where
     S: AsyncRead + Unpin,
@@ -1198,10 +1228,25 @@ where
     }
 
     if !limiter.is_active() {
-        // Fast path: read all remaining bytes at once
+        // Fast path: read all remaining bytes at once (or in a single deadline-wrapped read)
         let remaining = content_length - body.len();
         let mut remaining_buf = vec![0u8; remaining];
-        match stream.read_exact(&mut remaining_buf).await {
+        let read_fut = stream.read_exact(&mut remaining_buf);
+        let result = if let Some(dl) = deadline {
+            match tokio::time::timeout_at(dl, read_fut).await {
+                Ok(inner) => inner,
+                Err(_) => {
+                    // Deadline exceeded — return partial body
+                    return Err(Error::PartialBody {
+                        message: "transfer closed with outstanding read data remaining".to_string(),
+                        partial_body: body,
+                    });
+                }
+            }
+        } else {
+            read_fut.await
+        };
+        match result {
             Ok(_) => {}
             Err(e) if is_close_notify_error(&e) => {
                 // Treat as truncated — return partial body error
@@ -1235,7 +1280,21 @@ where
         let remaining = content_length - body.len();
         let chunk_size = remaining.min(THROTTLE_CHUNK_SIZE);
         let mut chunk_buf = vec![0u8; chunk_size];
-        match stream.read_exact(&mut chunk_buf).await {
+        let read_fut = stream.read_exact(&mut chunk_buf);
+        let result = if let Some(dl) = deadline {
+            match tokio::time::timeout_at(dl, read_fut).await {
+                Ok(inner) => inner,
+                Err(_) => {
+                    return Err(Error::PartialBody {
+                        message: "transfer closed with outstanding read data remaining".to_string(),
+                        partial_body: body,
+                    });
+                }
+            }
+        } else {
+            read_fut.await
+        };
+        match result {
             Ok(_) => {}
             Err(e)
                 if is_close_notify_error(&e) || e.kind() == std::io::ErrorKind::UnexpectedEof =>
@@ -1293,7 +1352,8 @@ where
     } else if !ignore_content_length && headers.contains_key("content-length") {
         let cl = &headers["content-length"];
         if let Ok(content_length) = cl.parse::<usize>() {
-            let body = read_exact_body(stream, content_length, body_prefix, limiter).await?;
+            let body =
+                read_exact_body(stream, content_length, body_prefix, limiter, deadline).await?;
             Ok((body, false, HashMap::new(), Vec::new()))
         } else {
             // Content-Length overflows usize — read to EOF (curl compat: test 395)

--- a/crates/urlx-cli/src/args.rs
+++ b/crates/urlx-cli/src/args.rs
@@ -901,9 +901,11 @@ fn parse_args_options_with_depth(args: &[String], config_depth: u32) -> Result<C
                 opts.easy.accept_encoding(true);
             }
             "--tr-encoding" => {
-                // Add TE: gzip and Connection: TE headers for transfer-encoding request
+                // Add TE: gzip header and mark that Connection should include TE.
+                // The h1 request builder merges TE into Connection (curl compat: tests
+                // 1125, 1171, 1277).
                 opts.easy.header("TE", "gzip");
-                opts.easy.header("Connection", "TE");
+                opts.easy.header("_tr_encoding_connection", "TE");
             }
             "--connect-timeout" => {
                 i += 1;
@@ -2948,23 +2950,25 @@ fn apply_variable_function(value: &[u8], func: &str) -> Result<Vec<u8>, u8> {
             Ok(simple_base64_decode(value))
         }
         "json" => {
-            // JSON string escaping (no wrapping quotes — curl compat)
-            let mut s = String::with_capacity(value.len());
+            // JSON string escaping (no wrapping quotes — curl compat).
+            // Operates on raw bytes: non-ASCII bytes are passed through as-is
+            // to preserve UTF-8 multibyte sequences (curl compat: test 268).
+            let mut out = Vec::with_capacity(value.len());
             for &byte in value {
                 match byte {
-                    b'"' => s.push_str("\\\""),
-                    b'\\' => s.push_str("\\\\"),
-                    b'\n' => s.push_str("\\n"),
-                    b'\r' => s.push_str("\\r"),
-                    b'\t' => s.push_str("\\t"),
+                    b'"' => out.extend_from_slice(b"\\\""),
+                    b'\\' => out.extend_from_slice(b"\\\\"),
+                    b'\n' => out.extend_from_slice(b"\\n"),
+                    b'\r' => out.extend_from_slice(b"\\r"),
+                    b'\t' => out.extend_from_slice(b"\\t"),
                     b if b < 0x20 => {
-                        use std::fmt::Write;
-                        let _ = write!(s, "\\u{:04x}", b);
+                        let hex = format!("\\u{b:04x}");
+                        out.extend_from_slice(hex.as_bytes());
                     }
-                    b => s.push(b as char),
+                    b => out.push(b),
                 }
             }
-            Ok(s.into_bytes())
+            Ok(out)
         }
         _ => {
             eprintln!("curl: unknown variable function: {func}");

--- a/crates/urlx-cli/src/transfer.rs
+++ b/crates/urlx-cli/src/transfer.rs
@@ -1340,10 +1340,34 @@ pub fn run(args: &[String]) -> ExitCode {
                 // If Content-Length is present but unparseable (e.g., too large), treat as exceeded
                 let cl_exceeded =
                     cl_header.is_some_and(|v| v.parse::<u64>().map_or(true, |cl| cl > max_size));
-                let exceeded = cl_exceeded || response.body().len() as u64 > max_size;
-                if exceeded {
+                if cl_exceeded {
+                    // Content-Length known upfront: error without output
                     if !opts.silent || opts.show_error {
                         eprintln!("curl: maximum file size exceeded",);
+                    }
+                    return ExitCode::from(63);
+                }
+                // For chunked/no-CL responses the body was already received.
+                // curl truncates at max-filesize bytes and outputs what fits,
+                // then returns error 63 (curl compat: test 457).
+                let body_exceeded = response.body().len() as u64 > max_size;
+                if body_exceeded {
+                    // Truncate body to max-filesize bytes before outputting
+                    let trunc_len =
+                        usize::try_from(max_size).unwrap_or_else(|_| response.body().len());
+                    let truncated_body = response.body()[..trunc_len].to_vec();
+                    response.set_body(truncated_body);
+                    // Output the response (headers + truncated body) first
+                    let _ = output_response(
+                        &response,
+                        opts.output_file.as_deref(),
+                        None,
+                        opts.include_headers,
+                        opts.silent,
+                        false, // don't suppress body
+                    );
+                    if !opts.silent || opts.show_error {
+                        eprintln!("curl: (63) Maximum file size exceeded",);
                     }
                     return ExitCode::from(63);
                 }


### PR DESCRIPTION
## Summary

- Pass 9 previously-failing curl tests: 223, 230, 268, 319, 418, 457, 1125, 1171, 1277
- Fix `--raw` mode to skip all decompression including Transfer-Encoding (test 319)
- Support multi-layer `Content-Encoding` (e.g. `deflate, identity, gzip`) by splitting and decoding in reverse order (test 230)
- Count `Transfer-Encoding` headers across all wire-order occurrences for the >5 encoding chain limit (test 418)
- Merge `TE` into the `Connection` header value from `--tr-encoding` instead of adding a separate header (tests 1125, 1171, 1277)
- Truncate body at `--max-filesize` bytes and output before returning error 63 for chunked responses (test 457)
- Fix `:json` variable function to preserve raw bytes for non-ASCII, avoiding double-encoding of UTF-8 multibyte sequences (test 268)
- Make `read_exact_body` respect the transfer deadline to detect bad `Content-Encoding` when server sends fewer bytes than `Content-Length` (test 223)

## Test plan
- [x] All 9 target tests pass: `223 230 268 319 418 457 1125 1171 1277`
- [x] No regressions in previously-passing tests (verified tests 1-60, 61-99, 221-234, 387, 784-791)
- [x] `cargo fmt`, `cargo clippy`, `cargo test` all clean