### PR TITLE
fix(http): redirect auth, -X request target, IPv6 scope, FTP credential forwarding

### DIFF
--- a/crates/liburlx/src/easy.rs
+++ b/crates/liburlx/src/easy.rs
@@ -241,6 +241,9 @@ pub struct Easy {
     /// Last response received, even if the transfer ultimately failed.
     /// This allows callers to output partial response data on error (curl compat).
     last_response: Option<Response>,
+    /// Netrc file contents for credential lookup during redirects.
+    /// When set, the redirect handler can look up credentials for new hosts.
+    netrc_content: Option<String>,
 }
 
 #[allow(clippy::missing_fields_in_debug, clippy::too_many_lines)] // h2_pool is cfg-gated and opaque
@@ -483,6 +486,7 @@ impl Clone for Easy {
             tftp_no_options: self.tftp_no_options,
             ftp_session: None,   // ephemeral — not cloned (connection state)
             last_response: None, // ephemeral — not cloned
+            netrc_content: self.netrc_content.clone(),
         }
     }
 }
@@ -615,6 +619,7 @@ impl Easy {
             tftp_no_options: false,
             ftp_session: None,
             last_response: None,
+            netrc_content: None,
         }
     }
 
@@ -1673,6 +1678,14 @@ impl Easy {
         self.auto_referer = enable;
     }
 
+    /// Set netrc file contents for credential lookup during redirects.
+    ///
+    /// When set, the redirect handler can look up credentials for new hosts
+    /// from the netrc content (curl compat: test 257).
+    pub fn set_netrc_content(&mut self, content: &str) {
+        self.netrc_content = Some(content.to_string());
+    }
+
     /// Check if a non-Basic auth method is configured (Digest, NTLM, `AnyAuth`).
     ///
     /// When challenge-response auth is configured, callers should not add
@@ -2368,6 +2381,13 @@ impl Easy {
         self.custom_request_target = Some(target.to_string());
     }
 
+    /// Clear the custom request target.
+    ///
+    /// After clearing, the request target is derived from the URL path + query.
+    pub fn clear_custom_request_target(&mut self) {
+        self.custom_request_target = None;
+    }
+
     /// Set the TFTP block size for transfers.
     ///
     /// Valid values are 8-65464 (RFC 2348). Defaults to 512.
@@ -2775,6 +2795,7 @@ impl Easy {
             self.form_data,
             self.allowed_protocols.as_deref(),
             &mut self.ftp_session,
+            self.netrc_content.as_deref(),
         );
 
         // Apply total transfer timeout if set.
@@ -2932,6 +2953,7 @@ async fn perform_transfer(
     form_data: bool,
     allowed_protocols: Option<&[String]>,
     ftp_session: &mut Option<crate::protocol::ftp::FtpSession>,
+    netrc_content: Option<&str>,
 ) -> Result<Response, Error> {
     let transfer_start = Instant::now();
     let original_url = url.clone();
@@ -2990,6 +3012,22 @@ async fn perform_transfer(
                         && !k.eq_ignore_ascii_case("_auto_authorization")
                         && !k.eq_ignore_ascii_case("cookie")
                 });
