### PR TITLE
fix(smtp,imap,pop3): implement STARTTLS upgrade for all protocols

### DIFF
--- a/crates/liburlx/src/protocol/imap.rs
+++ b/crates/liburlx/src/protocol/imap.rs
@@ -279,6 +279,59 @@ fn parse_imap_url(path: &str, query: Option<&str>) -> ImapParams {
     params
 }
 
+/// Perform the IMAP greeting and CAPABILITY exchange.
+///
+/// Returns `(is_preauth, auth_mechanisms, server_sasl_ir, has_starttls, cap_ok)`.
+///
+/// # Errors
+///
+/// Returns an error if the greeting is rejected.
+async fn imap_greeting_and_capability<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
+    reader: &mut BufReader<R>,
+    writer: &mut W,
+    tags: &mut TagCounter,
+) -> Result<(bool, Vec<String>, bool, bool, bool), Error> {
+    let greeting = read_greeting(reader).await?;
+    let is_preauth = greeting.contains("PREAUTH");
+    if !greeting.contains("OK") && !is_preauth {
+        return Err(Error::Http(format!("IMAP server rejected: {greeting}")));
+    }
+
+    let tag = tags.next_tag();
+    send_command(writer, &tag, "CAPABILITY").await?;
+    let cap_resp = read_response(reader, &tag).await?;
+
+    if !cap_resp.is_ok() {
+        // Return empty capabilities — caller checks cap_ok for error
+        return Ok((is_preauth, Vec::new(), false, false, false));
+    }
+
+    let (auth_mechs, sasl_ir) = parse_imap_capabilities(&cap_resp.data);
+    let has_starttls = cap_resp
+        .data
+        .iter()
+        .any(|line| line.split_whitespace().any(|t| t.eq_ignore_ascii_case("STARTTLS")));
+    Ok((is_preauth, auth_mechs, sasl_ir, has_starttls, true))
+}
+
+/// Parse AUTH mechanisms and SASL-IR from CAPABILITY response data.
+fn parse_imap_capabilities(data: &[String]) -> (Vec<String>, bool) {
+    let mut auth_mechs = Vec::new();
+    let mut sasl_ir = false;
+    for line in data {
+        for token in line.split_whitespace() {
+            if let Some(mech) = token.strip_prefix("AUTH=").or_else(|| token.strip_prefix("auth="))
+            {
+                auth_mechs.push(mech.to_uppercase());
+            }
+            if token.eq_ignore_ascii_case("SASL-IR") {
+                sasl_ir = true;
+            }
+        }
+    }
+    (auth_mechs, sasl_ir)
+}
+
 /// Execute an IMAP operation based on URL and options.
 ///
 /// URL format: `imap://user:pass@host:port/mailbox/;UID=N`
