### PR TITLE
fix(http): redirect, URL, and protocol handling edge cases

### DIFF
--- a/crates/liburlx/src/easy.rs
+++ b/crates/liburlx/src/easy.rs
@@ -2935,6 +2935,11 @@ async fn perform_transfer(
     // When redirecting to `http://user:pass@host/...`, these credentials replace
     // any existing auth headers.
     let mut redirect_url_auth: Option<String> = None;
+    // Track cumulative response header size across redirect chain.
+    // curl's MAX_HTTP_RESP_HEADER_SIZE = 6000 * 1024 = 6,144,000 bytes.
+    // Exceeding this limit returns CURLE_RECV_ERROR (56) (test 498).
+    let max_cumulative_header_size: usize = 6000 * 1024;
+    let mut cumulative_header_size: usize = 0;
 
     loop {
         // Determine effective proxy for this URL
@@ -4541,6 +4546,24 @@ async fn perform_transfer(
             }
         }
 
+        // Track cumulative response header size across redirect chain (test 498).
+        // curl's MAX_HTTP_RESP_HEADER_SIZE = 6000 * 1024.
+        // Use total_header_size if set, otherwise fall back to raw_headers length.
+        let resp_header_size = if response.total_header_size() > 0 {
+            response.total_header_size()
+        } else {
+            response.raw_headers().map_or(0, <[u8]>::len)
+        };
+        cumulative_header_size += resp_header_size;
+        if cumulative_header_size > max_cumulative_header_size {
+            return Err(Error::Transfer {
+                code: 56,
+                message: format!(
+                    "Too large response headers: {cumulative_header_size} > {max_cumulative_header_size}"
+                ),
+            });
+        }
+
         // Check for redirects
         if follow_redirects && response.is_redirect() {
             if redirects_followed >= max_redirects {
@@ -4569,6 +4592,11 @@ async fn perform_transfer(
             }
 
             if let Some(location) = response.header("location") {
+                // Normalize redirect URLs with triple slash (http:///host/path).
+                // curl treats http:///host as http://host (test 1141) but rejects
+                // http:////path (test 1142) as having too many slashes.
+                let location = normalize_redirect_slashes(location);
+
                 // Reject redirect URLs with empty authority (e.g. http:////path).
                 // curl returns CURLE_URL_MALFORMAT for these (test 1142).
                 if let Some(rest) = location.strip_prefix("http://") {
@@ -4587,9 +4615,20 @@ async fn perform_transfer(
                 }
 
                 // Resolve relative URLs against current URL
-                let mut next_url = if location.contains("://") {
+                // Only treat as absolute if "://" appears in the scheme portion
+                // (before any path/query/fragment). A query string like
+                // `?moo=http://foo` should not be treated as absolute (test 45).
+                let has_scheme = location.find("://").is_some_and(|pos| {
+                    let before = &location[..pos];
+                    // A scheme must be all alphanumeric/+/-./ and cannot contain ?, #, or /
+                    !before.is_empty()
+                        && !before.contains('?')
+                        && !before.contains('#')
+                        && !before.contains('/')
+                });
+                let mut next_url = if has_scheme {
                     // Absolute URL with scheme (http://, https://, imap://, etc.)
-                    Url::parse(location)?
+                    Url::parse(&location)?
                 } else if location.starts_with("//") {
                     // Protocol-relative URL (//host/path) — use current scheme
                     let scheme = current_url.scheme();
@@ -4597,7 +4636,7 @@ async fn perform_transfer(
                 } else {
                     // Relative URL: build from current URL's base
                     let base = current_url.as_str();
-                    Url::parse(&resolve_relative(base, location))?
+                    Url::parse(&resolve_relative(base, &location))?
                 };
                 // Clear raw_input so redirect uses normalized path (not user's original)
                 next_url.clear_raw_input();
@@ -4625,6 +4664,25 @@ async fn perform_transfer(
                     {
                         eprintln!("* Following redirect to {next_url}");
                     }
+                }
+
+                // If we used chunked upload and the server is HTTP/1.0, refuse to
+                // follow the redirect because HTTP/1.0 doesn't support chunked
+                // encoding for a re-sent upload (curl returns CURLE_UPLOAD_FAILED = 25,
+                // test 1073).
+                if chunked_upload
+                    && response.http_version()
+                        == crate::protocol::http::response::ResponseHttpVersion::Http10
+                {
+                    // Store the response so the CLI can output the headers (test 1073)
+                    if let Ok(mut guard) = last_resp_store.lock() {
+                        *guard = Some(response);
+                    }
+                    return Err(Error::Transfer {
+                        code: 25,
+                        message: "Upload failed (chunked encoding not supported by HTTP/1.0)"
+                            .to_string(),
+                    });
                 }
 
                 // 307/308: always preserve method and body
@@ -5840,7 +5898,14 @@ async fn do_single_request(
                 } else if is_http_proxy {
                     // Strip fragment and credentials from proxy request URL
                     // Credentials go in Authorization header, not the Request-URI
-                    let full = strip_url_credentials(&url.to_full_string());
+                    // When path_as_is is set, use raw_input to preserve dot segments
+                    // (curl compat: test 1241).
+                    let full = if path_as_is {
+                        let raw = url.raw_input().unwrap_or_else(|| url.as_str());
+                        strip_url_credentials(raw)
+                    } else {
+                        strip_url_credentials(&url.to_full_string())
+                    };
                     let full = full
                         .split_once('#')
                         .map_or_else(|| full.clone(), |(base, _)| base.to_string());
@@ -7015,6 +7080,25 @@ const fn proxy_type_to_scheme(ptype: u32) -> &'static str {
         // 0 = HTTP, 1 = HTTP 1.0, and any unknown type default to HTTP
         _ => "http",
     }
+}
+
+/// Normalize redirect Location URLs with extra slashes.
+///
+/// `http:///host/path` (triple slash) is treated as `http://host/path` by curl
+/// (test 1141). Only one extra slash is removed; `http:////path` (four or more
+/// slashes) is left unchanged and rejected later as an empty-authority URL.
+fn normalize_redirect_slashes(location: &str) -> String {
+    // Check for http:///X or https:///X where X is NOT another slash
+    for prefix in &["http:///", "https:///"] {
+        if let Some(rest) = location.strip_prefix(*prefix) {
+            if !rest.starts_with('/') {
+                // Triple slash with a host after — collapse to double slash
+                let scheme = &prefix[..prefix.len() - 3]; // "http:" or "https:"
+                return format!("{scheme}//{rest}");
+            }
+        }
+    }
+    location.to_string()
 }
 
 /// Resolve a relative URL against a base URL.

--- a/crates/liburlx/src/glob.rs
+++ b/crates/liburlx/src/glob.rs
@@ -90,6 +90,7 @@ const MAX_GLOB_PATTERNS: usize = 100;
 /// # Errors
 ///
 /// Returns an error if the glob pattern is malformed or exceeds the pattern limit.
+#[allow(clippy::too_many_lines)]
 fn parse_glob(pattern: &str) -> Result<Vec<Segment>, Error> {
     let mut segments = Vec::new();
     let mut chars = pattern.chars().peekable();
@@ -140,25 +141,80 @@ fn parse_glob(pattern: &str) -> Result<Vec<Segment>, Error> {
                 segments.push(set);
             }
             '[' => {
-                glob_count += 1;
-                if glob_count > MAX_GLOB_PATTERNS {
-                    let display_pos = pos + 1;
-                    let truncated: String = pattern.chars().take(pos + 2).collect();
-                    return Err(Error::UrlGlob {
-                        message: format!("too many [] sets in URL position {display_pos}:"),
-                        url: truncated,
-                        position: pos,
-                    });
+                // Peek ahead to decide how to handle the bracket:
+                // 1. Empty brackets `[]` → literal (curl compat: test 1290)
+                // 2. IPv6 address `[::1]` or `[::1%25scope]` → literal (test 1056)
+                // 3. Otherwise → glob range pattern
+                //
+                // IPv6 detection: scan to closing `]` and check if content looks
+                // like an IPv6 address (contains multiple colons, or starts with
+                // a colon, or contains `%` for scope IDs). A glob range never has
+                // colons before the step separator, so any `:` before a `-` range
+                // dash indicates IPv6.
+                #[allow(clippy::unused_peekable)]
+                let treat_as_literal = {
+                    let mut scan = chars.clone();
+                    let _ = scan.next(); // skip '['
+                    let mut bracket_content = String::new();
+                    let mut found_close = false;
+                    for c in scan {
+                        if c == ']' {
+                            found_close = true;
+                            break;
+                        }
+                        bracket_content.push(c);
+                    }
+                    if !found_close {
+                        false // unclosed bracket — let normal parser handle the error
+                    } else if bracket_content.is_empty() {
+                        true // empty brackets `[]`
+                    } else {
+                        // IPv6 heuristic: starts with `:` or hex digit followed
+                        // by `:`, or contains `%` (scope ID separator).
+                        // A valid glob range looks like `N-M` or `N-M:S` — never
+                        // starts with `:` and has at most one `:` (the step sep).
+                        let colon_count = bracket_content.chars().filter(|&c| c == ':').count();
+                        bracket_content.starts_with(':')
+                            || colon_count >= 2
+                            || bracket_content.contains('%')
+                    }
+                };
+
+                if treat_as_literal {
+                    // Consume everything from '[' to ']' as literal text
+                    literal.push('[');
+                    let _ = chars.next(); // consume '['
+                    pos += 1;
+                    // Consume up to and including ']'
+                    while let Some(&c) = chars.peek() {
+                        literal.push(c);
+                        let _ = chars.next();
+                        pos += c.len_utf8();
+                        if c == ']' {
+                            break;
+                        }
+                    }
+                } else {
+                    glob_count += 1;
+                    if glob_count > MAX_GLOB_PATTERNS {
+                        let display_pos = pos + 1;
+                        let truncated: String = pattern.chars().take(pos + 2).collect();
+                        return Err(Error::UrlGlob {
+                            message: format!("too many [] sets in URL position {display_pos}:"),
+                            url: truncated,
+                            position: pos,
+                        });
+                    }
+                    if !literal.is_empty() {
+                        segments.push(Segment::Literal(std::mem::take(&mut literal)));
+                    }
+                    let open_pos = pos;
+                    let _ = chars.next(); // consume '['
+                    pos += 1;
+                    let (range, consumed) = parse_range_with_len(&mut chars, pattern, open_pos)?;
+                    pos += consumed;
+                    segments.push(range);
                 }
-                if !literal.is_empty() {
-                    segments.push(Segment::Literal(std::mem::take(&mut literal)));
-                }
-                let open_pos = pos;
-                let _ = chars.next(); // consume '['
-                pos += 1;
-                let (range, consumed) = parse_range_with_len(&mut chars, pattern, open_pos)?;
-                pos += consumed;
-                segments.push(range);
             }
             _ => {
                 literal.push(ch);

--- a/crates/liburlx/src/protocol/http/h1.rs
+++ b/crates/liburlx/src/protocol/http/h1.rs
@@ -40,9 +40,17 @@ pub(crate) fn te_compression_encoding(te: &str) -> Option<String> {
     }
 }
 
-/// Maximum response header size (300 KB, matching curl's `CURL_MAX_HTTP_HEADER` = 300 * 1024).
-/// curl returns `CURLE_RECV_ERROR` (exit 56) when headers exceed this limit (test 497).
-const MAX_HEADER_SIZE: usize = 300 * 1024;
+/// Maximum size of a single response header line (100 KB, matching curl's
+/// `CURL_MAX_HTTP_HEADER`).  curl returns `CURLE_TOO_LARGE` (exit 100) when a
+/// *single* header exceeds this limit (test 1154).
+const MAX_HEADER_LINE_SIZE: usize = 100 * 1024;
+
+/// Maximum total response header section size per response.
+/// This is the same as curl's `MAX_HTTP_RESP_HEADER_SIZE` (6000 * 1024).
+/// Individual responses are allowed to have large headers as long as the total
+/// stays under this limit; the cumulative limit across redirects is enforced
+/// separately in the redirect loop.
+const MAX_HEADER_SIZE: usize = 6000 * 1024;
 
 /// Send an HTTP/1.x request and read the response.
 ///
@@ -664,10 +672,12 @@ where
     // Prepend 1xx informational response headers so --include shows them.
     // Normalize raw headers for output (unfold continuation lines, collapse whitespace).
     if informational_prefix.is_empty() {
+        resp.set_total_header_size(header_bytes.len());
         resp.set_raw_headers(normalize_raw_headers_for_output(&header_bytes));
     } else {
         let mut combined = informational_prefix;
         combined.extend_from_slice(&header_bytes);
+        resp.set_total_header_size(combined.len());
         resp.set_raw_headers(normalize_raw_headers_for_output(&combined));
     }
     if !trailers.is_empty() {
@@ -903,6 +913,7 @@ struct ParsedHeaders {
 }
 
 /// Parse raw header bytes into structured response headers.
+#[allow(clippy::too_many_lines)]
 fn parse_headers(data: &[u8]) -> Result<ParsedHeaders, Error> {
     // Find the end of headers (double CRLF or double LF)
     let header_end = data
@@ -969,6 +980,18 @@ fn parse_headers(data: &[u8]) -> Result<ParsedHeaders, Error> {
     };
     // Detect line ending style: if we find \r\n it's CRLF, otherwise bare LF
     let uses_crlf = data.windows(2).any(|w| w == b"\r\n");
+
+    // Check individual header line sizes (curl: CURLE_TOO_LARGE = 100, test 1154)
+    for header in parsed.headers.iter() {
+        // Total line size: "Name: Value\r\n"
+        let line_size = header.name.len() + 2 + header.value.len() + 2;
+        if line_size > MAX_HEADER_LINE_SIZE {
+            return Err(Error::Transfer {
+                code: 100,
+                message: format!("Too large response header: {line_size} > {MAX_HEADER_LINE_SIZE}"),
+            });
+        }
+    }
 
     // Extract raw header values from the wire data (httparse trims whitespace,
     // but curl preserves it in -i output)
@@ -1087,6 +1110,21 @@ fn parse_headers_large(data: &[u8]) -> Result<ParsedHeaders, Error> {
         }
     };
     let uses_crlf = data.windows(2).any(|w| w == b"\r\n");
+
+    // Check individual header line sizes (curl: CURLE_TOO_LARGE = 100, test 1154)
+    for header in parsed.headers.iter() {
+        if header.name.is_empty() {
+            break;
+        }
+        let line_size = header.name.len() + 2 + header.value.len() + 2;
+        if line_size > MAX_HEADER_LINE_SIZE {
+            return Err(Error::Transfer {
+                code: 100,
+                message: format!("Too large response header: {line_size} > {MAX_HEADER_LINE_SIZE}"),
+            });
+        }
+    }
+
     let raw_values = extract_raw_header_values(&data[..header_len]);
 
     let mut headers = HashMap::with_capacity(parsed.headers.len());

--- a/crates/liburlx/src/url.rs
+++ b/crates/liburlx/src/url.rs
@@ -68,15 +68,11 @@ impl Url {
                     if let Some(after_scheme) = input.find("://") {
                         let host_start = after_scheme + 3;
                         let rest = &input[host_start..];
-                        // Skip userinfo if present
-                        let host_part_start = rest.find('@').map_or(0, |at_pos| {
-                            let slash_pos = rest.find('/').unwrap_or(rest.len());
-                            if at_pos < slash_pos {
-                                at_pos + 1
-                            } else {
-                                0
-                            }
-                        });
+                        // Find end of authority (before path, query, or fragment)
+                        let authority_end = rest.find(['/', '?', '#']).unwrap_or(rest.len());
+                        let authority = &rest[..authority_end];
+                        // Skip userinfo if present (only look for @ within the authority)
+                        let host_part_start = authority.find('@').map_or(0, |at_pos| at_pos + 1);
                         let host_rest = &rest[host_part_start..];
                         // Find end of host (: for port, / for path, ? for query, # for fragment)
                         let host_end =

--- a/crates/urlx-cli/src/args.rs
+++ b/crates/urlx-cli/src/args.rs
@@ -3098,6 +3098,7 @@ fn warn_filename_like_flag(val: &str) {
 ///
 /// Protocol list format matches curl: comma-separated protocol names,
 /// optionally prefixed with `=` for exact set (e.g., `=http,https`).
+#[allow(dead_code)]
 pub fn is_protocol_allowed(url: &str, proto_list: &str) -> bool {
     let scheme = url.split("://").next().unwrap_or("").to_lowercase();
     if scheme.is_empty() {
@@ -3141,13 +3142,23 @@ pub fn parse_proto_spec(spec: &str) -> Vec<String> {
             continue;
         }
         if let Some(proto) = part.strip_prefix('+') {
-            let proto = proto.to_lowercase();
-            if !allowed.contains(&proto) {
-                allowed.push(proto);
+            if proto.eq_ignore_ascii_case("all") {
+                // +all means add all protocols
+                allowed = all_protocols.iter().map(|s| s.to_string()).collect();
+            } else {
+                let proto = proto.to_lowercase();
+                if !allowed.contains(&proto) {
+                    allowed.push(proto);
+                }
             }
         } else if let Some(proto) = part.strip_prefix('-') {
-            let proto = proto.to_lowercase();
-            allowed.retain(|p| p != &proto);
+            if proto.eq_ignore_ascii_case("all") {
+                // -all means remove all protocols
+                allowed.clear();
+            } else {
+                let proto = proto.to_lowercase();
+                allowed.retain(|p| p != &proto);
+            }
         } else if part.eq_ignore_ascii_case("all") {
             allowed = all_protocols.iter().map(|s| s.to_string()).collect();
         } else {

--- a/crates/urlx-cli/src/transfer.rs
+++ b/crates/urlx-cli/src/transfer.rs
@@ -6,8 +6,8 @@
 use std::process::ExitCode;
 
 use crate::args::{
-    is_protocol_allowed, parse_args, parse_proto_spec, percent_encode, print_usage, print_version,
-    CliOptions, ParseResult,
+    parse_args, parse_proto_spec, percent_encode, print_usage, print_version, CliOptions,
+    ParseResult,
 };
 use crate::output::{
     content_disposition_filename, format_headers, format_write_out, http_status_text,
@@ -300,8 +300,8 @@ pub fn extract_hostname(url: &str) -> String {
 #[allow(clippy::option_if_let_else)]
 fn extract_url_username(url: &str) -> Option<String> {
     let without_scheme = url.find("://").map_or(url, |pos| &url[pos + 3..]);
-    // Only look for @ in the authority part (before first / or ?)
-    let authority_end = without_scheme.find(['/', '?']).unwrap_or(without_scheme.len());
+    // Only look for @ in the authority part (before first /, ?, or #)
+    let authority_end = without_scheme.find(['/', '?', '#']).unwrap_or(without_scheme.len());
     let authority = &without_scheme[..authority_end];
     if let Some(at_pos) = authority.rfind('@') {
         let userinfo = &authority[..at_pos];
@@ -324,8 +324,8 @@ fn extract_url_username(url: &str) -> Option<String> {
 #[allow(clippy::option_if_let_else)]
 fn extract_url_username_raw(url: &str) -> Option<String> {
     let without_scheme = url.find("://").map_or(url, |pos| &url[pos + 3..]);
-    // Only look for @ in the authority part (before first / or ?)
-    let authority_end = without_scheme.find(['/', '?']).unwrap_or(without_scheme.len());
+    // Only look for @ in the authority part (before first /, ?, or #)
+    let authority_end = without_scheme.find(['/', '?', '#']).unwrap_or(without_scheme.len());
     let authority = &without_scheme[..authority_end];
     if let Some(at_pos) = authority.rfind('@') {
         let userinfo = &authority[..at_pos];
@@ -342,8 +342,8 @@ fn extract_url_username_raw(url: &str) -> Option<String> {
 #[allow(clippy::option_if_let_else)]
 fn extract_url_password(url: &str) -> Option<String> {
     let without_scheme = url.find("://").map_or(url, |pos| &url[pos + 3..]);
-    // Only look for @ in the authority part (before first / or ?)
-    let authority_end = without_scheme.find(['/', '?']).unwrap_or(without_scheme.len());
+    // Only look for @ in the authority part (before first /, ?, or #)
+    let authority_end = without_scheme.find(['/', '?', '#']).unwrap_or(without_scheme.len());
     let authority = &without_scheme[..authority_end];
     if let Some(at_pos) = authority.rfind('@') {
         let userinfo = &authority[..at_pos];
@@ -362,8 +362,8 @@ fn extract_url_password(url: &str) -> Option<String> {
 fn strip_url_credentials(url: &str) -> String {
     let scheme_end = url.find("://").map_or(0, |p| p + 3);
     let rest = &url[scheme_end..];
-    // Only look for @ in the authority part (before first / or ?)
-    let authority_end = rest.find(['/', '?']).unwrap_or(rest.len());
+    // Only look for @ in the authority part (before first /, ?, or #)
+    let authority_end = rest.find(['/', '?', '#']).unwrap_or(rest.len());
     let authority = &rest[..authority_end];
     if let Some(at_pos) = authority.find('@') {
         format!("{}{}", &url[..scheme_end], &rest[at_pos + 1..])
@@ -737,13 +737,18 @@ pub fn run(args: &[String]) -> ExitCode {
             url
         };
 
-        // --proto: validate URL scheme against allowed protocols
+        // --proto: validate URL scheme against allowed protocols.
+        // Use parse_proto_spec to properly interpret +all/-proto syntax.
         if let Some(ref proto_list) = opts.proto {
-            if !is_protocol_allowed(&url, proto_list) {
+            let allowed = parse_proto_spec(proto_list);
+            let scheme = url.split("://").next().unwrap_or("").to_lowercase();
+            if !scheme.is_empty() && !allowed.iter().any(|p| p == &scheme) {
                 if !opts.silent || opts.show_error {
-                    eprintln!("curl: protocol not allowed by --proto");
+                    eprintln!(
+                        "curl: (1) Protocol \"{scheme}\" not supported or disabled in libcurl"
+                    );
                 }
-                return ExitCode::FAILURE;
+                return ExitCode::from(1);
             }
         }
 
@@ -1207,6 +1212,15 @@ pub fn run(args: &[String]) -> ExitCode {
         let scheme = opts.easy.url_ref().map(|u| u.scheme().to_lowercase()).unwrap_or_default();
         if matches!(scheme.as_str(), "smtp" | "smtps" | "imap" | "imaps" | "pop3" | "pop3s") {
             opts.easy.custom_request_target(custom_req);
+        }
+    }
+
+    // --proto: pass allowed protocols to library for redirect checking too.
+    // curl's --proto restricts both initial requests AND redirect targets (test 1245).
+    if let Some(ref proto) = opts.proto {
+        let allowed = parse_proto_spec(proto);
+        if !allowed.is_empty() {
+            opts.easy.set_protocols_str(&allowed.join(","));
         }
     }
 


### PR DESCRIPTION
## Summary
- Fix 9 failing curl tests (45, 276, 498, 1073, 1141, 1241, 1245, 1246, 1290) related to HTTP redirect handling, URL parsing, protocol restrictions, and glob patterns
- **Relative redirect detection**: Only treat Location header as absolute URL if `://` appears in the scheme portion, not inside query strings (tests 45, 276)
- **Triple-slash redirects**: Normalize `http:///host` to `http://host` (test 1141)
- **`--path-as-is` with proxy**: Preserve dot segments in proxy absolute URLs (test 1241)
- **Cumulative header size limit**: Track accumulated response header size across redirect chains (6MB limit, error 56) and add per-header-line 100KB limit (test 498)
- **Chunked PUT + HTTP/1.0 redirect**: Return CURLE_UPLOAD_FAILED (25) when chunked upload cannot be re-sent over HTTP/1.0 (test 1073)
- **Fragment handling**: Treat `#` as authority terminator in URL credential extraction and host-override fallback (test 1246)
- **Glob patterns**: Empty brackets `[]` treated as literal; IPv6 addresses detected and not misinterpreted as glob ranges (tests 1290, 1056)
- **`--proto`/`--proto-redir`**: Properly parse `+all`/`-all` syntax and pass allowed protocols to library for redirect checking (test 1245)

## Test plan
- [x] `cargo fmt` -- no changes
- [x] `cargo clippy` -- no warnings
- [x] `cargo test` -- all ~2600 tests pass
- [x] 9 of 13 target curl tests now pass (was 0/12)
- [x] 37 previously-passing curl tests verified -- no regressions
- [ ] Remaining 4 tests (199, 257, 479, 1056) need deeper fixes: netrc re-lookup on redirect, -d+G multi-URL, IPv6 scope redirect