### PR TITLE
chore: permanently skip 16 source/build analysis curl tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ The project is MIT-licensed. The name "urlx" stands for "URL transfer."
 ## Current Status
 
 **Version:** v0.1.0 published (crates.io + GitHub Releases + Homebrew)
-**curl test suite:** 1,171 pass / 102 fail / 54 skip out of 1,327 tests (92% pass rate, tests 1-1400)
+**curl test suite:** 1,171 pass / 86 fail / 70 skip out of 1,327 tests (93.2% pass rate, tests 1-1400)
 **Rust test count:** 2,655
 **Blockers:** None — infrastructure is live
 
@@ -102,6 +102,7 @@ Some tests are expected to be permanently skipped:
 - Tests requiring curl debug builds (`feat:debug`, `feat:TrackMemory`)
 - Tests requiring protocols we haven't implemented yet (mark as TODO with the protocol name)
 - Tests checking curl-specific version strings
+- **Source/build analysis tests** (16 tests, documented in `tests/excluded-tests.txt`): 745, 1013, 1014, 1022, 1023, 1026, 1027, 1119, 1135, 1139, 1165, 1167, 1173, 1177, 1185, 1222 — these verify curl's own source code structure, build system, man pages, and symbol consistency; not applicable to urlx
 
 Document every skip with a reason. Skips without rationale are not allowed.
 
@@ -109,30 +110,30 @@ Document every skip with a reason. Skips without rationale are not allowed.
 
 ## Remaining Work: Failure Analysis (as of 2026-03-19)
 
-Full test suite run: 1,171 pass / 102 fail / 54 skip (tests 1-1400, 30s timeout). **92% pass rate.**
+Full test suite run: 1,171 pass / 86 fail / 70 skip (tests 1-1400, 30s timeout). **93.2% pass rate.**
+16 source/build analysis tests permanently excluded (see `tests/excluded-tests.txt`).
 
-### Failing Tests by Category (102 total)
+### Failing Tests by Category (86 total)
 
 | # | Category | Tests | Count | Details |
 |---|----------|-------|-------|---------|
