### PR TITLE
fix(http): proxy auth, CONNECT tunnel reuse, and upload resume (8 curl tests)

### DIFF
--- a/crates/liburlx/src/easy.rs
+++ b/crates/liburlx/src/easy.rs
@@ -5190,7 +5190,10 @@ async fn do_single_request(
     let (host, port) = url.host_and_port()?;
     let host_header = url.host_header_value();
     let is_tls = url.scheme() == "https";
-    let use_pool = proxy.is_none() && !fresh_connect;
+    // Pool direct connections and CONNECT tunnel connections (the tunnel stream
+    // acts like a direct connection after establishment). Non-tunnel proxy
+    // connections are not pooled (curl compat: tests 275, 1078).
+    let use_pool = (proxy.is_none() || http_proxy_tunnel) && !fresh_connect;
 
     // Build effective headers (add Accept-Encoding if decompression enabled)
     let mut effective_headers: Vec<(String, String)> = headers.to_vec();
@@ -5263,12 +5266,26 @@ async fn do_single_request(
 
             let request_target = resolve_request_target(custom_request_target, url, path_as_is);
             let use_http10 = http_version == HttpVersion::Http10;
+            // For reused CONNECT tunnel connections, strip proxy-related headers
+            // since proxy auth was handled by the original CONNECT (curl compat: tests 275, 1078)
+            let reuse_headers: Vec<(String, String)> = if http_proxy_tunnel {
+                effective_headers
+                    .iter()
+                    .filter(|(k, _)| {
+                        !k.eq_ignore_ascii_case("proxy-authorization")
+                            && !k.eq_ignore_ascii_case("proxy-connection")
+                    })
+                    .cloned()
+                    .collect()
+            } else {
+                effective_headers.clone()
+            };
             let result = crate::protocol::http::h1::request(
                 &mut stream,
                 method,
                 &host_header,
                 &request_target,
-                &effective_headers,
+                &reuse_headers,
                 body,
                 url.as_str(),
                 true,
@@ -5696,6 +5713,12 @@ async fn do_single_request(
                                 time_connect,
                             ));
                         }
+                        ConnectTunnelResult::NeedReconnect { .. } => {
+                            return Err(Error::Http(
+                                "proxy auth reconnection not supported for HTTPS tunnels"
+                                    .to_string(),
+                            ));
+                        }
                     };
 
                     let tls = crate::tls::TlsConnector::new(tls_config)?;
@@ -5767,6 +5790,12 @@ async fn do_single_request(
                                 url.as_str(),
                                 time_namelookup,
                                 time_connect,
+                            ));
+                        }
+                        ConnectTunnelResult::NeedReconnect { .. } => {
+                            return Err(Error::Http(
+                                "proxy auth reconnection not supported for HTTPS tunnels"
+                                    .to_string(),
                             ));
                         }
                     }
@@ -5890,6 +5919,67 @@ async fn do_single_request(
                 )
                 .await?;
 
+                let tunnel_result = match tunnel_result {
+                    ConnectTunnelResult::NeedReconnect { method, raw_407 } => {
+                        // Proxy closed connection after 407 — reconnect and retry
+                        // with pre-selected auth method (curl compat: test 1021)
+                        if verbose {
+                            #[allow(clippy::print_stderr)]
+                            {
+                                eprintln!("* Proxy connection closed, reconnecting for auth");
+                            }
+                        }
+                        let connect_addr = format!("{connect_host}:{connect_port}");
+                        let new_stream = if let Some(timeout_dur) = connect_timeout {
+                            tokio::time::timeout(
+                                timeout_dur,
+                                tokio::net::TcpStream::connect(&connect_addr),
+                            )
+                            .await
+                            .map_err(|_| Error::Timeout(timeout_dur))?
+                            .map_err(Error::Connect)?
+                        } else {
+                            tokio::net::TcpStream::connect(&connect_addr)
+                                .await
+                                .map_err(Error::Connect)?
+                        };
+                        // Set proxy credentials to the selected method for retry
+                        let retry_creds = proxy_credentials.map(|c| ProxyAuthCredentials {
+                            username: c.username.clone(),
+                            password: c.password.clone(),
+                            method,
+                            domain: c.domain.clone(),
+                        });
+                        establish_connect_tunnel(
+                            new_stream,
+                            &host,
+                            port,
+                            &effective_headers,
+                            retry_creds.as_ref(),
+                            proxy_headers,
+                            verbose,
+                            proxy_http_10,
+                        )
+                        .await
+                        .map(|r| match r {
+                            ConnectTunnelResult::Connected {
+                                stream,
+                                raw_connect: raw_retry,
+                                connect_status,
+                            } => {
+                                let mut combined = raw_407;
+                                combined.extend_from_slice(&raw_retry);
+                                ConnectTunnelResult::Connected {
+                                    stream,
+                                    raw_connect: combined,
+                                    connect_status,
+                                }
+                            }
+                            other => other,
+                        })?
+                    }
+                    other => other,
+                };
                 let (tunnel_stream, raw_connect, connect_status) = match tunnel_result {
                     ConnectTunnelResult::Connected { stream, raw_connect, connect_status } => {
                         (stream, raw_connect, connect_status)
@@ -5903,6 +5993,9 @@ async fn do_single_request(
                             time_connect,
                         ));
                     }
