### PR TITLE
docs: mark task 04 (email SASL auth) as complete

### DIFF
--- a/tasks/04-email-sasl-auth-completion.md
+++ b/tasks/04-email-sasl-auth-completion.md
@@ -1,5 +1,9 @@
 # Task 04: Complete Email SASL Authentication (IMAP, POP3, SMTP)
 
+## Status: COMPLETE
+
+All 37 tests pass as of 2026-03-19. This work was completed in PR #5 (`feat/email-sasl-auth-completion`, commit 29045c7).
+
 ## Summary
 While basic SASL mechanisms (PLAIN, LOGIN, CRAM-MD5, NTLM, EXTERNAL, XOAUTH2, OAUTHBEARER) are implemented, many SASL-related tests still fail due to edge cases: cancellation flows, --login-options forcing, --sasl-authzid, graceful downgrades, and specific mechanism ordering issues.
 


### PR DESCRIPTION
## Summary
- Mark task 04 (email SASL authentication) as complete — all 37 curl tests already pass on main
- This work was previously completed in PR #5 (`feat/email-sasl-auth-completion`, commit 29045c7)

## Verification

All 37 tests pass when run from a clean state:

```
TESTDONE: 37 tests were considered during 6 seconds.
TESTDONE: 37 tests out of 37 reported OK: 100%
```

**IMAP (14):** 779, 799, 827, 830, 831, 833, 834, 838, 839, 840, 844, 845, 848, 849
**POP3 (13):** 873, 876, 877, 879, 880, 884, 885, 886, 888, 889, 890, 892, 893
**SMTP (10):** 921, 932, 935, 936, 943, 944, 945, 948, 949, 992

Features covered:
- SASL cancellation (graceful `*` abort on invalid CRAM-MD5/NTLM challenges)
- `--login-options AUTH=` mechanism forcing
- `--sasl-authzid` for PLAIN auth
- SASL-IR (initial response) variants for EXTERNAL
- OAUTHBEARER with `--login-options`
- HTTP redirect to IMAP protocol (test 779)

## Test plan
- [x] All 37 curl tests pass
- [x] `cargo clippy` clean
- [x] `cargo test` passes (312 tests)