### PR TITLE
fix(cookie): cookie/HSTS edge cases and proxy anyauth Basic

### DIFF
--- a/crates/liburlx/src/cookie.rs
+++ b/crates/liburlx/src/cookie.rs
@@ -607,6 +607,19 @@ impl CookieJar {
             path = path.trim_end_matches('/').to_string();
         }
 
+        // Secure cookie eviction protection (RFC 6265bis §5.4.6, curl compat: test 414).
+        // Non-secure origins cannot overwrite existing cookies that have the Secure flag.
+        // This prevents HTTP sites from evicting HTTPS-set secure cookies.
+        if !is_secure_origin {
+            let has_existing_secure = self
+                .cookies
+                .iter()
+                .any(|c| c.secure && c.name == name && domain_matches(&domain, &c.domain));
+            if has_existing_secure {
+                return;
+            }
+        }
+
         // Replace existing cookie with same name+domain+path.
         // Normalize paths by stripping trailing slashes for comparison (curl compat:
         // paths "/overwrite/" and "/overwrite" refer to the same cookie).

--- a/crates/liburlx/src/easy.rs
+++ b/crates/liburlx/src/easy.rs
@@ -4388,6 +4388,150 @@ async fn perform_transfer(
                                         .await?;
                                     }
                                 }
+                                Some(ProxyAuthMethod::Basic) => {
+                                    // Proxy selected Basic auth: retry with
+                                    // Proxy-Authorization: Basic base64(user:pass)
+                                    // Store cookies from the 407 response first so
+                                    // they are available for the retry (test 1331).
+                                    if let Some(ref mut jar) = cookie_jar {
+                                        let cookie_host = headers
+                                            .iter()
+                                            .find(|(k, _)| k.eq_ignore_ascii_case("host"))
+                                            .map_or_else(
+                                                || current_url.host_str().unwrap_or(""),
+                                                |(_, v)| v.split(':').next().unwrap_or(v),
+                                            );
+                                        let cpath = current_url.path();
+                                        let is_secure = current_url.scheme() == "https"
+                                            || cookie_host.eq_ignore_ascii_case("localhost");
+                                        jar.store_from_headers(
+                                            response.headers(),
+                                            cookie_host,
+                                            cpath,
+                                            is_secure,
+                                        );
+                                    }
+                                    let encoded = {
+                                        use base64::Engine;
+                                        base64::engine::general_purpose::STANDARD.encode(format!(
+                                            "{}:{}",
+                                            pcreds.username, pcreds.password
+                                        ))
+                                    };
+                                    let basic_value = format!("Basic {encoded}");
+                                    redirect_chain.push(response.clone());
+                                    let mut basic_headers = request_headers.clone();
+                                    basic_headers.retain(|(k, _)| {
+                                        !k.eq_ignore_ascii_case("proxy-authorization")
+                                    });
+                                    saved_proxy_auth = Some((
+                                        "Proxy-Authorization".to_string(),
+                                        basic_value.clone(),
+                                    ));
+                                    basic_headers
+                                        .push(("Proxy-Authorization".to_string(), basic_value));
+                                    // Add cookies from the jar (including those just
+                                    // stored from the 407 response) to the retry headers.
+                                    if let Some(ref jar) = cookie_jar {
+                                        let cookie_host = basic_headers
+                                            .iter()
+                                            .find(|(k, _)| k.eq_ignore_ascii_case("host"))
+                                            .map_or_else(
+                                                || current_url.host_str().unwrap_or(""),
+                                                |(_, v)| v.split(':').next().unwrap_or(v.as_str()),
+                                            );
+                                        let cpath = current_url.path();
+                                        let is_sec = current_url.scheme() == "https"
+                                            || cookie_host.eq_ignore_ascii_case("localhost");
+                                        if let Some(cookie_hdr) =
+                                            jar.cookie_header(cookie_host, cpath, is_sec)
+                                        {
+                                            if let Some(existing) = basic_headers
+                                                .iter_mut()
+                                                .find(|(k, _)| k.eq_ignore_ascii_case("cookie"))
+                                            {
+                                                existing.1 =
+                                                    format!("{}; {}", cookie_hdr, existing.1);
+                                            } else {
+                                                basic_headers
+                                                    .push(("Cookie".to_string(), cookie_hdr));
+                                            }
+                                        }
+                                    }
+                                    response = Box::pin(do_single_request(
+                                        &current_url,
+                                        &current_method,
+                                        &basic_headers,
+                                        current_body.as_deref(),
+                                        verbose,
+                                        accept_encoding,
+                                        connect_timeout,
+                                        effective_proxy,
+                                        proxy_credentials,
+                                        resolve_overrides,
+                                        tls_config,
+                                        tcp_nodelay,
+                                        tcp_keepalive,
+                                        unix_socket,
+                                        interface,
+                                        local_port,
+                                        dns_shuffle,
+                                        dns_cache,
+                                        pool,
+                                        #[cfg(feature = "http2")]
+                                        h2_pool,
+                                        http_version,
+                                        expect_100_timeout,
+                                        happy_eyeballs_timeout,
+                                        ignore_content_length,
+                                        speed_limits,
+                                        ftp_ssl_mode,
+                                        use_ssl,
+                                        ssh_key_path,
+                                        proxy_tls_config,
+                                        alt_svc_cache,
+                                        #[cfg(feature = "http2")]
+                                        h2_config,
+                                        dns_resolver,
+                                        custom_request_target,
+                                        tftp_blksize,
+                                        tftp_no_options,
+                                        #[cfg(feature = "ssh")]
+                                        ssh_host_key_policy,
+                                        mail_from,
+                                        mail_rcpt,
+                                        fresh_connect,
+                                        forbid_reuse,
+                                        ftp_config,
+                                        proxy_headers,
+                                        connect_to,
+                                        path_as_is,
+                                        #[cfg(feature = "ssh")]
+                                        ssh_public_keyfile,
+                                        #[cfg(not(feature = "ssh"))]
+                                        None,
+                                        #[cfg(feature = "ssh")]
+                                        ssh_auth_types,
+                                        #[cfg(not(feature = "ssh"))]
+                                        None,
+                                        mail_auth,
+                                        sasl_authzid,
+                                        login_options,
+                                        sasl_ir,
+                                        oauth2_bearer,
+                                        haproxy_protocol,
+                                        abstract_unix_socket,
+                                        chunked_upload,
+                                        http09_allowed,
+                                        deadline,
+                                        http_proxy_tunnel,
+                                        proxy_http_10,
+                                        raw,
+                                        ftp_session,
+                                        redirected_from_http,
+                                    ))
+                                    .await?;
+                                }
                                 _ => {}
                             }
                         }

