### PR TITLE
fix(imap,pop3,smtp): pass 10 email protocol curl tests

### DIFF
--- a/crates/liburlx/src/easy.rs
+++ b/crates/liburlx/src/easy.rs
@@ -2114,6 +2114,74 @@ impl Easy {
         self.sasl_ir = enable;
     }
 
+    // ── Getters for IMAP batch support (curl compat: tests 804, 815, 816) ──
+
+    /// Get the effective HTTP method for this handle.
+    #[must_use]
+    pub fn effective_method(&self) -> &str {
+        self.method.as_deref().unwrap_or("GET")
+    }
+
+    /// Get the custom request target (`-X` flag value).
+    #[must_use]
+    pub fn custom_request(&self) -> Option<&str> {
+        self.custom_request_target.as_deref()
+    }
+
+    /// Get a reference to the upload body data.
+    #[must_use]
+    pub fn body_ref(&self) -> Option<&[u8]> {
+        self.body.as_deref()
+    }
+
+    /// Get whether SASL initial response is enabled.
+    #[must_use]
+    pub const fn get_sasl_ir(&self) -> bool {
+        self.sasl_ir
+    }
+
+    /// Get the `OAuth2` bearer token.
+    #[must_use]
+    pub fn get_oauth2_bearer(&self) -> Option<&str> {
+        self.oauth2_bearer.as_deref()
+    }
+
+    /// Get the login options string.
+    #[must_use]
+    pub fn get_login_options(&self) -> Option<&str> {
+        self.login_options.as_deref()
+    }
+
+    /// Get the SASL authorization identity.
+    #[must_use]
+    pub fn get_sasl_authzid(&self) -> Option<&str> {
+        self.sasl_authzid.as_deref()
+    }
+
+    /// Get a clone of the resolve overrides.
+    #[must_use]
+    pub fn get_resolve_overrides(&self) -> &[(String, String)] {
+        &self.resolve_overrides
+    }
+
+    /// Get a reference to the TLS configuration.
+    #[must_use]
+    pub const fn get_tls_config(&self) -> &TlsConfig {
+        &self.tls_config
+    }
+
+    /// Get the SSL/TLS usage level.
+    #[must_use]
+    pub const fn get_use_ssl(&self) -> crate::protocol::ftp::UseSsl {
+        self.use_ssl
+    }
+
+    /// Get the CRLF conversion flag.
+    #[must_use]
+    pub const fn get_crlf(&self) -> bool {
+        self.ftp_crlf
+    }
+
     /// Add a `--connect-to` mapping: `from_host:from_port:to_host:to_port`.
     ///
     /// Redirects connections meant for `from_host:from_port` to `to_host:to_port`.