-| 1 | **Source/build analysis** | 745, 1013, 1014, 1022, 1023, 1026, 1027, 1119, 1135, 1139, 1165, 1167, 1173, 1177, 1185, 1222 | 16 | curl-config, source symbol checks, man page sync, checksrc — N/A for urlx |
-| 2 | **IMAP edge cases** | 795, 800, 815, 816, 847, 897, 1221 | 7 | STORE/CLOSE/EXPUNGE custom commands, login options, IMAP via HTTP proxy |
-| 3 | **HTTP NTLM auth** | 547, 548, 555, 560, 694, 775, 895 | 7 | NTLM with POST callback, Negotiate, multi-interface |
-| 4 | **FTP over SOCKS/proxy** | 706, 707, 712, 713, 714, 715, 1050, 1059, 1069, 1105 | 10 | FTP via SOCKS4/5, HTTP CONNECT tunnel, IPv6 EPRT, proxy relay |
-| 5 | **HTTP PUT/POST edge cases** | 186, 357, 490, 491, 492, 493, 1015, 1077, 1106 | 9 | Expect 100, PUT methods, POST encoding, cookies with POST |
-| 6 | **HTTP headers/encoding** | 306, 313, 373, 379, 415, 471, 483 | 7 | HTTPS cert/CRL, chunked encoding, Content-Length edge cases, globbing |
-| 7 | **Email via HTTP tunnel** | 1319, 1320, 1321 | 3 | POP3/SMTP/IMAP through HTTP CONNECT proxy |
-| 8 | **SMTP/IMAP auth cancellation** | 932, 933, 971 | 3 | CRAM-MD5/NTLM graceful cancellation (hangs on --max-time + -T -) |
-| 9 | **HTTP etag/resume** | 338, 369, 481, 482, 484, 485, 487, 497 | 8 | Etag multi-URL, --no-clobber + resume, --remove-on-error |
-| 10 | **CLI/globbing/output** | 760, 761, 762, 776, 988, 1134, 1265, 1268, 1292, 1299, 1328, 1370, 1371, 1400 | 14 | Globbing edge cases, --remote-time, -J Content-Disposition, --libcurl, NO_PROXY IPv6 |
-| 11 | **FTP misc** | 203, 254, 590, 1217, 1224, 1225, 1226 | 7 | file:// edge case, IPv6 EPSV, FTP NLST, PASV RETR |
-| 12 | **SMTP MIME/misc** | 609, 646, 647, 648, 649, 669 | 6 | Multipart MIME, IMAP APPEND upload, SMTP edge cases |
-| 13 | **TLS/HTTPS** | 306, 313 | 2 | PEM cert validation, CRL checking |
-| 14 | **Misc** | 1020, 1105, 1106, 1117, 1147, 1148, 1152 | 7 | Various HTTP edge cases, proxy interactions |
+| 1 | **IMAP edge cases** | 795, 800, 815, 816, 847, 897, 1221 | 7 | STORE/CLOSE/EXPUNGE custom commands, login options, IMAP via HTTP proxy |
+| 2 | **HTTP NTLM auth** | 547, 548, 555, 560, 694, 775, 895 | 7 | NTLM with POST callback, Negotiate, multi-interface |
+| 3 | **FTP over SOCKS/proxy** | 706, 707, 712, 713, 714, 715, 1050, 1059, 1069, 1105 | 10 | FTP via SOCKS4/5, HTTP CONNECT tunnel, IPv6 EPRT, proxy relay |
+| 4 | **HTTP PUT/POST edge cases** | 186, 357, 490, 491, 492, 493, 1015, 1077, 1106 | 9 | Expect 100, PUT methods, POST encoding, cookies with POST |
+| 5 | **HTTP headers/encoding** | 306, 313, 373, 379, 415, 471, 483 | 7 | HTTPS cert/CRL, chunked encoding, Content-Length edge cases, globbing |
+| 6 | **Email via HTTP tunnel** | 1319, 1320, 1321 | 3 | POP3/SMTP/IMAP through HTTP CONNECT proxy |
+| 7 | **SMTP/IMAP auth cancellation** | 932, 933, 971 | 3 | CRAM-MD5/NTLM graceful cancellation (hangs on --max-time + -T -) |
+| 8 | **HTTP etag/resume** | 338, 369, 481, 482, 484, 485, 487, 497 | 8 | Etag multi-URL, --no-clobber + resume, --remove-on-error |
+| 9 | **CLI/globbing/output** | 760, 761, 762, 776, 988, 1134, 1265, 1268, 1292, 1299, 1328, 1370, 1371, 1400 | 14 | Globbing edge cases, --remote-time, -J Content-Disposition, --libcurl, NO_PROXY IPv6 |
+| 10 | **FTP misc** | 203, 254, 590, 1217, 1224, 1225, 1226 | 7 | file:// edge case, IPv6 EPSV, FTP NLST, PASV RETR |
+| 11 | **SMTP MIME/misc** | 609, 646, 647, 648, 649, 669 | 6 | Multipart MIME, IMAP APPEND upload, SMTP edge cases |
+| 12 | **TLS/HTTPS** | 306, 313 | 2 | PEM cert validation, CRL checking |
+| 13 | **Misc** | 1020, 1105, 1106, 1117, 1147, 1148, 1152 | 7 | Various HTTP edge cases, proxy interactions |
 
-### Permanently Skippable (~16 tests)
+### Permanently Skipped (16 tests)
 
-Tests in category 1 (source/build analysis) are not applicable to urlx — they verify curl's own source code structure, man pages, and build system. These should be permanently skipped.
+Source/build analysis tests (745, 1013, 1014, 1022, 1023, 1026, 1027, 1119, 1135, 1139, 1165, 1167, 1173, 1177, 1185, 1222) are permanently excluded via `tests/excluded-tests.txt`. They verify curl's own source code structure, man pages, and build system — not applicable to urlx.
 
 ### Addressable Failures (~86 tests)
 
@@ -155,8 +156,7 @@ Tests in category 1 (source/build analysis) are not applicable to urlx — they 
 
 | Milestone | Pass Rate | Work |
 |-----------|-----------|------|
-| Current | 92% (1,171/1,273 non-skipped) | — |
-| Skip source analysis tests | 93.5% (1,171/1,257) | 0 effort |
+| Current (source analysis skipped) | 93.2% (1,171/1,257 non-skipped) | Done |
 | FTP proxy + HTTP PUT/POST | 95% (~1,190) | 1 week |
 | IMAP + CLI + etag fixes | 97% (~1,220) | +1 week |
 | Long tail (NTLM, MIME, misc) | 98%+ (~1,240) | +2 weeks |
@@ -165,7 +165,7 @@ Tests in category 1 (source/build analysis) are not applicable to urlx — they 
 
 ## Test Suite Progress
 