+                // Look up netrc credentials for the new host (curl compat: test 257)
+                if let Some(netrc) = netrc_content {
+                    if let Ok(Some(entry)) = crate::netrc::lookup(netrc, cur_host) {
+                        let login = entry.login.as_deref().unwrap_or("");
+                        let password = entry.password.as_deref().unwrap_or("");
+                        if !login.is_empty() {
+                            use base64::Engine;
+                            let encoded = base64::engine::general_purpose::STANDARD
+                                .encode(format!("{login}:{password}"));
+                            request_headers.push((
+                                "_auto_Authorization".to_string(),
+                                format!("Basic {encoded}"),
+                            ));
+                        }
+                    }
+                }
             }
             if !orig_host.eq_ignore_ascii_case(cur_host) {
                 // Drop custom Host header on cross-host redirect (curl compat: test 184)
@@ -4746,9 +4784,33 @@ async fn perform_transfer(
                 }
 
                 // Cross-protocol redirect to FTP: perform FTP transfer
-                // (curl compat: tests 973, 1028, 1055)
+                // (curl compat: tests 973, 975, 1028, 1055)
                 if next_scheme == "ftp" || next_scheme == "ftps" {
                     redirect_chain.push(response);
+
+                    // When --location-trusted is set, carry credentials to the FTP URL
+                    // (curl compat: test 975). Check auth_credentials first, then
+                    // fall back to extracting from Basic auth header.
+                    let ftp_url = if unrestricted_auth {
+                        let (ftp_user, ftp_pass) = auth_credentials.map_or_else(
+                            || {
+                                // Extract from _auto_Authorization or Authorization header
+                                extract_basic_credentials(&request_headers).unwrap_or_default()
+                            },
+                            |auth| (auth.username.clone(), auth.password.clone()),
+                        );
+                        if ftp_user.is_empty() {
+                            next_url.clone()
+                        } else if let Ok(mut u) = url::Url::parse(next_url.as_str()) {
+                            let _ = u.set_username(&ftp_user);
+                            let _ = u.set_password(Some(&ftp_pass));
+                            Url::parse(u.as_str()).unwrap_or_else(|_| next_url.clone())
+                        } else {
+                            next_url.clone()
+                        }
+                    } else {
+                        next_url.clone()
+                    };
 
                     let effective_ssl_mode = if next_scheme == "ftps" {
                         crate::protocol::ftp::FtpSslMode::Implicit
@@ -4759,7 +4821,7 @@ async fn perform_transfer(
                     let ftp_upload_data = current_body.as_deref();
                     let ftp_resume_offset = None;
                     let ftp_result = crate::protocol::ftp::perform(
-                        &next_url,
+                        &ftp_url,
                         ftp_upload_data,
                         effective_ssl_mode,
                         use_ssl,
@@ -6969,6 +7031,29 @@ fn resolve_request_target(custom: Option<&str>, url: &Url, path_as_is: bool) -> 
     } else {
         url.request_target()
     }
+}
+
+/// Extract username and password from Basic auth headers.
+///
+/// Looks for `_auto_Authorization` or `Authorization` headers with `Basic` scheme
+/// and decodes the base64 credentials.
+fn extract_basic_credentials(headers: &[(String, String)]) -> Option<(String, String)> {
+    use base64::Engine;
+    for (k, v) in headers {
+        if k.eq_ignore_ascii_case("_auto_authorization") || k.eq_ignore_ascii_case("authorization")
+        {
+            if let Some(encoded) = v.strip_prefix("Basic ") {
+                if let Ok(decoded) = base64::engine::general_purpose::STANDARD.decode(encoded) {
+                    if let Ok(creds) = String::from_utf8(decoded) {
+                        if let Some((user, pass)) = creds.split_once(':') {
+                            return Some((user.to_string(), pass.to_string()));
+                        }
+                    }
+                }
+            }
+        }
+    }
+    None
 }
 
 /// Strip the raw header value prefix that `headers_ordered` includes.

--- a/crates/liburlx/src/url.rs
+++ b/crates/liburlx/src/url.rs
@@ -44,6 +44,30 @@ impl Url {
             }
         }
 
+        // Handle IPv6 scope IDs: [::1%259999] → strip %259999 for URL parsing,
+        // as the `url` crate doesn't support zone IDs (curl compat: test 1056).
+        // The scope ID is ignored for actual connections (OS strips it).
+        let input = if input.contains("%25") {
+            if let Some(bracket_start) = input.find('[') {
+                if let Some(bracket_end) = input[bracket_start..].find(']') {
+                    let bracket_end = bracket_start + bracket_end;
+                    let host_part = &input[bracket_start..=bracket_end];
+                    if let Some(pct_pos) = host_part.find("%25") {
+                        // Strip zone ID: [::1%259999] → [::1]
+                        format!("{}{}", &input[..bracket_start + pct_pos], &input[bracket_end..])
+                    } else {
+                        input
+                    }
+                } else {
+                    input
+                }
+            } else {
+                input
+            }
+        } else {
+            input
+        };
+
         match url::Url::parse(&input) {
             Ok(inner) => {
                 // Reject extremely long hostnames (curl returns CURLE_URL_MALFORMAT: test 399).

--- a/crates/urlx-cli/src/args.rs
+++ b/crates/urlx-cli/src/args.rs
@@ -716,10 +716,6 @@ fn parse_args_options_with_depth(args: &[String], config_depth: u32) -> Result<C
                 // Store original case value for non-HTTP protocols
                 // (IMAP/POP3/SMTP use -X as custom protocol command)
                 opts.custom_request_original = Some(val.to_string());
-                // Also set custom_request_target to preserve case for email
-                // protocols (IMAP/POP3/SMTP).  This ensures per-URL Easy
-                // handles cloned at --next time carry the original-case value.
-                opts.easy.custom_request_target(val);
             }
             "-H" | "--header" => {
                 i += 1;

--- a/crates/urlx-cli/src/transfer.rs
+++ b/crates/urlx-cli/src/transfer.rs
@@ -787,6 +787,8 @@ pub fn run(args: &[String]) -> ExitCode {
             if let Some(ref netrc_path) = opts.netrc_file {
                 match std::fs::read_to_string(netrc_path) {
                     Ok(contents) => {
+                        // Store netrc content for redirect credential lookup (test 257)
+                        opts.easy.set_netrc_content(&contents);
                         let host = extract_hostname(&url);
                         let url_user = extract_url_username(&url);
                         let url_pass = extract_url_password(&url);
@@ -1208,10 +1210,13 @@ pub fn run(args: &[String]) -> ExitCode {
 
     // For non-HTTP protocols, -X sets a custom protocol command (not HTTP request target).
     // Only set custom_request_target for non-HTTP schemes to avoid breaking HTTP -X behavior.
+    // For HTTP schemes, clear any stale custom_request_target (curl compat: tests 794, 796).
     if let Some(ref custom_req) = opts.custom_request_original {
         let scheme = opts.easy.url_ref().map(|u| u.scheme().to_lowercase()).unwrap_or_default();
         if matches!(scheme.as_str(), "smtp" | "smtps" | "imap" | "imaps" | "pop3" | "pop3s") {
             opts.easy.custom_request_target(custom_req);
+        } else {
+            opts.easy.clear_custom_request_target();
         }
     }
 


### PR DESCRIPTION
## Summary
- **Fix `-X`/`--request` setting `custom_request_target` for HTTP** — the method name was used as the URL path instead of the actual path (e.g., `IGLOO /796` became `IGLOO IGLOO`). Now only non-HTTP protocols (IMAP/POP3/SMTP) set `custom_request_target` from `-X`.
- **Add IPv6 scope ID (zone ID) handling** — URLs like `http://[::1%259999]:port/path` now strip the zone ID (`%259999`) before URL parsing since the `url` crate doesn't support RFC 6874.
- **Add netrc credential lookup during redirects** — when following redirects to a new host with `--netrc-optional`, credentials are looked up from the netrc file for the new host.
- **Forward HTTP auth credentials to FTP on cross-protocol redirect** — with `--location-trusted`, credentials from `auth_credentials` or Basic auth headers are embedded in the FTP URL.
- **New APIs**: `clear_custom_request_target()`, `set_netrc_content()`, `extract_basic_credentials()`

## Tests passing (32/32)
```
153 177 257 276 317 318 388 794 796 973 975 999 1028 1031
1040 1041 1042 1043 1056 1067 1071 1072 1079 1087 1088 1095
1143 1245 1273 1284 1285 1286
```

All 32 curl tests from the task pass. Breakdown:
- **Redirects (12):** 276, 794, 796, 973, 975, 999, 1028, 1031, 1056, 1067, 1143, 1245
- **Digest Auth (10):** 153, 177, 388, 1071, 1072, 1079, 1095, 1284, 1285, 1286
- **Auth Stripping (5):** 257, 317, 318, 1087, 1088
- **HTTP Resume (5):** 1040, 1041, 1042, 1043, 1273

## Test plan
- [x] All 32 target curl tests pass
- [x] `cargo fmt` — clean
- [x] `cargo clippy` — no errors or warnings
- [x] `cargo test` — all Rust tests pass
- [x] Pre-commit hooks pass