@@ -352,84 +405,79 @@ pub async fn fetch(
             .unwrap_or(&host);
     let addr = format!("{resolved_host}:{port}");
     let tcp = tokio::net::TcpStream::connect(&addr).await.map_err(Error::Connect)?;
+    let mut tags = TagCounter::new(tag_prefix);
 
-    let (reader, mut writer): (
-        Box<dyn tokio::io::AsyncRead + Unpin + Send>,
+    // Establish connection with appropriate TLS mode.
+    // For STARTTLS, we use concrete types for the initial negotiation
+    // (greeting, CAPABILITY, STARTTLS command), then unsplit → TLS handshake
+    // → re-split into type-erased boxed streams for the rest of the protocol.
+    #[allow(clippy::type_complexity)]
+    let (mut reader, mut writer, server_auth_mechs, server_sasl_ir, is_preauth): (
+        BufReader<Box<dyn tokio::io::AsyncRead + Unpin + Send>>,
         Box<dyn tokio::io::AsyncWrite + Unpin + Send>,
+        Vec<String>,
+        bool,
+        bool,
     ) = if use_implicit_tls {
         let connector = crate::tls::TlsConnector::new(tls_config)?;
         let (tls_stream, _alpn) = connector.connect(tcp, &host).await?;
         let (r, w) = tokio::io::split(tls_stream);
-        (Box::new(r), Box::new(w))
+        let mut rd = BufReader::new(Box::new(r) as Box<dyn tokio::io::AsyncRead + Unpin + Send>);
+        let mut wr: Box<dyn tokio::io::AsyncWrite + Unpin + Send> = Box::new(w);
+        let (is_preauth, auth_mechs, sasl_ir, _has_starttls, _cap_ok) =
+            imap_greeting_and_capability(&mut rd, &mut wr, &mut tags).await?;
+        (rd, wr, auth_mechs, sasl_ir, is_preauth)
     } else {
         let (r, w) = tokio::io::split(tcp);
-        (Box::new(r), Box::new(w))
-    };
-    let mut reader = BufReader::new(reader);
-    let mut tags = TagCounter::new(tag_prefix);
+        let mut plain_reader = BufReader::new(r);
+        let mut plain_writer = w;
+        let (is_preauth, auth_mechs, sasl_ir, has_starttls, cap_ok) =
+            imap_greeting_and_capability(&mut plain_reader, &mut plain_writer, &mut tags).await?;
 
-    // Read greeting
-    let greeting = read_greeting(&mut reader).await?;
-    let is_preauth = greeting.contains("PREAUTH");
-    if !greeting.contains("OK") && !is_preauth {
-        return Err(Error::Http(format!("IMAP server rejected: {greeting}")));
-    }
-
-    // CAPABILITY
-    let tag = tags.next_tag();
-    send_command(&mut writer, &tag, "CAPABILITY").await?;
-    let cap_resp = read_response(&mut reader, &tag).await?;
-
-    // If CAPABILITY itself failed and STARTTLS is required, error out
-    if !cap_resp.is_ok() && use_starttls && (use_ssl == UseSsl::All) {
-        return Err(Error::Transfer {
-            code: 64,
-            message: "IMAP STARTTLS required but CAPABILITY failed".to_string(),
-        });
-    }
-
-    // Parse AUTH mechanisms and STARTTLS from CAPABILITY
-    let mut server_auth_mechs = Vec::new();
-    let mut server_sasl_ir = false;
-    let mut has_starttls = false;
-    for line in &cap_resp.data {
-        for token in line.split_whitespace() {
-            if let Some(mech) = token.strip_prefix("AUTH=").or_else(|| token.strip_prefix("auth="))
-            {
-                server_auth_mechs.push(mech.to_uppercase());
-            }
-            if token.eq_ignore_ascii_case("SASL-IR") {
-                server_sasl_ir = true;
-            }
-            if token.eq_ignore_ascii_case("STARTTLS") {
-                has_starttls = true;
-            }
+        // CAPABILITY failed and STARTTLS required → error immediately (no LOGOUT)
+        if !cap_ok && use_starttls && use_ssl == UseSsl::All {
+            return Err(Error::Transfer {
+                code: 64,
+                message: "IMAP STARTTLS required but CAPABILITY failed".to_string(),
+            });
         }
-    }
 
-    // STARTTLS: upgrade plain connection to TLS if requested
-    if use_starttls && cap_resp.is_ok() {
-        if has_starttls {
-            // Server advertises STARTTLS — send the command
+        if use_starttls && has_starttls {
             let tag = tags.next_tag();
-            send_command(&mut writer, &tag, "STARTTLS").await?;
-            let starttls_resp = read_response(&mut reader, &tag).await?;
+            send_command(&mut plain_writer, &tag, "STARTTLS").await?;
+            let starttls_resp = read_response(&mut plain_reader, &tag).await?;
             if !starttls_resp.is_ok() {
-                // Server rejected STARTTLS — return CURLE_WEIRD_SERVER_REPLY (8)
                 return Err(Error::Protocol(8));
             }
-            // TLS handshake would happen here for full implementation
-        } else if use_ssl == UseSsl::All {
-            // STARTTLS not advertised but required
+            // Reassemble TCP stream and upgrade to TLS
+            let tcp_restored = plain_reader.into_inner().unsplit(plain_writer);
+            let connector = crate::tls::TlsConnector::new_no_alpn(tls_config)?;
+            let (tls_stream, _) = connector.connect(tcp_restored, &host).await?;
+            let (r, w) = tokio::io::split(tls_stream);
+            let mut rd =
+                BufReader::new(Box::new(r) as Box<dyn tokio::io::AsyncRead + Unpin + Send>);
+            let mut wr: Box<dyn tokio::io::AsyncWrite + Unpin + Send> = Box::new(w);
+            // Re-CAPABILITY over TLS (RFC 2595 Section 3.1)
+            let tag = tags.next_tag();
+            send_command(&mut wr, &tag, "CAPABILITY").await?;
+            let cap2 = read_response(&mut rd, &tag).await?;
+            let (auth_mechs2, sasl_ir2) = parse_imap_capabilities(&cap2.data);
+            (rd, wr, auth_mechs2, sasl_ir2, is_preauth)
+        } else if use_starttls && use_ssl == UseSsl::All && !has_starttls {
             let ltag = tags.next_tag();
-            let _ = send_command(&mut writer, &ltag, "LOGOUT").await;
+            let _ = send_command(&mut plain_writer, &ltag, "LOGOUT").await;
             return Err(Error::Transfer {
                 code: 64,
                 message: "IMAP STARTTLS required but not advertised".to_string(),
             });
+        } else {
+            let rd =
+                BufReader::new(Box::new(plain_reader.into_inner())
+                    as Box<dyn tokio::io::AsyncRead + Unpin + Send>);
+            let wr: Box<dyn tokio::io::AsyncWrite + Unpin + Send> = Box::new(plain_writer);
+            (rd, wr, auth_mechs, sasl_ir, is_preauth)
         }
-        // UseSsl::Try with no STARTTLS: continue without TLS
-    }
+    };
 
     // Skip authentication if PREAUTH was received (curl compat: test 846).
     // The server already authenticated the connection (e.g. via TLS client cert).
@@ -567,58 +615,73 @@ pub async fn fetch_multi(
             .unwrap_or(&host);
     let addr = format!("{resolved_host}:{port}");
     let tcp = tokio::net::TcpStream::connect(&addr).await.map_err(Error::Connect)?;
+    let mut tags = TagCounter::new(tag_prefix);
 
-    let (reader, mut writer): (
-        Box<dyn tokio::io::AsyncRead + Unpin + Send>,
+    // Same STARTTLS setup as fetch()
+    #[allow(clippy::type_complexity)]
+    let (mut reader, mut writer, server_auth_mechs, server_sasl_ir, is_preauth): (
+        BufReader<Box<dyn tokio::io::AsyncRead + Unpin + Send>>,
         Box<dyn tokio::io::AsyncWrite + Unpin + Send>,
+        Vec<String>,
+        bool,
+        bool,
     ) = if use_implicit_tls {
         let connector = crate::tls::TlsConnector::new(tls_config)?;
         let (tls_stream, _alpn) = connector.connect(tcp, &host).await?;
         let (r, w) = tokio::io::split(tls_stream);
-        (Box::new(r), Box::new(w))
+        let mut rd = BufReader::new(Box::new(r) as Box<dyn tokio::io::AsyncRead + Unpin + Send>);
+        let mut wr: Box<dyn tokio::io::AsyncWrite + Unpin + Send> = Box::new(w);
+        let (is_preauth, auth_mechs, sasl_ir, _has_starttls, _cap_ok) =
+            imap_greeting_and_capability(&mut rd, &mut wr, &mut tags).await?;
+        (rd, wr, auth_mechs, sasl_ir, is_preauth)
     } else {
         let (r, w) = tokio::io::split(tcp);
-        (Box::new(r), Box::new(w))
-    };
-    let mut reader = BufReader::new(reader);
-    let mut tags = TagCounter::new(tag_prefix);
+        let mut plain_reader = BufReader::new(r);
+        let mut plain_writer = w;
+        let (is_preauth, auth_mechs, sasl_ir, has_starttls, cap_ok) =
+            imap_greeting_and_capability(&mut plain_reader, &mut plain_writer, &mut tags).await?;
 
-    // Read greeting
-    let greeting = read_greeting(&mut reader).await?;
-    let is_preauth = greeting.contains("PREAUTH");
-    if !greeting.contains("OK") && !is_preauth {
-        return Err(Error::Http(format!("IMAP server rejected: {greeting}")));
-    }
-
-    // CAPABILITY
-    let tag = tags.next_tag();
-    send_command(&mut writer, &tag, "CAPABILITY").await?;
-    let cap_resp = read_response(&mut reader, &tag).await?;
-
-    if !cap_resp.is_ok() && use_starttls && (use_ssl == UseSsl::All) {
-        return Err(Error::Transfer {
-            code: 64,
-            message: "IMAP STARTTLS required but CAPABILITY failed".to_string(),
-        });
-    }
-
-    let mut server_auth_mechs = Vec::new();
-    let mut server_sasl_ir = false;
-    let mut _has_starttls = false;
-    for line in &cap_resp.data {
-        for token in line.split_whitespace() {
-            if let Some(mech) = token.strip_prefix("AUTH=").or_else(|| token.strip_prefix("auth="))
-            {
-                server_auth_mechs.push(mech.to_uppercase());
-            }
-            if token.eq_ignore_ascii_case("SASL-IR") {
-                server_sasl_ir = true;
-            }
-            if token.eq_ignore_ascii_case("STARTTLS") {
-                _has_starttls = true;
-            }
+        if !cap_ok && use_starttls && use_ssl == UseSsl::All {
+            return Err(Error::Transfer {
+                code: 64,
+                message: "IMAP STARTTLS required but CAPABILITY failed".to_string(),
+            });
         }
-    }
+
+        if use_starttls && has_starttls {
+            let tag = tags.next_tag();
+            send_command(&mut plain_writer, &tag, "STARTTLS").await?;
+            let starttls_resp = read_response(&mut plain_reader, &tag).await?;
+            if !starttls_resp.is_ok() {
+                return Err(Error::Protocol(8));
+            }
+            let tcp_restored = plain_reader.into_inner().unsplit(plain_writer);
+            let connector = crate::tls::TlsConnector::new_no_alpn(tls_config)?;
+            let (tls_stream, _) = connector.connect(tcp_restored, &host).await?;
+            let (r, w) = tokio::io::split(tls_stream);
+            let mut rd =
+                BufReader::new(Box::new(r) as Box<dyn tokio::io::AsyncRead + Unpin + Send>);
+            let mut wr: Box<dyn tokio::io::AsyncWrite + Unpin + Send> = Box::new(w);
+            let tag = tags.next_tag();
+            send_command(&mut wr, &tag, "CAPABILITY").await?;
+            let cap2 = read_response(&mut rd, &tag).await?;
+            let (auth_mechs2, sasl_ir2) = parse_imap_capabilities(&cap2.data);
+            (rd, wr, auth_mechs2, sasl_ir2, is_preauth)
+        } else if use_starttls && use_ssl == UseSsl::All && !has_starttls {
+            let ltag = tags.next_tag();
+            let _ = send_command(&mut plain_writer, &ltag, "LOGOUT").await;
+            return Err(Error::Transfer {
+                code: 64,
+                message: "IMAP STARTTLS required but not advertised".to_string(),
+            });
+        } else {
+            let rd =
+                BufReader::new(Box::new(plain_reader.into_inner())
+                    as Box<dyn tokio::io::AsyncRead + Unpin + Send>);
+            let wr: Box<dyn tokio::io::AsyncWrite + Unpin + Send> = Box::new(plain_writer);
+            (rd, wr, auth_mechs, sasl_ir, is_preauth)
+        }
+    };
 
     // Authenticate (skip if PREAUTH)
     if !is_preauth {

--- a/crates/liburlx/src/protocol/pop3.rs
+++ b/crates/liburlx/src/protocol/pop3.rs
@@ -166,6 +166,57 @@ async fn read_continuation<S: AsyncRead + Unpin>(
     Ok(line.trim().to_string())
 }
 
+/// Perform the POP3 greeting and CAPA exchange.
+///
+/// Returns `(apop_timestamp, sasl_mechanisms, has_apop, has_stls, capa_ok)`.
+///
+/// # Errors
+///
+/// Returns an error if the greeting is rejected.
+async fn pop3_greeting_and_capa<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
+    reader: &mut BufReader<R>,
+    writer: &mut W,
+) -> Result<(Option<String>, Vec<String>, bool, bool, bool), Error> {
+    let greeting = read_greeting(reader).await?;
+    if !greeting.ok {
+        return Err(Error::Http(format!("POP3 server rejected: {}", greeting.message)));
+    }
+
+    let apop_timestamp = extract_apop_timestamp(&greeting.message);
+
+    send_command(writer, "CAPA").await?;
+    let capa_resp = read_response(reader).await?;
+
+    if !capa_resp.ok {
+        return Ok((apop_timestamp, Vec::new(), false, false, false));
+    }
+
+    let capa_lines = read_multiline(reader).await?;
+    let (sasl_mechs, has_apop) = parse_pop3_capabilities(&capa_lines);
+    let has_stls = capa_lines
+        .iter()
+        .any(|l| l.to_uppercase() == "STLS" || l.to_uppercase().starts_with("STLS "));
+    Ok((apop_timestamp, sasl_mechs, has_apop, has_stls, true))
+}
+
+/// Parse POP3 CAPA response lines into SASL mechanisms and APOP flag.
+fn parse_pop3_capabilities(lines: &[String]) -> (Vec<String>, bool) {
+    let mut sasl_mechs = Vec::new();
+    let mut has_apop = false;
+    for line in lines {
+        let upper = line.to_uppercase();
+        if upper.starts_with("SASL") {
+            for mech in upper.split_whitespace().skip(1) {
+                sasl_mechs.push(mech.to_string());
+            }
+        }
+        if upper == "APOP" || upper.starts_with("APOP ") {
+            has_apop = true;
+        }
+    }
+    (sasl_mechs, has_apop)
+}
+
 /// Retrieve email from a POP3 server.
 ///
 /// URL format: `pop3://user:pass@host:port/N`
@@ -223,83 +274,81 @@ pub async fn retrieve(
     let addr = format!("{host}:{port}");
     let tcp = tokio::net::TcpStream::connect(&addr).await.map_err(Error::Connect)?;
 
-    let (reader, mut writer): (
-        Box<dyn tokio::io::AsyncRead + Unpin + Send>,
+    // Establish connection with appropriate TLS mode.
+    // For STLS (POP3's STARTTLS), we use concrete types for the initial
+    // negotiation (greeting, CAPA, STLS command), then unsplit → TLS handshake
+    // → re-split into type-erased boxed streams for the rest of the protocol.
+    #[allow(clippy::type_complexity)]
+    let (mut reader, mut writer, apop_timestamp, server_sasl_mechs, server_has_apop): (
+        BufReader<Box<dyn tokio::io::AsyncRead + Unpin + Send>>,
         Box<dyn tokio::io::AsyncWrite + Unpin + Send>,
+        Option<String>,
+        Vec<String>,
+        bool,
     ) = if use_implicit_tls {
         let connector = crate::tls::TlsConnector::new(tls_config)?;
         let (tls_stream, _alpn) = connector.connect(tcp, &host).await?;
         let (r, w) = tokio::io::split(tls_stream);
-        (Box::new(r), Box::new(w))
+        let mut rd = BufReader::new(Box::new(r) as Box<dyn tokio::io::AsyncRead + Unpin + Send>);
+        let mut wr: Box<dyn tokio::io::AsyncWrite + Unpin + Send> = Box::new(w);
+        let (apop_ts, sasl_mechs, has_apop, _has_stls, _capa_ok) =
+            pop3_greeting_and_capa(&mut rd, &mut wr).await?;
+        (rd, wr, apop_ts, sasl_mechs, has_apop)
     } else {
+        // Plain connection — use concrete types so we can unsplit for STLS
         let (r, w) = tokio::io::split(tcp);
-        (Box::new(r), Box::new(w))
-    };
-    let mut reader = BufReader::new(reader);
+        let mut plain_reader = BufReader::new(r);
+        let mut plain_writer = w;
+        let (apop_ts, sasl_mechs, has_apop, has_stls, capa_ok) =
+            pop3_greeting_and_capa(&mut plain_reader, &mut plain_writer).await?;
 
-    // Read greeting — skip banner lines until we find +OK or -ERR
-    let greeting = read_greeting(&mut reader).await?;
-    if !greeting.ok {
-        return Err(Error::Http(format!("POP3 server rejected: {}", greeting.message)));
-    }
-
-    // Extract APOP timestamp from greeting if present (e.g. "<1972.987654321@curl>")
-    let apop_timestamp = extract_apop_timestamp(&greeting.message);
-
-    // CAPA (curl always sends this before auth)
-    send_command(&mut writer, "CAPA").await?;
-    let capa_resp = read_response(&mut reader).await?;
-    let mut server_sasl_mechs = Vec::new();
-    let mut server_has_apop = false;
-    let mut server_has_stls = false;
-
-    // If CAPA failed and STARTTLS is required, error out immediately
-    if !capa_resp.ok && use_starttls && (use_ssl == UseSsl::All) {
-        return Err(Error::Transfer {
-            code: 64,
-            message: "POP3 STLS required but CAPA failed".to_string(),
-        });
-    }
-
-    if capa_resp.ok {
-        let capa_lines = read_multiline(&mut reader).await?;
-        for line in &capa_lines {
-            let upper = line.to_uppercase();
-            if upper.starts_with("SASL") {
-                for mech in upper.split_whitespace().skip(1) {
-                    server_sasl_mechs.push(mech.to_string());
-                }
-            }
-            if upper == "APOP" || upper.starts_with("APOP ") {
-                server_has_apop = true;
-            }
-            if upper == "STLS" || upper.starts_with("STLS ") {
-                server_has_stls = true;
-            }
+        // CAPA failed and STLS required → error immediately (no QUIT)
+        if !capa_ok && use_starttls && use_ssl == UseSsl::All {
+            return Err(Error::Transfer {
+                code: 64,
+                message: "POP3 STLS required but CAPA failed".to_string(),
+            });
         }
-    }
 
-    // STLS: upgrade plain connection to TLS if requested
-    if use_starttls {
-        if server_has_stls {
-            // Server advertises STLS — send the command
-            send_command(&mut writer, "STLS").await?;
-            let stls_resp = read_response(&mut reader).await?;
+        if use_starttls && has_stls {
+            send_command(&mut plain_writer, "STLS").await?;
+            let stls_resp = read_response(&mut plain_reader).await?;
             if !stls_resp.ok {
-                // Server rejected STLS — return CURLE_WEIRD_SERVER_REPLY (8)
                 return Err(Error::Protocol(8));
             }
-            // TLS handshake would happen here for full implementation
-        } else if use_ssl == UseSsl::All {
-            // STLS not advertised but required
-            let _ = send_command(&mut writer, "QUIT").await;
+            // Reassemble TCP stream and upgrade to TLS
+            let tcp_restored = plain_reader.into_inner().unsplit(plain_writer);
+            let connector = crate::tls::TlsConnector::new_no_alpn(tls_config)?;
+            let (tls_stream, _) = connector.connect(tcp_restored, &host).await?;
+            let (r, w) = tokio::io::split(tls_stream);
+            let mut rd =
+                BufReader::new(Box::new(r) as Box<dyn tokio::io::AsyncRead + Unpin + Send>);
+            let mut wr: Box<dyn tokio::io::AsyncWrite + Unpin + Send> = Box::new(w);
+            // Re-CAPA over TLS (RFC 2595)
+            send_command(&mut wr, "CAPA").await?;
+            let capa2 = read_response(&mut rd).await?;
+            let (sasl2, apop2) = if capa2.ok {
+                let lines = read_multiline(&mut rd).await?;
+                parse_pop3_capabilities(&lines)
+            } else {
+                (Vec::new(), false)
+            };
+            (rd, wr, apop_ts, sasl2, apop2)
+        } else if use_starttls && use_ssl == UseSsl::All && !has_stls {
+            let _ = send_command(&mut plain_writer, "QUIT").await;
             return Err(Error::Transfer {
                 code: 64,
                 message: "POP3 STLS required but not advertised".to_string(),
             });
+        } else {
+            // No TLS upgrade — box the plain streams
+            let rd =
+                BufReader::new(Box::new(plain_reader.into_inner())
+                    as Box<dyn tokio::io::AsyncRead + Unpin + Send>);
+            let wr: Box<dyn tokio::io::AsyncWrite + Unpin + Send> = Box::new(plain_writer);
+            (rd, wr, apop_ts, sasl_mechs, has_apop)
         }
-        // UseSsl::Try with no STLS: continue without TLS
-    }
+    };
 
     let forced =
         login_options.and_then(|lo| lo.strip_prefix("AUTH=").or_else(|| lo.strip_prefix("auth=")));

--- a/crates/liburlx/src/protocol/smtp.rs
+++ b/crates/liburlx/src/protocol/smtp.rs
@@ -203,6 +203,46 @@ enum SmtpMode {
     Help,
 }
 
+/// Perform the SMTP greeting and EHLO/HELO exchange.
+///
+/// Reads the server greeting, sends EHLO (with HELO fallback), and returns
+/// whether EHLO succeeded along with parsed capabilities.
+///
+/// # Errors
+///
+/// Returns an error if the greeting is rejected or HELO fails.
+async fn smtp_greeting_and_ehlo<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
+    reader: &mut BufReader<R>,
+    writer: &mut W,
+    ehlo_name: &str,
+) -> Result<(bool, EhloCapabilities), Error> {
+    let greeting = read_response(reader).await?;
+    if !greeting.is_ok() {
+        return Err(Error::Http(format!(
+            "SMTP server rejected connection: {} {}",
+            greeting.code, greeting.message
+        )));
+    }
+
+    send_command(writer, &format!("EHLO {ehlo_name}")).await?;
+    let ehlo_resp = read_response(reader).await?;
+
+    if ehlo_resp.is_ok() {
+        Ok((true, parse_ehlo_capabilities(&ehlo_resp.message)))
+    } else {
+        // Fall back to HELO
+        send_command(writer, &format!("HELO {ehlo_name}")).await?;
+        let helo_resp = read_response(reader).await?;
+        if !helo_resp.is_ok() {
+            return Err(Error::Http(format!(
+                "SMTP HELO failed: {} {}",
+                helo_resp.code, helo_resp.message
+            )));
+        }
+        Ok((false, EhloCapabilities::default()))
+    }
+}
+
 /// Send an email or execute an SMTP command.
 ///
 /// Connects to the SMTP server specified in the URL, performs EHLO/HELO,
@@ -261,81 +301,75 @@ pub async fn send_mail(
     let addr = format!("{host}:{port}");
     let tcp = tokio::net::TcpStream::connect(&addr).await.map_err(Error::Connect)?;
 
-    // Type-erased reader/writer so we can use either plain or TLS streams
-    let (reader, mut writer): (
-        Box<dyn tokio::io::AsyncRead + Unpin + Send>,
+    // Establish connection with appropriate TLS mode.
+    // For STARTTLS, we use concrete types for the initial negotiation (greeting,
+    // EHLO, STARTTLS command), then unsplit → TLS handshake → re-split into
+    // type-erased boxed streams for the rest of the protocol.
+    #[allow(clippy::type_complexity)]
+    let (mut reader, mut writer, caps, ehlo_ok): (
+        BufReader<Box<dyn tokio::io::AsyncRead + Unpin + Send>>,
         Box<dyn tokio::io::AsyncWrite + Unpin + Send>,
+        EhloCapabilities,
+        bool,
     ) = if use_implicit_tls {
         let connector = crate::tls::TlsConnector::new(tls_config)?;
         let (tls_stream, _alpn) = connector.connect(tcp, &host).await?;
         let (r, w) = tokio::io::split(tls_stream);
-        (Box::new(r), Box::new(w))
+        let mut rd = BufReader::new(Box::new(r) as Box<dyn tokio::io::AsyncRead + Unpin + Send>);
+        let mut wr: Box<dyn tokio::io::AsyncWrite + Unpin + Send> = Box::new(w);
+        let (ehlo_ok, caps) = smtp_greeting_and_ehlo(&mut rd, &mut wr, ehlo_name).await?;
+        (rd, wr, caps, ehlo_ok)
     } else {
+        // Plain connection — use concrete types so we can unsplit for STARTTLS
         let (r, w) = tokio::io::split(tcp);
-        (Box::new(r), Box::new(w))
-    };
-    let mut reader = BufReader::new(reader);
+        let mut plain_reader = BufReader::new(r);
+        let mut plain_writer = w;
+        let (ehlo_ok, caps) =
+            smtp_greeting_and_ehlo(&mut plain_reader, &mut plain_writer, ehlo_name).await?;
 
-    // Read server greeting
-    let greeting = read_response(&mut reader).await?;
-    if !greeting.is_ok() {
-        return Err(Error::Http(format!(
-            "SMTP server rejected connection: {} {}",
-            greeting.code, greeting.message
-        )));
-    }
-
-    // Send EHLO
-    send_command(&mut writer, &format!("EHLO {ehlo_name}")).await?;
-    let ehlo_resp = read_response(&mut reader).await?;
-
-    let (ehlo_ok, caps) = if ehlo_resp.is_ok() {
-        let caps = parse_ehlo_capabilities(&ehlo_resp.message);
-        (true, caps)
-    } else {
-        // Fall back to HELO
-        send_command(&mut writer, &format!("HELO {ehlo_name}")).await?;
-        let helo_resp = read_response(&mut reader).await?;
-        if !helo_resp.is_ok() {
-            return Err(Error::Http(format!(
-                "SMTP HELO failed: {} {}",
-                helo_resp.code, helo_resp.message
-            )));
-        }
-        // HELO = no capabilities
-        (false, EhloCapabilities::default())
-    };
-
-    // STARTTLS: upgrade plain connection to TLS if requested
-    if use_starttls && ehlo_ok {
-        if caps.starttls {
+        if use_starttls && ehlo_ok && caps.starttls {
             // Server advertises STARTTLS — send the command
-            send_command(&mut writer, "STARTTLS").await?;
-            let starttls_resp = read_response(&mut reader).await?;
+            send_command(&mut plain_writer, "STARTTLS").await?;
+            let starttls_resp = read_response(&mut plain_reader).await?;
             if !starttls_resp.is_ok() {
                 // Server rejected STARTTLS — return CURLE_WEIRD_SERVER_REPLY (8)
                 return Err(Error::Protocol(8));
             }
-            // TLS handshake would happen here (not needed for current tests)
-            // For now, this code path means STARTTLS succeeded — would need
-            // stream reassembly and TLS wrapping for full implementation.
-        } else if use_ssl == UseSsl::All {
-            // STARTTLS not advertised but required → CURLE_USE_SSL_FAILED (64)
-            let _ = send_command(&mut writer, "QUIT").await;
+
+            // Reassemble TCP stream from split halves and upgrade to TLS
+            let tcp_restored = plain_reader.into_inner().unsplit(plain_writer);
+            let connector = crate::tls::TlsConnector::new_no_alpn(tls_config)?;
+            let (tls_stream, _) = connector.connect(tcp_restored, &host).await?;
+            let (r, w) = tokio::io::split(tls_stream);
+            let mut rd =
+                BufReader::new(Box::new(r) as Box<dyn tokio::io::AsyncRead + Unpin + Send>);
+            let mut wr: Box<dyn tokio::io::AsyncWrite + Unpin + Send> = Box::new(w);
+
+            // Re-EHLO over the TLS connection (RFC 3207 Section 4.2)
+            send_command(&mut wr, &format!("EHLO {ehlo_name}")).await?;
+            let ehlo2 = read_response(&mut rd).await?;
+            let (ehlo_ok2, caps2) = if ehlo2.is_ok() {
+                (true, parse_ehlo_capabilities(&ehlo2.message))
+            } else {
+                (false, EhloCapabilities::default())
+            };
+            (rd, wr, caps2, ehlo_ok2)
+        } else if use_starttls && use_ssl == UseSsl::All && (!ehlo_ok || !caps.starttls) {
+            // STARTTLS required but not available or EHLO failed
+            let _ = send_command(&mut plain_writer, "QUIT").await;
             return Err(Error::Transfer {
                 code: 64,
-                message: "SMTP STARTTLS required but not advertised".to_string(),
+                message: "SMTP STARTTLS required but not available".to_string(),
             });
+        } else {
+            // No TLS upgrade — box the plain streams
+            let rd =
+                BufReader::new(Box::new(plain_reader.into_inner())
+                    as Box<dyn tokio::io::AsyncRead + Unpin + Send>);
+            let wr: Box<dyn tokio::io::AsyncWrite + Unpin + Send> = Box::new(plain_writer);
+            (rd, wr, caps, ehlo_ok)
         }
-        // UseSsl::Try with no STARTTLS advertised: continue without TLS
-    } else if use_starttls && !ehlo_ok && use_ssl == UseSsl::All {
-        // EHLO failed (HELO fallback), can't check STARTTLS, but it's required
-        let _ = send_command(&mut writer, "QUIT").await;
-        return Err(Error::Transfer {
-            code: 64,
-            message: "SMTP STARTTLS required but EHLO failed".to_string(),
-        });
-    }
+    };
 
     // Authenticate if credentials provided AND server advertises AUTH
     // When EHLO failed (HELO fallback), skip auth (no capability).


### PR DESCRIPTION
## Summary
- Implement actual TLS upgrade for SMTP STARTTLS, IMAP STARTTLS, and POP3 STLS commands
- Refactor connection setup to use concrete stream types for initial negotiation, then unsplit → TLS handshake → re-split into boxed streams
- Extract shared helper functions (`smtp_greeting_and_ehlo`, `imap_greeting_and_capability`, `pop3_greeting_and_capa`) to reduce code duplication
- After TLS upgrade, re-send capability commands (EHLO/CAPABILITY/CAPA) per RFC requirements

## Curl tests passing (16/16)
```
TESTDONE: 16 tests out of 16 reported OK: 100%
```

| Test | Description | Protocol |
|------|-------------|----------|
| 400 | FTPS dir list PASV unencrypted data | FTPS |
| 401 | FTPS PASV upload file | FTPS |
| 402 | FTP SSL required on non-SSL server | FTP |
| 403 | FTPS with CCC not supported by server | FTPS |
| 406 | FTPS dir list, PORT with specified IP | FTPS |
| 407 | Get two FTPS files from same dir | FTPS |
| 408 | FTPS PORT upload with CWD | FTPS |
| 409 | FTPS PASV upload file | FTPS |
| 980 | SMTP STARTTLS pipelined server response | SMTP |
| 981 | IMAP STARTTLS pipelined server response | IMAP |
| 982 | POP3 STARTTLS pipelined server response | POP3 |
| 983 | FTP STARTTLS pipelined server response | FTP |
| 984 | IMAP require STARTTLS with failing caps | IMAP |
| 985 | POP3 require STARTTLS with failing caps | POP3 |
| 986 | FTP require STARTTLS while preauth'd | FTP |
| 1112 | FTPS download with strict timeout | FTPS |

## Test plan
- [x] All 16 target curl tests pass
- [x] 312 Rust unit tests pass
- [x] No regressions on IMAP/POP3/SMTP tests (800-960 range)
- [x] cargo fmt, clippy, test, doc all pass