-1,171 of 1,327 tests pass (92%). The test suite spans tests 1-1400 with 54 skipped (libtests, missing features, debug-only).
+1,171 of 1,327 tests pass (93.2%). The test suite spans tests 1-1400 with 70 skipped (54 libtests/missing features/debug-only + 16 source analysis permanently excluded).
 
 ### By Range
 

--- a/scripts/run-curl-tests.sh
+++ b/scripts/run-curl-tests.sh
@@ -20,6 +20,7 @@ CURL_SRC="$PROJECT_ROOT/vendor/curl"
 TESTS_DIR="$CURL_BUILD/tests"
 WRAPPER="$SCRIPT_DIR/urlx-as-curl"
 URLX="$PROJECT_ROOT/target/release/urlx"
+EXCLUDE_FILE="$PROJECT_ROOT/tests/excluded-tests.txt"
 export URLX_BIN="$URLX"
 
 # Verify prerequisites
@@ -65,10 +66,19 @@ echo "urlx binary: $URLX"
 echo "Tests: ${*:-ALL}"
 echo ""
 
+# Build exclusion args: use -E file if the exclude file exists
+EXCLUDE_ARGS=()
+if [ -f "$EXCLUDE_FILE" ]; then
+    EXCLUDE_ARGS+=(-E "$EXCLUDE_FILE")
+    echo "Excluding tests listed in: $EXCLUDE_FILE"
+    echo ""
+fi
+
 perl runtests.pl \
     -a \
     -c "$WRAPPER" \
     -vc /usr/bin/curl \
+    "${EXCLUDE_ARGS[@]}" \
     "$@" 2>&1
 
 exit_code=$?

--- a/tasks/12-source-analysis-skips.md
+++ b/tasks/12-source-analysis-skips.md
@@ -1,6 +1,6 @@
 # Task 12: Source Analysis Tests — Permanent Skips
 
-## Status: Not Started
+## Status: Complete
 
 ## Problem
 

--- a/tests/excluded-tests.txt
+++ b/tests/excluded-tests.txt
@@ -1,0 +1,30 @@
+# Permanently excluded curl tests for urlx
+#
+# Format: type:patterns:reason
+# Types: test (by number), keyword (by keyword), tool (by tool name)
+#
+# These tests verify curl's own source code structure, build system,
+# man pages, and symbol consistency. They are not applicable to urlx
+# since it is a completely different codebase written in Rust.
+
+# curl source code analysis tests — verify internal curl source structure
+test:745:curl source analysis — typecheck-gcc and curl.h sync check
+test:1119:curl source analysis — symbols-in-versions and headers sync
+test:1135:curl source analysis — CURL_EXTERN function order
+test:1165:curl source analysis — CURL_DISABLE values in configure.ac
+test:1167:curl source analysis — curl prefix of public symbols
+test:1177:curl source analysis — CURL_VERSION_* constants sync
+test:1185:curl source analysis — checksrc source code style validation
+test:1222:curl source analysis — deprecation statuses across codebase
+
+# curl-config tests — urlx does not ship curl-config
+test:1013:curl-config not applicable — compares --version with --protocols
+test:1014:curl-config not applicable — compares --version with --features
+test:1022:curl-config not applicable — compares --version with --version
+test:1023:curl-config not applicable — compares --version with --vernum
+
+# curl documentation/help tests — urlx has its own help text and no embedded manual
+test:1026:urlx does not embed curl manual — --manual flag not applicable
+test:1027:urlx has different help text format — --help output differs
+test:1139:curl documentation — verifies all libcurl options have man pages
+test:1173:curl documentation — man page syntax checks


### PR DESCRIPTION
## Summary

- Add `tests/excluded-tests.txt` documenting 16 curl tests that verify curl's own source code structure, build system, man pages, and symbol consistency — not applicable to urlx
- Update `scripts/run-curl-tests.sh` to pass `-E excluded-tests.txt` to `runtests.pl`, automatically excluding these tests
- Update CLAUDE.md stats: pass rate moves from 92% to 93.2% (1,171/1,257 non-skipped), failure count drops from 102 to 86

### Tests excluded (16)
745, 1013, 1014, 1022, 1023, 1026, 1027, 1119, 1135, 1139, 1165, 1167, 1173, 1177, 1185, 1222

Each test has a documented rationale in the exclude file (curl-config checks, source symbol analysis, man page validation, checksrc, etc.).

## Test plan
- [ ] No Rust code changes — `cargo fmt`, `cargo clippy`, `cargo test` unaffected
- [ ] Verify `tests/excluded-tests.txt` contains all 16 tests with rationale
- [ ] Verify `scripts/run-curl-tests.sh` passes `-E` flag to runtests.pl