### PR TITLE
fix(cli): implement %{certs} write-out and fix local_ip on reused connections

### DIFF
--- a/crates/liburlx/src/easy.rs
+++ b/crates/liburlx/src/easy.rs
@@ -5284,7 +5284,21 @@ async fn do_single_request(
             .await;
 
             match result {
-                Ok((response, can_reuse)) => {
+                Ok((mut response, can_reuse)) => {
+                    // Populate connection address info from reused pooled stream
+                    // (curl compat: test 435 — local_ip/local_port on reused connections)
+                    {
+                        let mut info = response.transfer_info().clone();
+                        if let Some(local) = stream.local_addr() {
+                            info.local_ip = local.ip().to_string();
+                            info.local_port = local.port();
+                        }
+                        if let Some(peer) = stream.peer_addr() {
+                            info.remote_ip = peer.ip().to_string();
+                            info.remote_port = peer.port();
+                        }
+                        response.set_transfer_info(info);
+                    }
                     if can_reuse && !forbid_reuse {
                         pool.put(&host, port, is_tls, stream);
                     }
@@ -5778,6 +5792,17 @@ async fn do_single_request(
                 let (tls_stream, alpn) = tls.connect(tls_stream_inner, &host).await?;
                 let time_appconnect = request_start.elapsed();
 
+                // Capture TLS peer certificates for %{certs} write-out variable
+                #[cfg(feature = "rustls")]
+                let tls_certs_der: Vec<Vec<u8>> = tls_stream
+                    .get_ref()
+                    .1
+                    .peer_certificates()
+                    .map(|certs| certs.iter().map(|c| c.as_ref().to_vec()).collect())
+                    .unwrap_or_default();
+                #[cfg(not(feature = "rustls"))]
+                let tls_certs_der: Vec<Vec<u8>> = Vec::new();
+
                 let request_target = resolve_request_target(custom_request_target, url, path_as_is);
 
                 // Use HTTP/2 if ALPN negotiated it, unless user forced HTTP/1.x
@@ -5816,6 +5841,7 @@ async fn do_single_request(
                     info.time_appconnect = time_appconnect;
                     info.time_pretransfer = time_pretransfer;
                     info.time_starttransfer = time_starttransfer;
+                    info.certs_der.clone_from(&tls_certs_der);
                     resp.set_transfer_info(info);
                     return Ok(resp);
                 }
@@ -5856,6 +5882,7 @@ async fn do_single_request(
                 info.time_appconnect = time_appconnect;
                 info.time_pretransfer = time_pretransfer;
                 info.time_starttransfer = time_starttransfer;
+                info.certs_der = tls_certs_der;
                 resp.set_transfer_info(info);
                 resp
             }

--- a/crates/liburlx/src/pool.rs
+++ b/crates/liburlx/src/pool.rs
@@ -37,6 +37,30 @@ pub enum PooledStream {
     Unix(tokio::net::UnixStream),
 }
 
+impl PooledStream {
+    /// Get the local socket address of the underlying connection.
+    pub fn local_addr(&self) -> Option<std::net::SocketAddr> {
+        match self {
+            Self::Tcp(s) => s.local_addr().ok(),
+            #[cfg(feature = "rustls")]
+            Self::Tls(s) => s.get_ref().0.local_addr().ok(),
+            #[cfg(unix)]
+            Self::Unix(_) => None,
+        }
+    }
+
+    /// Get the peer socket address of the underlying connection.
+    pub fn peer_addr(&self) -> Option<std::net::SocketAddr> {
+        match self {
+            Self::Tcp(s) => s.peer_addr().ok(),
+            #[cfg(feature = "rustls")]
+            Self::Tls(s) => s.get_ref().0.peer_addr().ok(),
+            #[cfg(unix)]
+            Self::Unix(_) => None,
+        }
+    }
+}
+
 impl AsyncRead for PooledStream {
     fn poll_read(
         self: Pin<&mut Self>,

--- a/crates/liburlx/src/protocol/http/response.rs
+++ b/crates/liburlx/src/protocol/http/response.rs
@@ -81,6 +81,8 @@ pub struct TransferInfo {
     pub remote_ip: String,
     /// Remote port of the connection.
     pub remote_port: u16,
+    /// TLS peer certificate chain in DER-encoded format.
+    pub certs_der: Vec<Vec<u8>>,
 }
 
 /// An HTTP response with status, headers, and body.

--- a/crates/liburlx/tests/response_api_completeness.rs
+++ b/crates/liburlx/tests/response_api_completeness.rs
@@ -247,6 +247,7 @@ fn transfer_info_all_timing_fields() {
         local_port: 0,
         remote_ip: String::new(),
         remote_port: 0,
+        certs_der: Vec::new(),
     };
 
     assert_eq!(info.time_namelookup, Duration::from_millis(5));
@@ -316,6 +317,7 @@ fn transfer_info_clone_preserves_all_fields() {
         local_port: 0,
         remote_ip: String::new(),
         remote_port: 0,
+        certs_der: Vec::new(),
     };
     let cloned = info.clone();
     assert_eq!(cloned.time_namelookup, info.time_namelookup);

--- a/crates/urlx-cli/src/output.rs
+++ b/crates/urlx-cli/src/output.rs
@@ -640,6 +640,15 @@ pub fn format_write_out_with_context(
         result = result.replace("%{local_port}", &info.local_port.to_string());
     }
 
+    // %{certs}: TLS certificate chain in PEM format (curl compat: test 417)
+    if result.contains("%{certs}") {
+        let certs_pem = format_certs_pem(&info.certs_der);
+        #[allow(clippy::literal_string_with_formatting_args)]
+        {
+            result = result.replace("%{certs}", &certs_pem);
+        }
+    }
+
     // %{header_json}: format all response headers as a JSON object (curl compat: test 421)
     if result.contains("%{header_json}") {
         let json = format_header_json(response);
@@ -899,4 +908,50 @@ fn parse_url_components(
         query.to_string(),
         fragment.to_string(),
     )
+}
+
+/// Convert DER-encoded certificates to PEM format for `%{certs}`.
+///
+/// Each certificate is output as a PEM block with `-----BEGIN CERTIFICATE-----`
+/// and `-----END CERTIFICATE-----` markers, base64-encoded with 64-char line wrapping.
+fn format_certs_pem(certs_der: &[Vec<u8>]) -> String {
+    let mut result = String::new();
+    for cert in certs_der {
+        result.push_str("-----BEGIN CERTIFICATE-----\n");
+        let b64 = simple_base64_encode(cert);
+        // Wrap at 64 characters per line (PEM standard)
+        for chunk in b64.as_bytes().chunks(64) {
+            if let Ok(s) = std::str::from_utf8(chunk) {
+                result.push_str(s);
+            }
+            result.push('\n');
+        }
+        result.push_str("-----END CERTIFICATE-----\n");
+    }
+    result
+}
+
+/// Simple base64 encoder (no external dependency needed).
+fn simple_base64_encode(data: &[u8]) -> String {
+    const CHARS: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut result = String::with_capacity(data.len().div_ceil(3) * 4);
+    for chunk in data.chunks(3) {
+        let b0 = chunk[0] as u32;
+        let b1 = chunk.get(1).copied().unwrap_or(0) as u32;
+        let b2 = chunk.get(2).copied().unwrap_or(0) as u32;
+        let n = (b0 << 16) | (b1 << 8) | b2;
+        result.push(CHARS[((n >> 18) & 63) as usize] as char);
+        result.push(CHARS[((n >> 12) & 63) as usize] as char);
+        if chunk.len() > 1 {
+            result.push(CHARS[((n >> 6) & 63) as usize] as char);
+        } else {
+            result.push('=');
+        }
+        if chunk.len() > 2 {
+            result.push(CHARS[(n & 63) as usize] as char);
+        } else {
+            result.push('=');
+        }
+    }
+    result
 }


### PR DESCRIPTION
## Summary
- Implement `%{certs}` write-out variable that outputs the TLS peer certificate chain in PEM format (curl test 417)
- Fix empty `local_ip`/`local_port` on reused pooled HTTP connections (curl test 435)

## Changes
- **`crates/liburlx/src/pool.rs`**: Add `local_addr()` and `peer_addr()` methods to `PooledStream` to expose socket addresses from reused connections
- **`crates/liburlx/src/easy.rs`**: Capture TLS peer certificates after handshake; populate connection address info from reused pooled streams
- **`crates/liburlx/src/protocol/http/response.rs`**: Add `certs_der: Vec<Vec<u8>>` field to `TransferInfo` for DER-encoded certificate chain
- **`crates/urlx-cli/src/output.rs`**: Handle `%{certs}` variable in write-out formatting, converting DER certificates to PEM format

## Test plan
All 27 target tests from task 08 pass:
```
Test 417: TESTDONE: 1 tests out of 1 reported OK: 100%  (NEW - %{certs})
Test 421: TESTDONE: 1 tests out of 1 reported OK: 100%
Test 423: TESTDONE: 1 tests out of 1 reported OK: 100%
Test 424: TESTDONE: 1 tests out of 1 reported OK: 100%
Test 428: TESTDONE: 1 tests out of 1 reported OK: 100%
Test 429: TESTDONE: 1 tests out of 1 reported OK: 100%
Test 430: TESTDONE: 1 tests out of 1 reported OK: 100%
Test 431: TESTDONE: 1 tests out of 1 reported OK: 100%
Test 432: TESTDONE: 1 tests out of 1 reported OK: 100%
Test 433: TESTDONE: 1 tests out of 1 reported OK: 100%
Test 435: TESTDONE: 1 tests out of 1 reported OK: 100%  (NEW - local_ip fix)
Test 436: TESTDONE: 1 tests out of 1 reported OK: 100%
Test 448: TESTDONE: 1 tests out of 1 reported OK: 100%
Test 450: TESTDONE: 1 tests out of 1 reported OK: 100%
Test 451: TESTDONE: 1 tests out of 1 reported OK: 100%
Test 452: TESTDONE: 1 tests out of 1 reported OK: 100%
Test 453: TESTDONE: 1 tests out of 1 reported OK: 100%
Test 454: TESTDONE: 1 tests out of 1 reported OK: 100%
Test 455: TESTDONE: 1 tests out of 1 reported OK: 100%
Test 456: TESTDONE: 1 tests out of 1 reported OK: 100%
Test 458: TESTDONE: 1 tests out of 1 reported OK: 100%
Test 459: TESTDONE: 1 tests out of 1 reported OK: 100%
Test 462: TESTDONE: 1 tests out of 1 reported OK: 100%
Test 978: TESTDONE: 1 tests out of 1 reported OK: 100%
Test 1188: TESTDONE: 1 tests out of 1 reported OK: 100%
Test 1340: TESTDONE: 1 tests out of 1 reported OK: 100%
Test 1341: TESTDONE: 1 tests out of 1 reported OK: 100%
```

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets --all-features` clean
- [x] `cargo test` passes (312 tests)
- [x] `cargo test --all-features` passes
- [x] Pre-commit hooks pass (fmt, clippy, test, deny, doc)