### PR TITLE
fix(http,tls,cookie,cli): pass 7 HTTP headers/encoding/TLS edge case tests

### DIFF
--- a/crates/liburlx/src/cookie.rs
+++ b/crates/liburlx/src/cookie.rs
@@ -502,12 +502,16 @@ impl CookieJar {
                             path = p.to_string();
                         }
                     } else if attr_name.eq_ignore_ascii_case("expires") {
+                        // Reject date strings >= MAX_DATE_LENGTH (curl compat: test 483)
+                        const MAX_DATE_LENGTH: usize = 80;
                         // Parse date in various formats (RFC 2616, Netscape, etc.)
-                        if let Some(t) = parse_cookie_date(attr_value) {
-                            // Only set if max-age hasn't already been set
-                            // (max-age takes precedence per RFC 6265 §5.3)
-                            if expires.is_none() {
-                                expires = Some(cap_cookie_expiry(t));
+                        if attr_value.len() < MAX_DATE_LENGTH {
+                            if let Some(t) = parse_cookie_date(attr_value) {
+                                // Only set if max-age hasn't already been set
+                                // (max-age takes precedence per RFC 6265 §5.3)
+                                if expires.is_none() {
+                                    expires = Some(cap_cookie_expiry(t));
+                                }
                             }
                         }
                     } else if attr_name.eq_ignore_ascii_case("max-age") {

--- a/crates/liburlx/src/easy.rs
+++ b/crates/liburlx/src/easy.rs
@@ -1465,6 +1465,14 @@ impl Easy {
         self.tls_config.ca_cert = Some(path.to_path_buf());
     }
 
+    /// Set the path to a CRL (Certificate Revocation List) file in PEM format.
+    ///
+    /// When set, the server's certificate chain is checked against this CRL.
+    /// Equivalent to curl's `--crlfile` flag or `CURLOPT_CRLFILE`.
+    pub fn ssl_crl_file(&mut self, path: &Path) {
+        self.tls_config.crl_file = Some(path.to_path_buf());
+    }
+
     /// Set the path to a client certificate in PEM format.
     ///
     /// Used for mutual TLS (mTLS) authentication.
@@ -5542,7 +5550,16 @@ async fn do_single_request(
                     }
                     return Ok(maybe_decompress_inner(response, accept_encoding, raw));
                 }
-                Err(_) => {
+                Err(e) => {
+                    // Only retry on a fresh connection for I/O-level errors
+                    // (stale/reset connections). For protocol-level errors like
+                    // version mismatch or weird server reply, propagate immediately
+                    // (curl compat: test 471 — HTTP/1.1 to HTTP/2 switch).
+                    match &e {
+                        Error::Http(msg) if msg.contains("Weird server reply") => return Err(e),
+                        Error::UnsupportedProtocol(_) => return Err(e),
+                        _ => {}
+                    }
                     // Pooled connection was stale — fall through to create new one
                     if verbose {
                         #[allow(clippy::print_stderr)]

--- a/crates/liburlx/src/protocol/http/h1.rs
+++ b/crates/liburlx/src/protocol/http/h1.rs
@@ -599,6 +599,36 @@ where
         }
     }
 
+    // If parse_headers detected a control-character body error (e.g., CR in
+    // Content-Length value), return the raw header bytes before the bad line
+    // as response body (curl outputs raw data on weird server reply — test 415).
+    if let Some(body_err) = ph.body_error {
+        // Build raw header bytes from the truncated (valid) parsed headers
+        let line_ending: &[u8] = if ph.uses_crlf { b"\r\n" } else { b"\n" };
+        let mut raw_body = Vec::new();
+        // Status line
+        if let Some(first_line_end) =
+            header_bytes.windows(line_ending.len()).position(|w| w == line_ending)
+        {
+            raw_body.extend_from_slice(&header_bytes[..first_line_end]);
+            raw_body.extend_from_slice(line_ending);
+        }
+        // Valid header lines (before the bad one)
+        for (k, v) in &ph.headers_ordered {
+            raw_body.extend_from_slice(k.as_bytes());
+            raw_body.extend_from_slice(v.as_bytes());
+            raw_body.extend_from_slice(line_ending);
+        }
+        let mut resp = Response::new(ph.status, ph.headers.clone(), raw_body, url.to_string());
+        resp.set_headers_ordered(ph.headers_ordered);
+        resp.set_status_reason(ph.reason);
+        resp.set_uses_crlf(ph.uses_crlf);
+        resp.set_http_version(ph.version);
+        resp.set_raw_headers(Vec::new());
+        resp.set_body_error(Some(body_err));
+        return Ok((resp, true));
+    }
+
     // 204 and 304 responses have no body per HTTP spec.
     // Also skip body when a Range request got a non-206/416 response
     // (server doesn't support ranges — curl returns CURLE_RANGE_ERROR
@@ -830,12 +860,17 @@ where
 
         buf.extend_from_slice(&tmp[..n]);
 
-        // Check for end of headers (supports both \r\n\r\n and \n\n)
-        if let Some((pos, len)) = find_header_end(&buf) {
-            let header_end = pos + len;
-            let body_prefix = buf[header_end..].to_vec();
-            buf.truncate(header_end);
-            return Ok((buf, body_prefix));
+        // Only look for header end if the response starts with "HTTP/"
+        // (an HTTP status line). Otherwise this is HTTP/0.9 — raw body
+        // without headers. Keep reading until EOF (curl compat: test 306).
+        if buf.starts_with(b"HTTP/") {
+            // Check for end of headers (supports both \r\n\r\n and \n\n)
+            if let Some((pos, len)) = find_header_end(&buf) {
+                let header_end = pos + len;
+                let body_prefix = buf[header_end..].to_vec();
+                buf.truncate(header_end);
+                return Ok((buf, body_prefix));
+            }
         }
 
         if buf.len() > MAX_HEADER_SIZE {
@@ -910,6 +945,8 @@ struct ParsedHeaders {
     headers: HashMap<String, String>,
     original_names: HashMap<String, String>,
     headers_ordered: Vec<(String, String)>,
+    /// If set, indicates a header-level error that should be returned as `body_error`.
+    body_error: Option<String>,
 }
 
 /// Parse raw header bytes into structured response headers.
@@ -928,6 +965,59 @@ fn parse_headers(data: &[u8]) -> Result<ParsedHeaders, Error> {
         return Err(Error::Http("Weird server reply: binary zero in headers".to_string()));
     }
 
+    // Check for control characters (bare CR not followed by LF) in header values
+    // that would cause httparse to fail. Truncate headers at the offending line
+    // and flag as body_error (curl compat: test 415 — Content-Length: \r-6).
+    let mut trunc_body_error: Option<String> = None;
+    let data_slice = &data[..header_end];
+    let truncated_data = {
+        let mut truncated: Option<Vec<u8>> = None;
+        // Scan header lines (skip status line)
+        let lines_start = data_slice
+            .windows(2)
+            .position(|w| w == b"\r\n")
+            .map(|p| p + 2)
+            .or_else(|| data_slice.iter().position(|&b| b == b'\n').map(|p| p + 1))
+            .unwrap_or(0);
+        let mut pos = lines_start;
+        while pos < data_slice.len() {
+            // Find end of this line
+            let line_end = data_slice[pos..]
+                .windows(2)
+                .position(|w| w == b"\r\n")
+                .map(|p| pos + p + 2)
+                .or_else(|| data_slice[pos..].iter().position(|&b| b == b'\n').map(|p| pos + p + 1))
+                .unwrap_or(data_slice.len());
+            let line = &data_slice[pos..line_end];
+            // Check if this header line has a bare CR in the value area
+            // (after the colon). A bare CR is \r NOT followed by \n.
+            if let Some(colon_pos) = line.iter().position(|&b| b == b':') {
+                let value_area = &line[colon_pos + 1..];
+                let has_bare_cr = value_area.windows(2).any(|w| w[0] == b'\r' && w[1] != b'\n')
+                    || (value_area.last() == Some(&b'\r') && !value_area.ends_with(b"\r\n"));
+                if has_bare_cr {
+                    // Truncate headers at this line
+                    let line_ending = if data_slice[..pos].ends_with(b"\r\n") {
+                        b"\r\n" as &[u8]
+                    } else {
+                        b"\n" as &[u8]
+                    };
+                    let mut trunc = data_slice[..pos].to_vec();
+                    trunc.extend_from_slice(line_ending);
+                    truncated = Some(trunc);
+                    trunc_body_error = Some("negative_content_length".to_string());
+                    break;
+                }
+            }
+            if line == b"\r\n" || line == b"\n" {
+                break; // End of headers
+            }
+            pos = line_end;
+        }
+        truncated
+    };
+    let data = truncated_data.as_ref().map_or(data_slice, |trunc| trunc.as_slice());
+
     // Unfold HTTP header continuation lines (RFC 2616 §2.2, obsoleted but still supported
     // for compat). A line starting with SP or HT is a continuation of the previous header.
     // Replace "\r\n " / "\r\n\t" / "\n " / "\n\t" with a single space.
@@ -940,7 +1030,14 @@ fn parse_headers(data: &[u8]) -> Result<ParsedHeaders, Error> {
     let header_len = match parsed.parse(data) {
         Ok(httparse::Status::Complete(len)) => len,
         Ok(httparse::Status::Partial) => {
-            return Err(Error::Http("incomplete response headers".to_string()));
+            // If we truncated headers, this is expected — the truncated block
+            // doesn't have a final \r\n\r\n after the last header line.
+            // Fall through to use what we have.
+            if trunc_body_error.is_some() {
+                data.len()
+            } else {
+                return Err(Error::Http("incomplete response headers".to_string()));
+            }
         }
         Err(e) => {
             let emsg = e.to_string();
@@ -948,6 +1045,11 @@ fn parse_headers(data: &[u8]) -> Result<ParsedHeaders, Error> {
             // curl returns CURLE_UNSUPPORTED_PROTOCOL (1) for these.
             // Only treat as version error if the response actually started with "HTTP/".
             if emsg.contains("invalid HTTP version") && data.starts_with(b"HTTP/") {
+                // HTTP/2 or HTTP/3 status line on HTTP/1.x connection = version
+                // mismatch → CURLE_WEIRD_SERVER_REPLY (8) (curl compat: test 471)
+                if data.starts_with(b"HTTP/2") || data.starts_with(b"HTTP/3") {
+                    return Err(Error::Http("Weird server reply: version mismatch".to_string()));
+                }
                 return Err(Error::UnsupportedProtocol(
                     "unsupported HTTP version in response".to_string(),
                 ));
@@ -1051,6 +1153,7 @@ fn parse_headers(data: &[u8]) -> Result<ParsedHeaders, Error> {
         headers,
         original_names,
         headers_ordered,
+        body_error: trunc_body_error,
     })
 }
 
@@ -1171,6 +1274,7 @@ fn parse_headers_large(data: &[u8]) -> Result<ParsedHeaders, Error> {
         headers,
         original_names,
         headers_ordered,
+        body_error: None,
     })
 }
 

--- a/crates/liburlx/src/tls.rs
+++ b/crates/liburlx/src/tls.rs
@@ -95,6 +95,13 @@ pub struct TlsConfig {
     /// Alternative to `client_key` (file path). Must correspond to the
     /// client certificate. Equivalent to `CURLOPT_SSLKEY_BLOB`.
     pub client_key_blob: Option<Vec<u8>>,
+
+    /// Path to a CRL (Certificate Revocation List) file in PEM format.
+    ///
+    /// When set, the server's certificate chain is checked against this CRL.
+    /// If any certificate in the chain has been revoked, the connection fails
+    /// with error 60. Equivalent to curl's `--crlfile`.
+    pub crl_file: Option<PathBuf>,
 }
 
 impl Default for TlsConfig {
@@ -113,6 +120,7 @@ impl Default for TlsConfig {
             ca_cert_blob: None,
             client_cert_blob: None,
             client_key_blob: None,
+            crl_file: None,
         }
     }
 }
@@ -190,13 +198,37 @@ mod rustls_impl {
                 // Custom CA bundle from file
                 let root_store = load_ca_certs(ca_path)?;
 
-                let builder = Self::config_builder(&versions).with_root_certificates(root_store);
+                // When a CRL file is specified, build a custom verifier with
+                // CRL checking (curl compat: test 313 — --crlfile)
+                if let Some(ref crl_path) = tls_config.crl_file {
+                    let crls = load_crls(crl_path)?;
+                    let verifier =
+                        rustls::client::WebPkiServerVerifier::builder(Arc::new(root_store))
+                            .with_crls(crls)
+                            .build()
+                            .map_err(|e| {
+                                Error::Tls(format!("CRL verifier build failed: {e}").into())
+                            })?;
 
-                let mut config = Self::with_client_auth(builder, tls_config)?;
-                if use_http_alpn {
-                    Self::configure_alpn(&mut config);
+                    let builder = Self::config_builder(&versions)
+                        .dangerous()
+                        .with_custom_certificate_verifier(verifier);
+
+                    let mut config = builder.with_no_client_auth();
+                    if use_http_alpn {
+                        Self::configure_alpn(&mut config);
+                    }
+                    config
+                } else {
+                    let builder =
+                        Self::config_builder(&versions).with_root_certificates(root_store);
+
+                    let mut config = Self::with_client_auth(builder, tls_config)?;
+                    if use_http_alpn {
+                        Self::configure_alpn(&mut config);
+                    }
+                    config
                 }
-                config
             } else if let Some(ref ca_blob) = tls_config.ca_cert_blob {
                 // Custom CA bundle from in-memory blob
                 let root_store = load_ca_certs_from_blob(ca_blob)?;
@@ -478,6 +510,25 @@ mod rustls_impl {
         }
 
         Ok(root_store)
+    }
+
+    /// Load CRLs (Certificate Revocation Lists) from a PEM file.
+    fn load_crls(
+        path: &std::path::Path,
+    ) -> Result<Vec<rustls::pki_types::CertificateRevocationListDer<'static>>, Error> {
+        use rustls::pki_types::pem::PemObject;
+        use rustls::pki_types::CertificateRevocationListDer;
+
+        let crls = CertificateRevocationListDer::pem_file_iter(path)
+            .map_err(|e| Error::Tls(Box::new(e)))?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| Error::Tls(Box::new(e)))?;
+
+        if crls.is_empty() {
+            return Err(Error::Tls("no valid CRLs found in file".into()));
+        }
+
+        Ok(crls)
     }
 
     /// Load client certificates from a PEM file.

--- a/crates/urlx-cli/src/args.rs
+++ b/crates/urlx-cli/src/args.rs
@@ -88,6 +88,8 @@ pub struct CliOptions {
     pub(crate) proto_default: Option<String>,
     pub(crate) output_dir: Option<String>,
     pub(crate) remove_on_error: bool,
+    /// `--no-clobber`: don't overwrite existing output files, append `.1`, `.2`, etc.
+    pub(crate) no_clobber: bool,
     pub(crate) fail_with_body: bool,
     pub(crate) fail_early: bool,
     pub(crate) retry_all_errors: bool,
@@ -662,6 +664,7 @@ fn parse_args_options_with_depth(args: &[String], config_depth: u32) -> Result<C
         proto_default: None,
         output_dir: None,
         remove_on_error: false,
+        no_clobber: false,
         fail_with_body: false,
         fail_early: false,
         retry_all_errors: false,
@@ -1066,6 +1069,11 @@ fn parse_args_options_with_depth(args: &[String], config_depth: u32) -> Result<C
                 i += 1;
                 let val = require_arg(args, i, "--cacert")?;
                 opts.easy.ssl_ca_cert(std::path::Path::new(val));
+            }
+            "--crlfile" => {
+                i += 1;
+                let val = require_arg(args, i, "--crlfile")?;
+                opts.easy.ssl_crl_file(std::path::Path::new(val));
             }
             "--cert" => {
                 i += 1;
@@ -1962,6 +1970,9 @@ fn parse_args_options_with_depth(args: &[String], config_depth: u32) -> Result<C
             "--remove-on-error" => {
                 opts.remove_on_error = true;
             }
+            "--no-clobber" => {
+                opts.no_clobber = true;
+            }
             "--skip-existing" => {
                 opts.skip_existing = true;
             }
@@ -2049,7 +2060,6 @@ fn parse_args_options_with_depth(args: &[String], config_depth: u32) -> Result<C
             | "--basic"
             | "--proxy-basic"
             | "--tcp-fastopen"
-            | "--no-clobber"
             | "--ca-native"
             | "--no-ca-native"
             | "--disallow-username-in-url"
@@ -2136,7 +2146,6 @@ fn parse_args_options_with_depth(args: &[String], config_depth: u32) -> Result<C
             | "--pass"
             | "--proxy-cert-type"
             | "--proxy-key-type"
-            | "--crlfile"
             | "--proxy-crlfile"
             | "--proxy-pinnedpubkey"
             | "--proxy-pass"

--- a/crates/urlx-cli/src/transfer.rs
+++ b/crates/urlx-cli/src/transfer.rs
@@ -1071,6 +1071,26 @@ pub fn run(args: &[String]) -> ExitCode {
         }
     }
 
+    // --no-clobber: if output file exists, rename to .1, .2, etc. (curl compat: test 379)
+    if opts.no_clobber {
+        if let Some(ref path) = opts.output_file {
+            if std::path::Path::new(path).exists() {
+                let mut n = 1u32;
+                loop {
+                    let candidate = format!("{path}.{n}");
+                    if !std::path::Path::new(&candidate).exists() {
+                        opts.output_file = Some(candidate);
+                        break;
+                    }
+                    n += 1;
+                    if n > 100 {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
     // -C - auto-resume: determine offset from existing output file size
     if opts.auto_resume {
         if opts.is_upload {


### PR DESCRIPTION
## Summary

- **Test 306**: Fix HTTP/0.9 detection over HTTPS — don't treat body data containing `\n\n` as header terminators when response doesn't start with `HTTP/`
- **Test 313**: Implement `--crlfile` for CRL-based certificate revocation checking via rustls `WebPkiServerVerifier`
- **Test 373**: Already passing (chunked null bytes)
- **Test 379**: Implement `--no-clobber` with automatic file numbering (`.1`, `.2`) and proper `--remove-on-error` interaction
- **Test 415**: Handle Content-Length with control characters (bare CR) — detect, truncate headers, output valid prefix as body data, return error 8
- **Test 471**: Return error 8 for HTTP/2 status line on HTTP/1.x connection; don't retry protocol errors on fresh connections
- **Test 483**: Add `MAX_DATE_LENGTH=80` check to cookie expires parsing (curl compat)

## Test plan

- [x] All 7 target tests pass: `runtests.pl 306 313 373 379 415 471 483`
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets` clean
- [x] `cargo test` passes (all 312+ Rust tests)
- [ ] Full curl test suite regression check (tests 1-1400)