+                    ConnectTunnelResult::NeedReconnect { .. } => {
+                        return Err(Error::Http("proxy auth reconnection failed".to_string()));
+                    }
                 };
 
                 let request_target = resolve_request_target(custom_request_target, url, path_as_is);
@@ -5915,7 +6008,7 @@ async fn do_single_request(
                     .filter(|(k, _)| !k.eq_ignore_ascii_case("proxy-authorization"))
                     .cloned()
                     .collect();
-                let (resp, _can_reuse) = crate::protocol::http::h1::request(
+                let (resp, can_reuse) = crate::protocol::http::h1::request(
                     &mut stream,
                     method,
                     &host_header,
@@ -5923,7 +6016,7 @@ async fn do_single_request(
                     &tunnel_headers,
                     body,
                     url.as_str(),
-                    true, // Suppress Connection: close (tunneled request acts like direct)
+                    use_pool, // Allow connection reuse for tunnel (curl compat: tests 275, 1078)
                     use_http10,
                     expect_100_timeout,
                     ignore_content_length,
@@ -5935,6 +6028,12 @@ async fn do_single_request(
                 )
                 .await?;
                 let time_starttransfer = request_start.elapsed();
+
+                // Pool the tunnel stream for reuse by subsequent requests to
+                // the same target host (curl compat: tests 275, 1078)
+                if can_reuse && use_pool && !forbid_reuse {
+                    pool.put(&host, port, false, stream);
+                }
 
                 let mut resp = resp;
                 resp.set_connect_code(connect_status);
@@ -6263,6 +6362,14 @@ enum ConnectTunnelResult<S> {
         /// Raw CONNECT response bytes (for output).
         raw_response: Vec<u8>,
     },
+    /// Proxy returned 407 with Connection: close; caller must reconnect
+    /// and retry with the specified auth method (curl compat: test 1021).
+    NeedReconnect {
+        /// The auth method selected from the 407 response.
+        method: ProxyAuthMethod,
+        /// Raw 407 response bytes (for --include output).
+        raw_407: Vec<u8>,
+    },
 }
 
 /// Establish an HTTP CONNECT tunnel through a proxy.
@@ -6451,6 +6558,20 @@ where
                     // AnyAuth in CONNECT: parse Proxy-Authenticate and select method
                     if let Some(ref auth_header) = proxy_auth_header {
                         let selected = select_proxy_auth_method(auth_header);
+
+                        // Check if proxy closed the connection (curl compat: test 1021).
+                        // If so, caller must reconnect before retrying.
+                        let conn_close = find_header(&response_headers, "connection")
+                            .is_some_and(|v| v.eq_ignore_ascii_case("close"));
+                        if conn_close {
+                            if let Some(method) = selected {
+                                return Ok(ConnectTunnelResult::NeedReconnect {
+                                    method,
+                                    raw_407: raw_connect,
+                                });
+                            }
+                        }
+
                         match selected {
                             Some(ProxyAuthMethod::Ntlm) => {
                                 // Need to send Type 1 — the initial CONNECT had no auth

--- a/crates/urlx-cli/src/args.rs
+++ b/crates/urlx-cli/src/args.rs
@@ -716,10 +716,6 @@ fn parse_args_options_with_depth(args: &[String], config_depth: u32) -> Result<C
                 // Store original case value for non-HTTP protocols
                 // (IMAP/POP3/SMTP use -X as custom protocol command)
                 opts.custom_request_original = Some(val.to_string());
-                // Also set custom_request_target to preserve case for email
-                // protocols (IMAP/POP3/SMTP).  This ensures per-URL Easy
-                // handles cloned at --next time carry the original-case value.
-                opts.easy.custom_request_target(val);
             }
             "-H" | "--header" => {
                 i += 1;

--- a/crates/urlx-cli/src/transfer.rs
+++ b/crates/urlx-cli/src/transfer.rs
@@ -643,6 +643,37 @@ pub fn run(args: &[String]) -> ExitCode {
                 }
             }
         }
+        // Apply Content-Range + body slicing for resumed uploads in multi-URL mode
+        // (curl compat: test 1002 — -T file -C 2 with multiple URLs)
+        if opts.is_upload {
+            if let Some(offset) = opts.resume_offset {
+                if offset > 0 {
+                    let is_ftp_upload = opts
+                        .urls
+                        .first()
+                        .is_some_and(|u| u.starts_with("ftp://") || u.starts_with("ftps://"));
+                    if !is_ftp_upload {
+                        if let Some(body_data) = opts.easy.take_body() {
+                            let total = body_data.len() as u64;
+                            let end = total.saturating_sub(1);
+                            if offset <= end {
+                                #[allow(clippy::cast_possible_truncation)]
+                                let start = offset as usize;
+                                let sliced = &body_data[start..];
+                                opts.easy.header(
+                                    "Content-Range",
+                                    &format!("bytes {offset}-{end}/{total}"),
+                                );
+                                opts.easy.body(sliced);
+                            } else {
+                                opts.easy.body(&[]);
+                            }
+                        }
+                        opts.easy.clear_range();
+                    }
+                }
+            }
+        }
     }
 
     // Refresh per_url_easy entries to pick up modifications made in run() after
@@ -714,6 +745,7 @@ pub fn run(args: &[String]) -> ExitCode {
             &opts.per_url_easy,
             &opts.per_url_upload_files,
             &opts.per_url_group,
+            opts.resume_offset,
         );
     }
 
@@ -2143,6 +2175,7 @@ pub fn run_multi(
     per_url_easy: &[Option<liburlx::Easy>],
     per_url_upload_files: &[Option<String>],
     per_url_group: &[usize],
+    resume_offset: Option<u64>,
 ) -> ExitCode {
     if parallel {
         return run_multi_parallel(
@@ -2249,11 +2282,38 @@ pub fn run_multi(
         if is_upload && i > 0 && !is_ftp_url {
             let has_own_upload = per_url_upload_files.get(i).is_some_and(|f| f.is_some());
             if has_own_upload {
-                // This URL has its own -T flag: re-read the file and PUT
+                // This URL has its own -T flag: re-read the file
                 if let Some(Some(ref path)) = per_url_upload_files.get(i) {
                     if let Ok(data) = std::fs::read(path) {
-                        easy.body(&data);
-                        easy.method("PUT");
+                        // Apply resume offset if set (Content-Range + body slicing, curl compat: test 1002)
+                        if let Some(offset) = resume_offset {
+                            if offset > 0 {
+                                let total = data.len() as u64;
+                                let end = total.saturating_sub(1);
+                                if offset <= end {
+                                    #[allow(clippy::cast_possible_truncation)]
+                                    let start = offset as usize;
+                                    let sliced = &data[start..];
+                                    easy.remove_header("Content-Range");
+                                    easy.header(
+                                        "Content-Range",
+                                        &format!("bytes {offset}-{end}/{total}"),
+                                    );
+                                    easy.body(sliced);
+                                } else {
+                                    easy.body(&[]);
+                                }
+                            } else {
+                                easy.body(&data);
+                            }
+                        } else {
+                            easy.body(&data);
+                        }
+                        // Only default to PUT if no explicit -X method was set
+                        // (curl compat: test 1002 — -X GET overrides -T's PUT)
+                        if easy.method_is_default() {
+                            easy.method("PUT");
+                        }
                     }
                 }
             } else if easy.has_body() {


### PR DESCRIPTION
## Summary
- Fix `-X` flag incorrectly setting `custom_request_target`, causing malformed proxy request lines (`GET GET HTTP/1.1` instead of `GET http://host/path HTTP/1.1`)
- Add `Content-Range` header and body slicing for resumed uploads (`-T file -C offset`) in multi-URL mode
- Respect `-X` method override when re-reading `-T` upload files in multi-URL transfers
- Enable connection pooling for CONNECT tunnel streams so subsequent requests to the same host reuse the established tunnel
- Handle proxy `Connection: close` after 407 by reconnecting and retrying CONNECT with the selected auth method (NTLM)
- Add `NeedReconnect` variant to `ConnectTunnelResult` for proxy auth reconnection flow

## Tests Passing

**8 new tests passing** (23/25 total, 2 are libtests requiring C programs):

| Test | Description | Status |
|------|-------------|--------|
| 259 | HTTP POST multipart with Expect + proxy anyauth (Digest) | PASS |
| 275 | HTTP CONNECT tunnel reuse for two URLs to same host | PASS |
| 1001 | HTTP PUT with Digest auth, resume, custom method via proxy | PASS |
| 1002 | HTTP PUT with Digest auth, resume, custom method, two URLs | PASS |
| 1021 | HTTP CONNECT with proxy-anyauth NTLM + Connection: close | PASS |
| 1078 | HTTP/1.0 CONNECT with proxytunnel + HTTP version downgrade | PASS |
| 1230 | HTTP CONNECT to IPv6 numerical address | PASS |
| 1288 | Suppress proxy CONNECT response headers | PASS |
| 590 | libtest (C program) - not CLI-testable | SKIP |
| 694 | libtest (C program) - not CLI-testable | SKIP |

```
TESTDONE: 25 tests were considered during 11 seconds.
TESTDONE: 23 tests out of 25 reported OK: 92%
```

Previously passing tests (1-60) verified with no regressions.

## Test plan
- [x] All 25 target tests run (23 pass, 2 are libtests)
- [x] Regression check on tests 1-60 (all pass)
- [x] `cargo fmt`, `cargo clippy`, `cargo test`, `cargo doc` all pass
- [x] Pre-commit hooks pass