### PR TITLE
fix(auth): NTLM username length limit and IMAP credential quoting

### DIFF
--- a/crates/liburlx/src/auth/ntlm.rs
+++ b/crates/liburlx/src/auth/ntlm.rs
@@ -123,19 +123,30 @@ pub fn parse_type2_message(base64_msg: &str) -> Result<NtlmChallenge, Error> {
     Ok(NtlmChallenge { server_challenge, flags, target_info })
 }
 
+/// Maximum buffer size for NTLM Type 3 messages, matching curl's `NTLM_BUFSIZE`.
+const NTLM_BUFSIZE: usize = 1024;
+
+/// Size of the NTLM Type 3 message header (signature + type + 6 field descriptors + flags).
+const NTLM_TYPE3_HEADER_SIZE: usize = 64;
+
 /// Generate an NTLM Type 3 (Authenticate) message using `NTLMv1`.
 ///
 /// Uses `NTLMv1` (24-byte LM and NT responses) with OEM encoding,
 /// matching curl's NTLM implementation. Includes the `WORKSTATION` hostname.
 ///
-/// Returns the base64-encoded message.
-#[must_use]
+/// Returns the base64-encoded message, or an error if the credentials are
+/// too large (matching curl's `CURLE_TOO_LARGE` = 100 behavior).
+///
+/// # Errors
+///
+/// Returns [`Error::Transfer`] with code 100 if the combined size of domain,
+/// username, and workstation fields would exceed the NTLM buffer limit.
 pub fn create_type3_message(
     challenge: &NtlmChallenge,
     username: &str,
     password: &str,
     domain: &str,
-) -> String {
+) -> Result<String, Error> {
     use base64::Engine as _;
 
     let nt_hash = compute_nt_hash(password);
@@ -149,6 +160,22 @@ pub fn create_type3_message(
     let domain_bytes = domain.as_bytes().to_vec();
     let username_bytes = username.as_bytes().to_vec();
     let workstation_bytes = WORKSTATION.as_bytes().to_vec();
+
+    // Check total message size against NTLM buffer limit (curl compat: test 775).
+    // curl uses a fixed 1024-byte buffer for Type 3 messages and returns
+    // CURLE_TOO_LARGE (100) if domain + username + hostname exceed available space.
+    let payload_size = NTLM_TYPE3_HEADER_SIZE
+        + lm_response.len()
+        + nt_response.len()
+        + domain_bytes.len()
+        + username_bytes.len()
+        + workstation_bytes.len();
+    if payload_size >= NTLM_BUFSIZE {
+        return Err(Error::Transfer {
+            code: 100,
+            message: "user + domain + hostname too big for NTLM".to_string(),
+        });
+    }
 
     // Calculate offsets — Type 3 header is 64 bytes:
     // 8 (sig) + 4 (type) + 6*8 (fields) + 4 (flags) = 64
@@ -214,7 +241,7 @@ pub fn create_type3_message(
     msg.extend_from_slice(&username_bytes);
     msg.extend_from_slice(&workstation_bytes);
 
-    base64::engine::general_purpose::STANDARD.encode(&msg)
+    Ok(base64::engine::general_purpose::STANDARD.encode(&msg))
 }
 
 /// Compute the NT hash: `MD4(UTF-16LE(password))`.
@@ -420,7 +447,7 @@ mod tests {
             target_info: None,
         };
 
-        let msg = create_type3_message(&challenge, "user", "password", "DOMAIN");
+        let msg = create_type3_message(&challenge, "user", "password", "DOMAIN").unwrap();
         let data = base64::engine::general_purpose::STANDARD.decode(&msg).unwrap();
 
         // Verify signature
@@ -451,7 +478,7 @@ mod tests {
             target_info: None,
         };
 
-        let msg = create_type3_message(&challenge, "testuser", "testpass", "");
+        let msg = create_type3_message(&challenge, "testuser", "testpass", "").unwrap();
         let data = base64::engine::general_purpose::STANDARD.decode(&msg).unwrap();
 
         // Username should be OEM (ASCII), not UTF-16LE
@@ -480,7 +507,7 @@ mod tests {
         let type2_b64 = "TlRMTVNTUAACAAAAAgACADAAAACGggEAc51AYVDgyNcAAAAAAAAAAG4AbgAyAAAAQ0MCAAQAQwBDAAEAEgBFAEwASQBTAEEAQgBFAFQASAAEABgAYwBjAC4AaQBjAGUAZABlAHYALgBuAHUAAwAsAGUAbABpAHMAYQBiAGUAdABoAC4AYwBjAC4AaQBjAGUAZABlAHYALgBuAHUAAAAAAA==";
         let challenge = parse_type2_message(type2_b64).unwrap();
 
-        let msg = create_type3_message(&challenge, "testuser", "testpass", "");
+        let msg = create_type3_message(&challenge, "testuser", "testpass", "").unwrap();
         let actual = base64::engine::general_purpose::STANDARD.decode(&msg).unwrap();
 
         // Verify structural match (LM/NT responses will differ due to DES determinism,
@@ -525,7 +552,7 @@ mod tests {
         let type2_b64 = "TlRMTVNTUAACAAAAAgACADAAAACGggEAc51AYVDgyNcAAAAAAAAAAG4AbgAyAAAAQ0MCAAQAQwBDAAEAEgBFAEwASQBTAEEAQgBFAFQASAAEABgAYwBjAC4AaQBjAGUAZABlAHYALgBuAHUAAwAsAGUAbABpAHMAYQBiAGUAdABoAC4AYwBjAC4AaQBjAGUAZABlAHYALgBuAHUAAAAAAA==";
         let challenge = parse_type2_message(type2_b64).unwrap();
 
-        let msg = create_type3_message(&challenge, "myself", "secret", "mydomain");
+        let msg = create_type3_message(&challenge, "myself", "secret", "mydomain").unwrap();
         let actual = base64::engine::general_purpose::STANDARD.decode(&msg).unwrap();
 
         assert_eq!(actual.len(), expected.len(), "Type3 length must match for test 91");
@@ -540,8 +567,8 @@ mod tests {
             target_info: None,
         };
 
-        let msg1 = create_type3_message(&challenge, "user1", "pass", "DOM");
-        let msg2 = create_type3_message(&challenge, "user2", "pass", "DOM");
+        let msg1 = create_type3_message(&challenge, "user1", "pass", "DOM").unwrap();
+        let msg2 = create_type3_message(&challenge, "user2", "pass", "DOM").unwrap();
         assert_ne!(msg1, msg2);
     }
 
@@ -606,12 +633,27 @@ mod tests {
         };
 
         // Step 3: Create Type 3 with credentials
-        let type3 = create_type3_message(&challenge, "admin", "secret", "WORKGROUP");
+        let type3 = create_type3_message(&challenge, "admin", "secret", "WORKGROUP").unwrap();
         let type3_data = base64::engine::general_purpose::STANDARD.decode(&type3).unwrap();
         assert_eq!(
             u32::from_le_bytes([type3_data[8], type3_data[9], type3_data[10], type3_data[11]]),
             AUTHENTICATE_MESSAGE
         );
+    }
+
+    #[test]
+    fn type3_too_long_username_returns_error() {
+        // curl test 775: username longer than ~900 chars exceeds NTLM_BUFSIZE (1024)
+        let challenge = NtlmChallenge {
+            server_challenge: [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08],
+            flags: NTLMSSP_NEGOTIATE_NTLM | NTLMSSP_NEGOTIATE_OEM,
+            target_info: None,
+        };
+
+        // testuser + 1100 * 'A' = 1108 chars — exceeds 1024 buffer
+        let long_user = format!("testuser{}", "A".repeat(1100));
+        let result = create_type3_message(&challenge, &long_user, "testpass", "");
+        assert!(result.is_err(), "Too-long username must return an error");
     }
 
     #[test]

--- a/crates/liburlx/src/easy.rs
+++ b/crates/liburlx/src/easy.rs
@@ -3731,12 +3731,25 @@ async fn perform_transfer(
                                 if let Some(type2_data) = www_auth.strip_prefix("NTLM ") {
                                     let challenge =
                                         crate::auth::ntlm::parse_type2_message(type2_data)?;
-                                    let type3 = crate::auth::ntlm::create_type3_message(
+                                    let type3 = match crate::auth::ntlm::create_type3_message(
                                         &challenge,
                                         &auth.username,
                                         &auth.password,
                                         domain,
-                                    );
+                                    ) {
+                                        Ok(t3) => t3,
+                                        Err(e) => {
+                                            // NTLM Type 3 too large: store the 401
+                                            // headers (without body) so the CLI can
+                                            // output them before the error (curl compat: test 775).
+                                            let mut headers_only = response.clone();
+                                            headers_only.set_body(Vec::new());
+                                            if let Ok(mut guard) = last_resp_store.lock() {
+                                                *guard = Some(headers_only);
+                                            }
+                                            return Err(e);
+                                        }
+                                    };
 
                                     // Save the Type 2 401 response for --include output
                                     redirect_chain.push(response.clone());
@@ -3934,7 +3947,7 @@ async fn perform_transfer(
                                     &pcreds.username,
                                     &pcreds.password,
                                     domain,
-                                );
+                                )?;
 
                                 // Save the 407 response for --include output
                                 redirect_chain.push(response.clone());
@@ -4250,12 +4263,13 @@ async fn perform_transfer(
                                                         type2_data,
                                                     )?;
                                                 let domain = pcreds.domain.as_deref().unwrap_or("");
-                                                let type3 = crate::auth::ntlm::create_type3_message(
-                                                    &challenge,
-                                                    &pcreds.username,
-                                                    &pcreds.password,
-                                                    domain,
-                                                );
+                                                let type3 =
+                                                    crate::auth::ntlm::create_type3_message(
+                                                        &challenge,
+                                                        &pcreds.username,
+                                                        &pcreds.password,
+                                                        domain,
+                                                    )?;
                                                 redirect_chain.push(type1_resp);
                                                 let mut type3_headers = request_headers.clone();
                                                 type3_headers.retain(|(k, _)| {
@@ -6761,7 +6775,7 @@ where
                                 &creds.username,
                                 &creds.password,
                                 domain,
-                            );
+                            )?;
 
                             // Send CONNECT with Type 3
                             let (status3, _, raw3) = send_connect_request(
@@ -6849,7 +6863,7 @@ where
                                                 &creds.username,
                                                 &creds.password,
                                                 domain,
-                                            );
+                                            )?;
                                             let (status3, _, raw3) = send_connect_request(
                                                 &mut stream,
                                                 target_host,

--- a/crates/liburlx/src/protocol/imap.rs
+++ b/crates/liburlx/src/protocol/imap.rs
@@ -967,7 +967,7 @@ async fn do_imap_auth<S: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
         let cont2 = read_continuation(reader).await?;
         let challenge_b64 = cont2.trim_start_matches('+').trim();
         if let Ok(challenge) = crate::auth::ntlm::parse_type2_message(challenge_b64) {
-            let type3 = crate::auth::ntlm::create_type3_message(&challenge, user, pass, "");
+            let type3 = crate::auth::ntlm::create_type3_message(&challenge, user, pass, "")?;
             send_raw(writer, type3.as_bytes()).await?;
             let auth_resp = read_response(reader, &tag).await?;
             if auth_resp.is_ok() {

--- a/crates/liburlx/src/protocol/pop3.rs
+++ b/crates/liburlx/src/protocol/pop3.rs
@@ -687,7 +687,7 @@ async fn do_pop3_auth<S: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
         let _ = reader.read_line(&mut line2).await;
         let challenge_b64 = line2.trim().trim_start_matches('+').trim();
         if let Ok(challenge) = crate::auth::ntlm::parse_type2_message(challenge_b64) {
-            let type3 = crate::auth::ntlm::create_type3_message(&challenge, user, pass, "");
+            let type3 = crate::auth::ntlm::create_type3_message(&challenge, user, pass, "")?;
             writer
                 .write_all(format!("{type3}\r\n").as_bytes())
                 .await

--- a/crates/liburlx/src/protocol/smtp.rs
+++ b/crates/liburlx/src/protocol/smtp.rs
@@ -642,7 +642,7 @@ async fn do_auth<S: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
             // Parse Type 2 and generate Type 3
             let challenge_b64 = resp2.message.trim();
             if let Ok(challenge) = crate::auth::ntlm::parse_type2_message(challenge_b64) {
-                let type3 = crate::auth::ntlm::create_type3_message(&challenge, user, pass, "");
+                let type3 = crate::auth::ntlm::create_type3_message(&challenge, user, pass, "")?;
                 send_command(writer, &type3).await?;
                 let auth_resp = read_response(reader).await?;
                 if auth_resp.is_ok() {

--- a/crates/urlx-cli/src/transfer.rs
+++ b/crates/urlx-cli/src/transfer.rs
@@ -944,22 +944,31 @@ pub fn run(args: &[String]) -> ExitCode {
                 || url.starts_with("pop3://")
                 || url.starts_with("pop3s://")
             {
-                // Reject credentials with characters that break URL parsing
-                // (curl compat: test 896 — `"` and `{` in credentials)
-                let has_bad_char = |s: &str| s.contains('"') || s.contains('{') || s.contains('}');
-                if has_bad_char(user) || has_bad_char(pass) {
-                    if !opts.silent || opts.show_error {
-                        eprintln!("curl: (3) URL using bad/illegal format or missing URL");
+                // Percent-encode special chars in credentials for URL embedding
+                // (curl compat: test 895/896 — `"`, `{`, `}` in credentials)
+                let encode_userinfo = |s: &str| -> String {
+                    let mut out = String::with_capacity(s.len());
+                    for c in s.chars() {
+                        match c {
+                            '"' => out.push_str("%22"),
+                            '{' => out.push_str("%7B"),
+                            '}' => out.push_str("%7D"),
+                            '@' => out.push_str("%40"),
+                            ':' => out.push_str("%3A"),
+                            _ => out.push(c),
+                        }
                     }
-                    return ExitCode::from(3);
-                }
+                    out
+                };
+                let encoded_user = encode_userinfo(user);
+                let encoded_pass = encode_userinfo(pass);
                 let base_url = strip_url_credentials(&url);
                 let scheme_end = base_url.find("://").map_or(0, |p| p + 3);
                 let new_url = format!(
                     "{}{}:{}@{}",
                     &base_url[..scheme_end],
-                    user,
-                    pass,
+                    encoded_user,
+                    encoded_pass,
                     &base_url[scheme_end..]
                 );
                 if let Err(e) = opts.easy.url(&new_url) {


### PR DESCRIPTION
## Summary

- Add NTLM Type 3 message size check matching curl's `NTLM_BUFSIZE` (1024 bytes). Returns `CURLE_TOO_LARGE` (100) when credentials exceed the buffer instead of generating an oversized message.
- Change `create_type3_message` from `-> String` to `-> Result<String, Error>` with proper error propagation through all callers (easy.rs, imap.rs, smtp.rs, pop3.rs).
- Store headers-only 401 response before NTLM error so CLI outputs response headers matching curl behavior.
- Percent-encode special characters (`"`, `{`, `}`) in `-u` credentials for non-HTTP protocols instead of rejecting them, enabling IMAP LOGIN with quoted usernames.

## Curl test results

| Test | Description | Result |
|------|------------|--------|
| 547 | HTTP POST proxy NTLM auth (read callback) | PASS |
| 548 | HTTP POST proxy NTLM auth (POSTFIELDS) | PASS |
| 555 | HTTP POST proxy NTLM auth (multi interface) | PASS |
| 560 | HTTPS GET multi interface | SKIP (stunnel HTTPS server infra) |
| 694 | HTTP NTLM twice, verify auth used | PASS |
| 775 | HTTP NTLM with too-long username (error 100) | PASS |
| 895 | IMAP with --login-options 'AUTH=*' | PASS |

Test 560 is skipped due to HTTPS test server (stunnel) infrastructure not starting — this is a pre-existing environment issue, not a code problem. It uses a libcurl C test binary (lib560) testing the multi-interface, not our CLI binary.

## Test plan

- [x] All 23 NTLM unit tests pass
- [x] All workspace tests pass (2655 tests)
- [x] `cargo fmt`, `cargo clippy`, `cargo test`, `cargo doc` all pass
- [x] 6/7 curl tests pass, 1 skipped (infra)
- [x] No regressions in existing NTLM tests (67, 68, 91)