### PR TITLE
fix(cookie): preserve cookie jar across multi-URL transfers

### DIFF
--- a/crates/liburlx/src/cookie.rs
+++ b/crates/liburlx/src/cookie.rs
@@ -1440,4 +1440,42 @@ mod tests {
         // But not over HTTP
         assert!(jar.cookie_header("example.com", "/", false).is_none());
     }
+
+    #[test]
+    fn test_329_max_age_zero_deletes() {
+        // Simulate test 329
+        let mut jar = CookieJar::new();
+
+        // Load cookies from files
+        let data1 = b".host.foo.com\tTRUE\t/we/want/\tFALSE\t22147483647\ttest\tno\n";
+        let data2 = b".host.foo.com\tTRUE\t/we/want/\tFALSE\t22147483647\ttester\tyes\n";
+        jar.load_from_reader(std::io::Cursor::new(data1)).unwrap();
+        jar.load_from_reader(std::io::Cursor::new(data2)).unwrap();
+        assert_eq!(jar.len(), 2);
+
+        // First request: should send both
+        let header = jar.cookie_header("host.foo.com", "/we/want/329", false);
+        assert!(header.is_some());
+        let h = header.unwrap();
+        assert!(h.contains("tester=yes"), "should have tester=yes, got: {h}");
+        assert!(h.contains("test=no"), "should have test=no, got: {h}");
+
+        // Server responds with Max-Age=0 for test cookie and Max-Age=-1 for testn1
+        jar.parse_set_cookie(
+            "testn1=yes; path=/we/want/; domain=.host.foo.com; Max-Age=-1;",
+            "host.foo.com",
+            "/we/want/329",
+            false,
+        );
+        jar.parse_set_cookie(
+            "test=yes; path=/we/want/; domain=.host.foo.com; Max-Age=0;",
+            "host.foo.com",
+            "/we/want/329",
+            false,
+        );
+
+        // Second request should only send tester=yes
+        let header = jar.cookie_header("host.foo.com", "/we/want/3290002", false);
+        assert_eq!(header, Some("tester=yes".to_string()), "Only tester=yes should be sent");
+    }
 }

--- a/crates/liburlx/src/easy.rs
+++ b/crates/liburlx/src/easy.rs
@@ -981,6 +981,26 @@ impl Easy {
         Ok(())
     }
 
+    /// Returns the number of cookies in the cookie jar (0 if no jar).
+    #[must_use]
+    pub fn cookie_count(&self) -> usize {
+        self.cookie_jar.as_ref().map_or(0, CookieJar::len)
+    }
+
+    /// Transfer the cookie jar and HSTS cache from another Easy handle.
+    ///
+    /// This preserves accumulated cookies and HSTS entries when switching
+    /// Easy handles in multi-URL sequential mode (curl compat: cookies
+    /// must persist across URLs in the same invocation).
+    pub fn transfer_state_from(&mut self, other: &mut Self) {
+        if other.cookie_jar.is_some() {
+            self.cookie_jar = other.cookie_jar.take();
+        }
+        if other.hsts_cache.is_some() {
+            self.hsts_cache = other.hsts_cache.take();
+        }
+    }
+
     /// Set the proxy URL.
     ///
     /// HTTP URLs are forwarded through the proxy. HTTPS URLs use

--- a/crates/urlx-cli/src/transfer.rs
+++ b/crates/urlx-cli/src/transfer.rs
@@ -2127,6 +2127,10 @@ pub fn run_multi(
             let mut new_easy = per_easy.clone();
             // Preserve FTP session for connection reuse across URLs (curl compat: tests 146, 210, 698)
             new_easy.take_ftp_session_from(&mut easy);
+            // Transfer accumulated cookie jar and HSTS cache from the previous
+            // Easy handle so cookies persist across sequential URLs (curl compat:
+            // tests 327, 329, 331, 392, 1218, 1228, 1258).
+            new_easy.transfer_state_from(&mut easy);
             easy = new_easy;
         }
 


### PR DESCRIPTION
## Summary

- Fixed a bug where the cookie jar was lost between sequential URL transfers in multi-URL mode (`curl url1 url2 -b none`).
- Root cause: the `per_url_easy` mechanism replaced the Easy handle for every URL, discarding accumulated cookies and HSTS state. Now `transfer_state_from()` preserves this state across handle switches.
- Added `Easy::transfer_state_from()` to transfer cookie jar and HSTS cache between Easy handles.
- Added `Easy::cookie_count()` utility method.
- Added unit test for Max-Age=0 cookie deletion scenario (curl test 329).

## Test plan
- [x] `cargo fmt`, `cargo clippy`, `cargo test` pass (all pre-commit hooks pass)
- [x] 17 of 19 curl tests from task 06 pass when run individually: 327, 329, 331, 392, 420, 427, 440, 441, 443, 444, 798, 898, 1151, 1160, 1218, 1228, 1258
- [ ] Test 414 (secure cookie protection on HTTP->HTTPS redirect) - known issue, requires deeper secure cookie overwrite protection
- [ ] Test 1331 (proxy-anyauth + cookies) - fundamentally a proxy auth retry issue, not a cookie bug