--- a/crates/urlx-cli/src/transfer.rs
+++ b/crates/urlx-cli/src/transfer.rs
@@ -2426,13 +2426,21 @@ pub fn run_multi(
 
         match rt.block_on(easy.perform_async()) {
             Ok(response) => {
-                // Downgrade HTTP version if server responded with HTTP/1.0 (curl compat: test 1074).
-                // Subsequent requests on the same connection should use HTTP/1.0.
+                // Downgrade HTTP version if server responded with HTTP/1.0 AND the
+                // connection is being kept alive (curl compat: test 1074).
+                // Only downgrade when connection reuse is expected — if the server
+                // closes the connection, the next request creates a fresh connection
+                // which should use HTTP/1.1 (curl compat: test 1258).
                 if response.http_version()
                     == liburlx::protocol::http::response::ResponseHttpVersion::Http10
                 {
-                    easy.http_version(liburlx::HttpVersion::Http10);
-                    downgraded_http10 = true;
+                    let has_keepalive = response
+                        .header("connection")
+                        .is_some_and(|v| v.eq_ignore_ascii_case("keep-alive"));
+                    if has_keepalive {
+                        easy.http_version(liburlx::HttpVersion::Http10);
+                        downgraded_http10 = true;
+                    }
                 }
                 if fail_on_error && response.status() >= 400 {
                     let err_msg =


### PR DESCRIPTION
## Summary
- **Secure cookie eviction protection** (test 414): non-secure HTTP origins can no longer overwrite cookies that have the `Secure` flag, preventing cookie hijacking via HTTP→HTTPS redirect chains (RFC 6265bis §5.4.6)
- **HTTP/1.0 version downgrade scoping** (test 1258): only downgrade to HTTP/1.0 for subsequent requests when the server responded with `Connection: Keep-Alive` (connection reuse). New connections always use HTTP/1.1
- **Proxy anyauth Basic retry** (test 1331): when `--proxy-anyauth` selects Basic auth from a 407 response, retry the request with `Proxy-Authorization` and include cookies from the 407 response

## Test Results
All 19 curl tests from the task pass (with `-d` flag for C test servers):
```
327, 329, 331, 392, 414, 420, 427, 440, 441, 443, 444, 798, 898, 1151, 1160, 1218, 1228, 1258, 1331
```

Test 1074 (HTTP/1.0 downgrade with keep-alive) continues to pass — no regression.

```
TESTDONE: 21 tests out of 21 reported OK: 100%
```

## Test plan
- [x] All 19 target tests pass
- [x] Test 1074 (HTTP/1.0 downgrade) regression check passes
- [x] Tests 1-99 show no regressions (95/98 pass, 3 pre-existing failures)
- [x] `cargo fmt`, `cargo clippy`, `cargo test`, `cargo doc` all pass
- [x] Pre-commit hooks pass