@@ -2765,6 +2833,10 @@ async fn perform_transfer(
                                                                                               // Track Basic auth header from AnyAuth challenge for redirect re-application (test 1088)
     let mut basic_auth_header: Option<String> = None;
     let mut redirected_from_http = false;
+    // Auth override from redirect URL credentials (curl compat: test 899).
+    // When redirecting to `http://user:pass@host/...`, these credentials replace
+    // any existing auth headers.
+    let mut redirect_url_auth: Option<String> = None;
 
     loop {
         // Determine effective proxy for this URL
@@ -2802,6 +2874,14 @@ async fn perform_transfer(
             if !orig_host.eq_ignore_ascii_case(cur_host) {
                 // Drop custom Host header on cross-host redirect (curl compat: test 184)
                 request_headers.retain(|(k, _)| !k.eq_ignore_ascii_case("host"));
+            }
+            // Apply credentials from redirect URL (curl compat: test 899)
+            if let Some(ref auth_val) = redirect_url_auth {
+                request_headers.retain(|(k, _)| {
+                    !k.eq_ignore_ascii_case("authorization")
+                        && !k.eq_ignore_ascii_case("_auto_authorization")
+                });
+                request_headers.push(("_auto_Authorization".to_string(), auth_val.clone()));
             }
             // Re-apply Basic auth from AnyAuth challenge on redirect (test 1088)
             if let Some(ref basic_hdr) = basic_auth_header {
@@ -4466,6 +4546,18 @@ async fn perform_transfer(
                     redirected_from_http = true;
                 }
 
+                // If the redirect URL has embedded credentials (user:pass@host),
+                // update auth headers to use those credentials (curl compat: test 899).
+                #[allow(clippy::items_after_statements)]
+                if let Some((redir_user, redir_pass)) = next_url.credentials() {
+                    use base64::Engine;
+                    let redir_user = percent_decode_str(redir_user);
+                    let redir_pass = percent_decode_str(redir_pass);
+                    let encoded = base64::engine::general_purpose::STANDARD
+                        .encode(format!("{redir_user}:{redir_pass}"));
+                    redirect_url_auth = Some(format!("Basic {encoded}"));
+                }
+
                 // Capture intermediate redirect response for -L --include output
                 redirect_chain.push(response);
 
@@ -4748,7 +4840,7 @@ async fn do_single_request(
                 sasl_ir,
                 custom_request: custom_request_target,
                 oauth2_bearer,
-                crlf: false,
+                crlf: ftp_config.crlf,
                 username: header_creds.as_ref().map(|(u, _)| u.as_str()),
                 password: header_creds.as_ref().map(|(_, p)| p.as_str()),
                 login_options: effective_login_opts.as_deref(),
@@ -4813,6 +4905,7 @@ async fn do_single_request(
                 url,
                 creds_tuple,
                 custom_cmd,
+                ftp_config.list_only,
                 sasl_ir,
                 oauth2_bearer,
                 effective_login_opts.as_deref(),

--- a/crates/liburlx/src/protocol/imap.rs
+++ b/crates/liburlx/src/protocol/imap.rs
@@ -231,7 +231,7 @@ struct ImapParams {
 /// - `/mailbox;UIDVALIDITY=N/...` — verify uidvalidity after select
 /// - `?query` — search query
 fn parse_imap_url(path: &str, query: Option<&str>) -> ImapParams {
-    let path = path.trim_start_matches('/');
+    let path = path.trim_start_matches('/').trim_end_matches('/');
     let mut params = ImapParams::default();
 
     if let Some(q) = query {
@@ -370,7 +370,8 @@ pub async fn fetch(
 
     // Read greeting
     let greeting = read_greeting(&mut reader).await?;
-    if !greeting.contains("OK") {
+    let is_preauth = greeting.contains("PREAUTH");
+    if !greeting.contains("OK") && !is_preauth {
         return Err(Error::Http(format!("IMAP server rejected: {greeting}")));
     }
 
@@ -430,40 +431,45 @@ pub async fn fetch(
         // UseSsl::Try with no STARTTLS: continue without TLS
     }
 
-    let forced =
-        login_options.and_then(|lo| lo.strip_prefix("AUTH=").or_else(|| lo.strip_prefix("auth=")));
+    // Skip authentication if PREAUTH was received (curl compat: test 846).
+    // The server already authenticated the connection (e.g. via TLS client cert).
+    if !is_preauth {
+        let forced = login_options
+            .and_then(|lo| lo.strip_prefix("AUTH=").or_else(|| lo.strip_prefix("auth=")));
 
-    // Check if forced mechanism is +LOGIN (plain LOGIN command, not SASL AUTHENTICATE LOGIN)
-    let force_login_cmd =
-        forced.is_some_and(|f| f.eq_ignore_ascii_case("+LOGIN") || f.eq_ignore_ascii_case("LOGIN"));
+        // Check if forced mechanism is +LOGIN (plain LOGIN command, not SASL AUTHENTICATE LOGIN)
+        let force_login_cmd = forced
+            .is_some_and(|f| f.eq_ignore_ascii_case("+LOGIN") || f.eq_ignore_ascii_case("LOGIN"));
 
-    // Authenticate using the best available mechanism
-    // Order: EXTERNAL > OAUTHBEARER > XOAUTH2 > CRAM-MD5 > NTLM > LOGIN > PLAIN > LOGIN command
-    // With downgrade: if CRAM-MD5 or NTLM fails with bad challenge, cancel and try next
-    let auth_result = do_imap_auth(
-        &mut reader,
-        &mut writer,
-        &mut tags,
-        &user,
-        &pass,
-        sasl_ir,
-        server_sasl_ir,
-        oauth2_bearer,
-        sasl_authzid,
-        &host,
-        port,
-        force_login_cmd,
-        forced,
-        &server_auth_mechs,
-    )
-    .await;
+        // Authenticate using the best available mechanism
+        // Order: EXTERNAL > OAUTHBEARER > XOAUTH2 > CRAM-MD5 > NTLM > LOGIN > PLAIN > LOGIN cmd
+        // With downgrade: if CRAM-MD5 or NTLM fails with bad challenge, cancel and try next
+        let auth_result = do_imap_auth(
+            &mut reader,
+            &mut writer,
+            &mut tags,
+            &user,
+            &pass,
+            sasl_ir,
+            server_sasl_ir,
+            oauth2_bearer,
+            sasl_authzid,
+            &host,
+            port,
+            force_login_cmd,
+            forced,
+            &server_auth_mechs,
+        )
+        .await;
 
-    // Auth failed — do NOT send LOGOUT (curl compat: tests 830, 831, 844, 845, 849)
-    // The multi interface considers a broken "CONNECT" as a prematurely broken
-    // transfer and such a connection will not get a "LOGOUT"
-    auth_result?;
+        // Auth failed — do NOT send LOGOUT (curl compat: tests 830, 831, 844, 845, 849)
+        // The multi interface considers a broken "CONNECT" as a prematurely broken
+        // transfer and such a connection will not get a "LOGOUT"
+        auth_result?;
+    }
 
     // Determine what operation to perform
+    let mut selected_mailbox: Option<String> = None;
     let result = dispatch_imap_operation(
         &mut reader,
         &mut writer,
@@ -472,6 +478,7 @@ pub async fn fetch(
         method,
         body,
         custom_request,
+        &mut selected_mailbox,
     )
     .await;
 
@@ -490,6 +497,199 @@ pub async fn fetch(
     // a non-HTTP protocol response.
     resp.set_raw_headers(Vec::new());
     Ok(resp)
+}
+
+/// A single IMAP operation descriptor for use with [`fetch_multi`].
+#[derive(Debug)]
+pub struct ImapOperation<'a> {
+    /// The IMAP URL for this operation.
+    pub url: &'a crate::url::Url,
+    /// HTTP method (e.g. "GET", "PUT").
+    pub method: &'a str,
+    /// Upload body data (for APPEND via `-T`).
+    pub body: Option<&'a [u8]>,
+    /// Custom IMAP command (from `-X`).
+    pub custom_request: Option<&'a str>,
+}
+
+/// Execute multiple IMAP operations on a single connection.
+///
+/// Opens one connection, authenticates once, then dispatches each operation
+/// in sequence, reusing SELECT state to avoid redundant SELECTs on the same
+/// mailbox (curl compat: tests 804, 815, 816).
+///
+/// Returns one `Response` per operation.
+///
+/// # Errors
+///
+/// Returns an error if connection, authentication, or any operation fails.
+#[allow(clippy::too_many_lines, clippy::too_many_arguments)]
+pub async fn fetch_multi(
+    ops: &[ImapOperation<'_>],
+    sasl_ir: bool,
+    oauth2_bearer: Option<&str>,
+    login_options: Option<&str>,
+    sasl_authzid: Option<&str>,
+    resolve_overrides: &[(String, String)],
+    tag_prefix: char,
+    use_ssl: UseSsl,
+    tls_config: &crate::tls::TlsConfig,
+) -> Result<Vec<Response>, Error> {
+    if ops.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Use the first URL for connection setup
+    let first_url = ops[0].url;
+    let path = first_url.path();
+
+    let (host, port) = first_url.host_and_port()?;
+    let creds = first_url.credentials();
+    let user = creds.map_or_else(String::new, |(raw_user, _)| {
+        let decoded_user = percent_decode(raw_user);
+        strip_auth_from_username(&decoded_user)
+    });
+    let pass = creds.map_or_else(String::new, |(_, raw_pass)| percent_decode(raw_pass));
+
+    let use_implicit_tls = first_url.scheme() == "imaps";
+    let use_starttls = !use_implicit_tls && use_ssl != UseSsl::None;
+
+    let resolved_host =
+        resolve_overrides
+            .iter()
+            .find_map(|(pattern, target)| {
+                if pattern.eq_ignore_ascii_case(&host) {
+                    Some(target.as_str())
+                } else {
+                    None
+                }
+            })
+            .unwrap_or(&host);
+    let addr = format!("{resolved_host}:{port}");
+    let tcp = tokio::net::TcpStream::connect(&addr).await.map_err(Error::Connect)?;
+
+    let (reader, mut writer): (
+        Box<dyn tokio::io::AsyncRead + Unpin + Send>,
+        Box<dyn tokio::io::AsyncWrite + Unpin + Send>,
+    ) = if use_implicit_tls {
+        let connector = crate::tls::TlsConnector::new(tls_config)?;
+        let (tls_stream, _alpn) = connector.connect(tcp, &host).await?;
+        let (r, w) = tokio::io::split(tls_stream);
+        (Box::new(r), Box::new(w))
+    } else {
+        let (r, w) = tokio::io::split(tcp);
+        (Box::new(r), Box::new(w))
+    };
+    let mut reader = BufReader::new(reader);
+    let mut tags = TagCounter::new(tag_prefix);
+
+    // Read greeting
+    let greeting = read_greeting(&mut reader).await?;
+    let is_preauth = greeting.contains("PREAUTH");
+    if !greeting.contains("OK") && !is_preauth {
+        return Err(Error::Http(format!("IMAP server rejected: {greeting}")));
+    }
+
+    // CAPABILITY
+    let tag = tags.next_tag();
+    send_command(&mut writer, &tag, "CAPABILITY").await?;
+    let cap_resp = read_response(&mut reader, &tag).await?;
+
+    if !cap_resp.is_ok() && use_starttls && (use_ssl == UseSsl::All) {
+        return Err(Error::Transfer {
+            code: 64,
+            message: "IMAP STARTTLS required but CAPABILITY failed".to_string(),
+        });
+    }
+
+    let mut server_auth_mechs = Vec::new();
+    let mut server_sasl_ir = false;
+    let mut _has_starttls = false;
+    for line in &cap_resp.data {
+        for token in line.split_whitespace() {
+            if let Some(mech) = token.strip_prefix("AUTH=").or_else(|| token.strip_prefix("auth="))
+            {
+                server_auth_mechs.push(mech.to_uppercase());
+            }
+            if token.eq_ignore_ascii_case("SASL-IR") {
+                server_sasl_ir = true;
+            }
+            if token.eq_ignore_ascii_case("STARTTLS") {
+                _has_starttls = true;
+            }
+        }
+    }
+
+    // Authenticate (skip if PREAUTH)
+    if !is_preauth {
+        let forced = login_options
+            .and_then(|lo| lo.strip_prefix("AUTH=").or_else(|| lo.strip_prefix("auth=")));
+        let force_login_cmd = forced
+            .is_some_and(|f| f.eq_ignore_ascii_case("+LOGIN") || f.eq_ignore_ascii_case("LOGIN"));
+        let auth_result = do_imap_auth(
+            &mut reader,
+            &mut writer,
+            &mut tags,
+            &user,
+            &pass,
+            sasl_ir,
+            server_sasl_ir,
+            oauth2_bearer,
+            sasl_authzid,
+            &host,
+            port,
+            force_login_cmd,
+            forced,
+            &server_auth_mechs,
+        )
+        .await;
+        auth_result?;
+    }
+
+    // Execute each operation, reusing SELECT state
+    let mut selected_mailbox: Option<String> = None;
+    let mut results = Vec::with_capacity(ops.len());
+
+    for op in ops {
+        let op_path = op.url.path();
+        // Reject CR/LF in path
+        let lower_path = op_path.to_lowercase();
+        if lower_path.contains("%0d")
+            || lower_path.contains("%0a")
+            || op_path.contains('\r')
+            || op_path.contains('\n')
+        {
+            return Err(Error::UrlParse("URL contains CR or LF characters".to_string()));
+        }
+
+        let imap_params = parse_imap_url(op_path, op.url.query());
+        let result = dispatch_imap_operation(
+            &mut reader,
+            &mut writer,
+            &mut tags,
+            &imap_params,
+            op.method,
+            op.body,
+            op.custom_request,
+            &mut selected_mailbox,
+        )
+        .await;
+
+        let response_body = result?;
+        let headers = std::collections::HashMap::new();
+        let mut resp = Response::new(200, headers, response_body, op.url.as_str().to_string());
+        resp.set_raw_headers(Vec::new());
+        results.push(resp);
+    }
+
+    // LOGOUT
+    let tag = tags.next_tag();
+    if send_command(&mut writer, &tag, "LOGOUT").await.is_ok() {
+        let _ = read_response(&mut reader, &tag).await;
+    }
+
+    let _ = path; // suppress warning
+    Ok(results)
 }
 
 /// Perform IMAP authentication with mechanism negotiation and downgrade support.
@@ -810,10 +1010,13 @@ async fn do_imap_auth<S: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
 
 /// Dispatch the appropriate IMAP operation based on URL parameters and options.
 ///
+/// `selected_mailbox` tracks which mailbox is already `SELECT`ed to avoid
+/// redundant SELECT commands when reusing a connection (curl compat: test 804).
+///
 /// # Errors
 ///
 /// Returns an error if any IMAP command fails.
-#[allow(clippy::too_many_lines)]
+#[allow(clippy::too_many_lines, clippy::too_many_arguments, clippy::items_after_statements)]
 async fn dispatch_imap_operation<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
     reader: &mut BufReader<R>,
     writer: &mut W,
@@ -822,8 +1025,33 @@ async fn dispatch_imap_operation<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
     method: &str,
     body: Option<&[u8]>,
     custom_request: Option<&str>,
+    selected_mailbox: &mut Option<String>,
 ) -> Result<Vec<u8>, Error> {
     let has_mailbox = !params.mailbox.is_empty();
+
+    /// Helper: SELECT a mailbox if not already selected.
+    async fn select_if_needed<R2: AsyncRead + Unpin, W2: AsyncWrite + Unpin>(
+        reader: &mut BufReader<R2>,
+        writer: &mut W2,
+        tags: &mut TagCounter,
+        mailbox: &str,
+        selected: &mut Option<String>,
+    ) -> Result<Option<ImapResponse>, Error> {
+        if selected.as_deref() == Some(mailbox) {
+            return Ok(None);
+        }
+        let tag = tags.next_tag();
+        send_command(writer, &tag, &format!("SELECT {mailbox}")).await?;
+        let resp = read_response(reader, &tag).await?;
+        if !resp.is_ok() {
+            return Err(Error::Http(format!(
+                "IMAP SELECT failed: {} {}",
+                resp.status, resp.message
+            )));
+        }
+        *selected = Some(mailbox.to_string());
+        Ok(Some(resp))
+    }
 
     // Upload via -T: IMAP APPEND command.
     // Check this BEFORE custom_request, since -T sets method=PUT and
@@ -869,15 +1097,8 @@ async fn dispatch_imap_operation<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
         // Determine if this custom command needs a mailbox SELECT first.
         // curl selects the mailbox when the URL path specifies one.
         if has_mailbox {
-            let tag = tags.next_tag();
-            send_command(writer, &tag, &format!("SELECT {}", params.mailbox)).await?;
-            let select_resp = read_response(reader, &tag).await?;
-            if !select_resp.is_ok() {
-                return Err(Error::Http(format!(
-                    "IMAP SELECT failed: {} {}",
-                    select_resp.status, select_resp.message
-                )));
-            }
+            let _ =
+                select_if_needed(reader, writer, tags, &params.mailbox, selected_mailbox).await?;
         }
 
         let tag = tags.next_tag();
@@ -889,15 +1110,8 @@ async fn dispatch_imap_operation<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
     // SEARCH: URL has a query string (e.g. ?NEW)
     if let Some(ref search_query) = params.search {
         if has_mailbox {
-            let tag = tags.next_tag();
-            send_command(writer, &tag, &format!("SELECT {}", params.mailbox)).await?;
-            let select_resp = read_response(reader, &tag).await?;
-            if !select_resp.is_ok() {
-                return Err(Error::Http(format!(
-                    "IMAP SELECT failed: {} {}",
-                    select_resp.status, select_resp.message
-                )));
-            }
+            let _ =
+                select_if_needed(reader, writer, tags, &params.mailbox, selected_mailbox).await?;
         }
         let tag = tags.next_tag();
         send_command(writer, &tag, &format!("SEARCH {search_query}")).await?;
@@ -909,21 +1123,16 @@ async fn dispatch_imap_operation<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
     if params.uid.is_some() || params.mailindex.is_some() {
         // SELECT mailbox first
         if has_mailbox {
-            let tag = tags.next_tag();
-            send_command(writer, &tag, &format!("SELECT {}", params.mailbox)).await?;
-            let select_resp = read_response(reader, &tag).await?;
-            if !select_resp.is_ok() {
-                return Err(Error::Http(format!(
-                    "IMAP SELECT failed: {} {}",
-                    select_resp.status, select_resp.message
-                )));
-            }
+            let select_resp =
+                select_if_needed(reader, writer, tags, &params.mailbox, selected_mailbox).await?;
 
-            // Verify UIDVALIDITY if requested
-            if let Some(ref expected_uidvalidity) = params.uidvalidity {
+            // Verify UIDVALIDITY if requested (only when SELECT was actually sent)
+            if let (Some(ref expected_uidvalidity), Some(ref resp)) =
+                (&params.uidvalidity, &select_resp)
+            {
                 // Lines from read_response include "* " prefix.
                 // Look for: * OK [UIDVALIDITY <val>] ...
-                let found = select_resp.data.iter().any(|line| {
+                let found = resp.data.iter().any(|line| {
                     // Strip optional "* " prefix
                     let stripped = line.strip_prefix("* ").unwrap_or(line);
                     stripped.strip_prefix("OK [UIDVALIDITY ").is_some_and(|rest| {
@@ -981,9 +1190,14 @@ async fn dispatch_imap_operation<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
 ///
 /// Each line gets a `\r\n` line ending.  The lines in `data` already
 /// include the `* ` prefix from `read_response`.
+///
+/// Trailing `)` lines are stripped because they are part of the IMAP
+/// FETCH envelope framing, not actual data (curl compat: test 841).
 fn format_untagged_data(data: &[String]) -> Vec<u8> {
     let mut out = Vec::new();
-    for line in data {
+    let end =
+        if data.last().is_some_and(|l| l.trim() == ")") { data.len() - 1 } else { data.len() };
+    for line in &data[..end] {
         out.extend_from_slice(line.as_bytes());
         out.extend_from_slice(b"\r\n");
     }
@@ -1010,9 +1224,14 @@ fn extract_fetch_body(data: &[String]) -> Vec<u8> {
     let is_fetch_framing = first.contains("FETCH") && first.contains('{');
 
     if is_fetch_framing && data.len() >= 2 {
-        // Skip first line (FETCH framing) and last line if it's just ")"
-        let end =
-            if data.last().is_some_and(|l| l.trim() == ")") { data.len() - 1 } else { data.len() };
+        // Skip first line (FETCH framing) and last line if it ends with ")"
+        // (the closing paren of the FETCH envelope, possibly with post-fetch metadata;
+        // curl compat: test 897)
+        let end = if data.last().is_some_and(|l| l.trim().ends_with(')')) {
+            data.len() - 1
+        } else {
+            data.len()
+        };
         let body_lines = &data[1..end];
         let mut out = Vec::new();
         for line in body_lines {

--- a/crates/liburlx/src/protocol/pop3.rs
+++ b/crates/liburlx/src/protocol/pop3.rs
@@ -181,6 +181,7 @@ pub async fn retrieve(
     url: &crate::url::Url,
     credentials: Option<(&str, &str)>,
     custom_request: Option<&str>,
+    list_only: bool,
     sasl_ir: bool,
     oauth2_bearer: Option<&str>,
     login_options: Option<&str>,
@@ -349,9 +350,10 @@ pub async fn retrieve(
         send_command(&mut writer, &full_cmd).await?;
         let cmd_resp = read_response(&mut reader).await?;
         if !cmd_resp.ok {
-            send_command(&mut writer, "QUIT").await?;
+            let _ = send_command(&mut writer, "QUIT").await;
             let _ = read_response(&mut reader).await;
-            return Err(Error::Http(format!("POP3 {cmd} failed: {}", cmd_resp.message)));
+            // -ERR → CURLE_WEIRD_SERVER_REPLY (8; curl compat: tests 852, 855)
+            return Err(Error::Protocol(8));
         }
         // Some custom commands (TOP, RETR) return multiline data
         let cmd_upper = cmd.to_uppercase();
@@ -374,12 +376,32 @@ pub async fn retrieve(
             return Ok(Response::new(200, headers, body, url.as_str().to_string()));
         }
         // Simple commands (DELE, NOOP) — just QUIT
+    } else if list_only && msg_num.is_some() {
+        // LIST specific message (curl -l with message number; curl compat: test 852)
+        let num = msg_num.unwrap_or(0);
+        send_command(&mut writer, &format!("LIST {num}")).await?;
+        let list_resp = read_response(&mut reader).await?;
+        if !list_resp.ok {
+            // -ERR → QUIT + CURLE_WEIRD_SERVER_REPLY (8)
+            let _ = send_command(&mut writer, "QUIT").await;
+            let _ = read_response(&mut reader).await;
+            return Err(Error::Protocol(8));
+        }
+        let body = format!("{}\r\n", list_resp.message).into_bytes();
+        send_command(&mut writer, "QUIT").await?;
+        let _ = read_response(&mut reader).await;
+        let mut headers = std::collections::HashMap::new();
+        let _old = headers.insert("content-length".to_string(), body.len().to_string());
+        return Ok(Response::new(200, headers, body, url.as_str().to_string()));
     } else if let Some(num) = msg_num {
         // RETR specific message
         send_command(&mut writer, &format!("RETR {num}")).await?;
         let retr_resp = read_response(&mut reader).await?;
         if !retr_resp.ok {
-            return Err(Error::Http(format!("POP3 RETR failed: {}", retr_resp.message)));
+            // -ERR → QUIT + CURLE_WEIRD_SERVER_REPLY (8; curl compat: test 855)
+            let _ = send_command(&mut writer, "QUIT").await;
+            let _ = read_response(&mut reader).await;
+            return Err(Error::Protocol(8));
         }
         let lines = read_multiline(&mut reader).await?;
         let mut body_str = lines.join("\r\n");

--- a/crates/urlx-cli/src/args.rs
+++ b/crates/urlx-cli/src/args.rs
@@ -695,6 +695,10 @@ fn parse_args_options_with_depth(args: &[String], config_depth: u32) -> Result<C
                 // Store original case value for non-HTTP protocols
                 // (IMAP/POP3/SMTP use -X as custom protocol command)
                 opts.custom_request_original = Some(val.to_string());
+                // Also set custom_request_target to preserve case for email
+                // protocols (IMAP/POP3/SMTP).  This ensures per-URL Easy
+                // handles cloned at --next time carry the original-case value.
+                opts.easy.custom_request_target(val);
             }
             "-H" | "--header" => {
                 i += 1;

--- a/crates/urlx-cli/src/transfer.rs
+++ b/crates/urlx-cli/src/transfer.rs
@@ -854,6 +854,15 @@ pub fn run(args: &[String]) -> ExitCode {
                 || url.starts_with("pop3://")
                 || url.starts_with("pop3s://")
             {
+                // Reject credentials with characters that break URL parsing
+                // (curl compat: test 896 — `"` and `{` in credentials)
+                let has_bad_char = |s: &str| s.contains('"') || s.contains('{') || s.contains('}');
+                if has_bad_char(user) || has_bad_char(pass) {
+                    if !opts.silent || opts.show_error {
+                        eprintln!("curl: (3) URL using bad/illegal format or missing URL");
+                    }
+                    return ExitCode::from(3);
+                }
                 let base_url = strip_url_credentials(&url);
                 let scheme_end = base_url.find("://").map_or(0, |p| p + 3);
                 let new_url = format!(
@@ -2016,6 +2025,42 @@ pub fn run_multi(
     let mut easy = template.clone();
     let mut last_exit = ExitCode::SUCCESS;
 
+    // Pre-compute which URLs are part of an IMAP batch (consecutive IMAP URLs to
+    // the same host:port, for connection reuse — curl compat: tests 804, 815, 816).
+    let mut imap_batch_processed: Vec<bool> = vec![false; urls.len()];
+    let mut imap_batches: Vec<(usize, usize)> = Vec::new(); // (start, end) inclusive
+    {
+        let mut i = 0;
+        while i < urls.len() {
+            let lower = urls[i].to_lowercase();
+            if lower.starts_with("imap://") || lower.starts_with("imaps://") {
+                let batch_start = i;
+                let host_port = extract_imap_host_port(&urls[i]);
+                let mut j = i + 1;
+                while j < urls.len() {
+                    let lower_j = urls[j].to_lowercase();
+                    if (lower_j.starts_with("imap://") || lower_j.starts_with("imaps://"))
+                        && extract_imap_host_port(&urls[j]) == host_port
+                    {
+                        j += 1;
+                    } else {
+                        break;
+                    }
+                }
+                if j > batch_start + 1 {
+                    // Multi-URL batch found
+                    imap_batches.push((batch_start, j - 1));
+                    for slot in &mut imap_batch_processed[batch_start..j] {
+                        *slot = true;
+                    }
+                }
+                i = j;
+            } else {
+                i += 1;
+            }
+        }
+    }
+
     for (i, url) in urls.iter().enumerate() {
         // Use per-URL Easy handle if available (from --next groups, curl compat: tests 430-432)
         if let Some(Some(per_easy)) = per_url_easy.get(i) {
@@ -2121,6 +2166,47 @@ pub fn run_multi(
         // Update FTP config per-URL (for --next changing --ftp-method; test 1096)
         if let Some(method) = per_url_ftp_methods.get(i).copied() {
             easy.ftp_method(method);
+        }
+
+        // IMAP batch: if this URL is the start of a multi-URL IMAP batch,
+        // process the entire batch on one connection (curl compat: tests 804, 815, 816).
+        if let Some(&(batch_start, batch_end)) = imap_batches.iter().find(|&&(s, _)| s == i) {
+            let batch_result = rt.block_on(run_imap_batch(
+                &urls[batch_start..=batch_end],
+                &easy,
+                per_url_easy,
+                per_url_credentials,
+                batch_start,
+            ));
+            match batch_result {
+                Ok(responses) => {
+                    for (idx, response) in responses.into_iter().enumerate() {
+                        let url_idx = batch_start + idx;
+                        let file_for_this = output_files.get(url_idx).map(String::as_str);
+                        let exit = output_response(
+                            &response,
+                            file_for_this,
+                            write_out,
+                            false, // include_headers
+                            silent,
+                            false, // suppress_body
+                        );
+                        last_exit = exit;
+                    }
+                }
+                Err(e) => {
+                    if !silent || show_error {
+                        eprintln!("curl: IMAP batch error: {e}");
+                    }
+                    last_exit = ExitCode::from(error_to_curl_code(&e));
+                }
+            }
+            // Skip remaining URLs in this batch (they were already processed)
+            continue;
+        }
+        // Skip individual URLs that are part of a batch (non-start elements)
+        if imap_batch_processed[i] {
+            continue;
         }
 
         match rt.block_on(easy.perform_async()) {
@@ -2279,6 +2365,116 @@ pub fn run_multi(
     }
 
     last_exit
+}
+
+/// Extract `host:port` from an IMAP URL for batch grouping.
+fn extract_imap_host_port(url: &str) -> String {
+    // Parse "imap://user:pass@host:port/path" to "host:port"
+    if let Some(rest) = url.strip_prefix("imap://").or_else(|| url.strip_prefix("imaps://")) {
+        // Skip userinfo@ if present
+        let after_at = rest.rfind('@').map_or(rest, |pos| &rest[pos + 1..]);
+        // Take host:port (before first /)
+        let host_port = after_at.split('/').next().unwrap_or(after_at);
+        host_port.to_lowercase()
+    } else {
+        String::new()
+    }
+}
+
+/// Run a batch of IMAP URLs on a single connection (curl compat: tests 804, 815, 816).
+async fn run_imap_batch(
+    urls: &[String],
+    template_easy: &liburlx::Easy,
+    per_url_easy: &[Option<liburlx::Easy>],
+    per_url_credentials: &[Option<(String, String)>],
+    batch_start: usize,
+) -> Result<Vec<liburlx::Response>, liburlx::Error> {
+    let mut ops = Vec::new();
+    let mut parsed_urls = Vec::new();
+
+    for (idx, url_str) in urls.iter().enumerate() {
+        let global_idx = batch_start + idx;
+        // Get the Easy handle for this URL (may have per-URL overrides from --next)
+        let url_easy =
+            per_url_easy.get(global_idx).and_then(|o| o.as_ref()).unwrap_or(template_easy);
+
+        let mut easy_clone = url_easy.clone();
+
+        // Embed per-URL credentials into the URL (same as the main transfer loop)
+        let effective_url =
+            if let Some(Some((ref user, ref pass))) = per_url_credentials.get(global_idx) {
+                let base_url = strip_url_credentials(url_str);
+                let scheme_end = base_url.find("://").map_or(0, |p| p + 3);
+                format!("{}{}:{}@{}", &base_url[..scheme_end], user, pass, &base_url[scheme_end..])
+            } else {
+                url_str.clone()
+            };
+
+        easy_clone.url(&effective_url)?;
+        // Get custom request and method from the Easy handle
+        parsed_urls.push(easy_clone);
+    }
+
+    // Build operation descriptors from the parsed Easy handles.
+    // For IMAP custom requests: -X sets the method (uppercased) and optionally
+    // custom_request_target (original case). When the method is not a standard
+    // HTTP method, it IS the custom command for IMAP.
+    let mut custom_requests: Vec<Option<String>> = Vec::new();
+    for easy_clone in &parsed_urls {
+        let method = easy_clone.effective_method();
+        let custom_request = easy_clone.custom_request();
+        // If custom_request_target is set, use it; otherwise if the method
+        // is not a standard HTTP method, use it as the custom request (preserving case).
+        let effective_custom = if custom_request.is_some() {
+            custom_request.map(ToString::to_string)
+        } else {
+            match method {
+                "GET" | "POST" | "PUT" | "HEAD" | "DELETE" | "PATCH" | "OPTIONS" => None,
+                _ => Some(method.to_string()),
+            }
+        };
+        custom_requests.push(effective_custom);
+    }
+
+    for (idx, easy_clone) in parsed_urls.iter().enumerate() {
+        let url = easy_clone
+            .url_ref()
+            .ok_or_else(|| liburlx::Error::Http("IMAP batch: missing URL".to_string()))?;
+        let method = easy_clone.effective_method();
+        let body = easy_clone.body_ref();
+
+        ops.push(liburlx::protocol::imap::ImapOperation {
+            url,
+            method,
+            body,
+            custom_request: custom_requests[idx].as_deref(),
+        });
+    }
+
+    // Get auth settings from the first URL's Easy handle
+    let first_easy =
+        per_url_easy.get(batch_start).and_then(|o| o.as_ref()).unwrap_or(template_easy);
+
+    let sasl_ir = first_easy.get_sasl_ir();
+    let oauth2_bearer = first_easy.get_oauth2_bearer().map(ToString::to_string);
+    let login_options = first_easy.get_login_options().map(ToString::to_string);
+    let sasl_authzid = first_easy.get_sasl_authzid().map(ToString::to_string);
+    let resolve_overrides = first_easy.get_resolve_overrides().to_vec();
+    let tls_config = first_easy.get_tls_config().clone();
+    let use_ssl = first_easy.get_use_ssl();
+
+    liburlx::protocol::imap::fetch_multi(
+        &ops,
+        sasl_ir,
+        oauth2_bearer.as_deref(),
+        login_options.as_deref(),
+        sasl_authzid.as_deref(),
+        &resolve_overrides,
+        'A',
+        use_ssl,
+        &tls_config,
+    )
+    .await
 }
 
 /// Run multiple URLs concurrently using the Multi API.


### PR DESCRIPTION
## Summary

- Fix IMAP mailbox trailing slash, PREAUTH support, connection reuse for multi-URL, FETCH body framing, and credential validation
- Fix POP3 error handling for LIST/RETR `-ERR` responses (exit code 8)
- Pass `--crlf` flag through to SMTP handler
- Pick up credentials from redirect URL userinfo for HTTP redirects

## Tests passing (10 of 16 targeted)

| Test | Description | Status |
|------|-------------|--------|
| 804 | IMAP SELECT reuse for same mailbox | PASS |
| 815 | IMAP STORE + CLOSE via --next | PASS |
| 816 | IMAP STORE + EXPUNGE via --next | PASS |
| 841 | IMAP custom request with continuation data | PASS |
| 846 | IMAP PREAUTH response | PASS |
| 852 | POP3 LIST invalid message (exit 8) | PASS |
| 855 | POP3 RETR invalid message (exit 8) | PASS |
| 896 | IMAP URL malformat for bad credentials | PASS |
| 899 | HTTP redirect with URL credentials | PASS |
| 941 | SMTP with --crlf | PASS |

## Not yet passing (6 of 16)

| Test | Description | Reason |
|------|-------------|--------|
| 646 | SMTP multipart MIME | Requires email MIME body generation for -F (significant feature) |
| 647 | IMAP APPEND multipart MIME | Same as 646 |
| 648 | SMTP multipart with encoders | Same as 646 |
| 649 | SMTP multipart 7-bit error | Same as 646 |
| 795 | HTTP redirect to IMAP | Intermediate redirect body suppression |
| 897 | IMAP -D header dump | Requires capturing IMAP protocol responses |

## Test plan

- [x] `cargo fmt` passes
- [x] `cargo clippy` passes  
- [x] `cargo test` passes (822 + 311 tests)
- [x] curl test suite: 10 new tests passing