### PR TITLE
fix(imap): pass IMAP edge case tests 795, 800, 815, 816, 847, 897, 1221

### DIFF
--- a/crates/liburlx/src/easy.rs
+++ b/crates/liburlx/src/easy.rs
@@ -5026,6 +5026,99 @@ async fn perform_transfer(
                     }
                 }
 
+                // Cross-protocol redirect to IMAP: perform IMAP transfer
+                // (curl compat: test 795)
+                if next_scheme == "imap" || next_scheme == "imaps" {
+                    redirect_chain.push(response);
+
+                    let imap_result = Box::pin(do_single_request(
+                        &next_url,
+                        "GET",
+                        &[],
+                        None,
+                        verbose,
+                        false,
+                        connect_timeout,
+                        proxy.cloned().as_ref(),
+                        proxy_credentials,
+                        resolve_overrides,
+                        tls_config,
+                        tcp_nodelay,
+                        tcp_keepalive,
+                        unix_socket,
+                        interface,
+                        local_port,
+                        dns_shuffle,
+                        dns_cache,
+                        pool,
+                        #[cfg(feature = "http2")]
+                        h2_pool,
+                        http_version,
+                        expect_100_timeout,
+                        happy_eyeballs_timeout,
+                        ignore_content_length,
+                        speed_limits,
+                        ftp_ssl_mode,
+                        use_ssl,
+                        ssh_key_path,
+                        proxy_tls_config,
+                        alt_svc_cache,
+                        #[cfg(feature = "http2")]
+                        h2_config,
+                        dns_resolver,
+                        custom_request_target,
+                        tftp_blksize,
+                        tftp_no_options,
+                        #[cfg(feature = "ssh")]
+                        ssh_host_key_policy,
+                        mail_from,
+                        mail_rcpt,
+                        fresh_connect,
+                        forbid_reuse,
+                        ftp_config,
+                        proxy_headers,
+                        connect_to,
+                        path_as_is,
+                        #[cfg(feature = "ssh")]
+                        ssh_public_keyfile,
+                        #[cfg(not(feature = "ssh"))]
+                        None,
+                        #[cfg(feature = "ssh")]
+                        ssh_auth_types,
+                        #[cfg(not(feature = "ssh"))]
+                        None,
+                        mail_auth,
+                        sasl_authzid,
+                        login_options,
+                        sasl_ir,
+                        oauth2_bearer,
+                        haproxy_protocol,
+                        abstract_unix_socket,
+                        chunked_upload,
+                        http09_allowed,
+                        deadline,
+                        http_proxy_tunnel,
+                        proxy_http_10,
+                        raw,
+                        ftp_session,
+                        true,
+                    ))
+                    .await;
+
+                    match imap_result {
+                        Ok(mut imap_resp) => {
+                            // Clear IMAP protocol headers and body — don't include them
+                            // in output when redirecting from HTTP to IMAP.
+                            // Only the HTTP redirect headers are shown (curl compat: test 795).
+                            imap_resp.set_raw_headers(Vec::new());
+                            imap_resp.set_body(Vec::new());
+                            imap_resp.set_redirect_responses(redirect_chain);
+                            return Ok(imap_resp);
+                        }
+                        Err(e) => return Err(e),
+                    }
+                }
+
                 // Capture intermediate redirect response for -L --include output
                 redirect_chain.push(response);
 

--- a/crates/liburlx/src/protocol/imap.rs
+++ b/crates/liburlx/src/protocol/imap.rs
@@ -10,6 +10,23 @@ use crate::error::Error;
 use crate::protocol::ftp::UseSsl;
 use crate::protocol::http::response::Response;
 
+tokio::task_local! {
+    /// Per-task IMAP protocol transcript buffer for `-D` header dump.
+    static IMAP_TRANSCRIPT: std::cell::RefCell<Vec<u8>>;
+}
+
+/// Record a line to the IMAP protocol transcript (if recording is active).
+fn record_transcript(data: &[u8]) {
+    let _ = IMAP_TRANSCRIPT.try_with(|t| {
+        t.borrow_mut().extend_from_slice(data);
+    });
+}
+
+/// Take the accumulated IMAP transcript, leaving an empty buffer.
+fn take_transcript() -> Vec<u8> {
+    IMAP_TRANSCRIPT.try_with(|t| std::mem::take(&mut *t.borrow_mut())).unwrap_or_default()
+}
+
 /// An IMAP response from the server.
 #[derive(Debug, Clone)]
 pub struct ImapResponse {
@@ -70,6 +87,8 @@ async fn read_response<S: AsyncRead + Unpin>(
         if bytes_read == 0 {
             return Err(Error::Http("IMAP connection closed unexpectedly".to_string()));
         }
+
+        record_transcript(line.as_bytes());
 
         let trimmed = line.trim_end_matches('\n').trim_end_matches('\r');
 
@@ -147,6 +166,8 @@ async fn read_greeting<S: AsyncRead + Unpin>(stream: &mut BufReader<S>) -> Resul
             return Err(Error::Http("IMAP connection closed before greeting".to_string()));
         }
 
+        record_transcript(line.as_bytes());
+
         let trimmed = line.trim();
         if trimmed.starts_with("* OK") || trimmed.starts_with("* PREAUTH") {
             return Ok(trimmed.to_string());
@@ -171,6 +192,7 @@ async fn read_continuation<S: AsyncRead + Unpin>(
     if bytes_read == 0 {
         return Err(Error::Http("IMAP connection closed waiting for continuation".to_string()));
     }
+    record_transcript(line.as_bytes());
     Ok(line.trim().to_string())
 }
 
@@ -361,6 +383,43 @@ pub async fn fetch(
     use_ssl: UseSsl,
     tls_config: &crate::tls::TlsConfig,
 ) -> Result<Response, Error> {
+    IMAP_TRANSCRIPT
+        .scope(std::cell::RefCell::new(Vec::new()), async {
+            fetch_inner(
+                url,
+                method,
+                body,
+                custom_request,
+                sasl_ir,
+                oauth2_bearer,
+                login_options,
+                sasl_authzid,
+                resolve_overrides,
+                tag_prefix,
+                use_ssl,
+                tls_config,
+            )
+            .await
+        })
+        .await
+}
+
+/// Inner implementation of [`fetch`], runs within an `IMAP_TRANSCRIPT` scope.
+#[allow(clippy::too_many_lines, clippy::too_many_arguments)]
+async fn fetch_inner(
+    url: &crate::url::Url,
+    method: &str,
+    body: Option<&[u8]>,
+    custom_request: Option<&str>,
+    sasl_ir: bool,
+    oauth2_bearer: Option<&str>,
+    login_options: Option<&str>,
+    sasl_authzid: Option<&str>,
+    resolve_overrides: &[(String, String)],
+    tag_prefix: char,
+    use_ssl: UseSsl,
+    tls_config: &crate::tls::TlsConfig,
+) -> Result<Response, Error> {
     // Reject URLs with CR or LF in the path (curl compat: test 829).
     // Check BEFORE credentials or connection setup.
     let path = url.path();
@@ -530,6 +589,10 @@ pub async fn fetch(
     )
     .await;
 
+    // Capture protocol transcript BEFORE LOGOUT for -D header dump (curl compat: test 897).
+    // Strip FETCH body content from the transcript — only protocol framing should appear.
+    let transcript_data = strip_fetch_body_from_transcript(&take_transcript());
+
     // LOGOUT — always send, even on error (curl compat: test 803)
     let tag = tags.next_tag();
     if send_command(&mut writer, &tag, "LOGOUT").await.is_ok() {
@@ -541,9 +604,8 @@ pub async fn fetch(
 
     let headers = std::collections::HashMap::new();
     let mut resp = Response::new(200, headers, response_body, url.as_str().to_string());
-    // Set empty raw headers so the CLI doesn't synthesize HTTP framing for
-    // a non-HTTP protocol response.
-    resp.set_raw_headers(Vec::new());
+    // Set the protocol transcript as raw headers for -D header dump.
+    resp.set_raw_headers(transcript_data);
     Ok(resp)
 }
 
@@ -1317,6 +1379,58 @@ fn extract_fetch_body(data: &[String]) -> Vec<u8> {
 fn strip_auth_from_username(username: &str) -> String {
     let upper = username.to_uppercase();
     upper.find(";AUTH=").map_or_else(|| username.to_string(), |pos| username[..pos].to_string())
+}
+
+/// Strip FETCH body content from an IMAP protocol transcript.
+///
+/// IMAP FETCH responses include literal body data between `{SIZE}\r\n` and the
+/// closing envelope line.  The `-D` header dump should only contain protocol
+/// framing, not message body content (curl compat: test 897).
+fn strip_fetch_body_from_transcript(transcript: &[u8]) -> Vec<u8> {
+    let text = String::from_utf8_lossy(transcript);
+    let mut result = Vec::with_capacity(transcript.len());
+    let mut skip_body = false;
+    let mut literal_remaining: usize = 0;
+
+    for line in text.split_inclusive('\n') {
+        if skip_body {
+            // Count consumed bytes until we've passed the literal size
+            if literal_remaining > 0 {
+                let line_bytes = line.len();
+                if line_bytes >= literal_remaining {
+                    literal_remaining = 0;
+                    // This line contains the end of the literal; skip it entirely.
+                    // The next line is the closing envelope.
+                    continue;
+                }
+                literal_remaining -= line_bytes;
+                continue;
+            }
+            // Literal exhausted — this line is the closing envelope (ends with `)\r\n`)
+            result.extend_from_slice(line.as_bytes());
+            skip_body = false;
+            continue;
+        }
+
+        // Check for FETCH literal: `* NNN FETCH (BODY[...] {SIZE}\r\n`
+        if line.contains("FETCH") && line.contains('{') {
+            if let Some(brace_start) = line.rfind('{') {
+                let after_brace = &line[brace_start + 1..];
+                let size_str: String =
+                    after_brace.chars().take_while(char::is_ascii_digit).collect();
+                if let Ok(size) = size_str.parse::<usize>() {
+                    result.extend_from_slice(line.as_bytes());
+                    skip_body = true;
+                    literal_remaining = size;
+                    continue;
+                }
+            }
+        }
+
+        result.extend_from_slice(line.as_bytes());
+    }
+
+    result
 }
 
 /// Percent-decode a URL path segment.

--- a/crates/urlx-cli/src/args.rs
+++ b/crates/urlx-cli/src/args.rs
@@ -717,8 +717,10 @@ fn parse_args_options_with_depth(args: &[String], config_depth: u32) -> Result<C
                 let val = require_arg(args, i, "-X")?;
                 opts.easy.method(val);
                 // Store original case value for non-HTTP protocols
-                // (IMAP/POP3/SMTP use -X as custom protocol command)
+                // (IMAP/POP3/SMTP use -X as custom protocol command).
+                // Also set on the Easy handle so --next clones preserve it.
                 opts.custom_request_original = Some(val.to_string());
+                opts.easy.custom_request_target(val);
             }
             "-H" | "--header" => {
                 i += 1;
@@ -2234,6 +2236,7 @@ fn parse_args_options_with_depth(args: &[String], config_depth: u32) -> Result<C
                 opts.easy.clear_body();
                 opts.has_post_data = false;
                 opts.easy.reset_method();
+                opts.easy.clear_custom_request_target();
                 opts.easy.set_form_data(false);
                 opts.json_mode = false;
                 opts.next_needs_url = true;
@@ -2393,15 +2396,41 @@ pub fn read_data_source(path: &str) -> Result<Vec<u8>, std::io::Error> {
     }
 }
 
-/// If the value contains `=`, only the part after the first `=` is encoded
-/// (the name is passed through as-is). Otherwise the entire value is encoded.
+/// Encode a string for form-URL-encoding (application/x-www-form-urlencoded).
+///
+/// Supports the following formats (matching curl):
+/// - `content` — encode entire string
+/// - `=content` — use content as-is (no encoding)
+/// - `name=content` — encode only the content, prepend `name=`
+/// - `@filename` — read file, encode contents
+/// - `name@filename` — read file, encode contents, prepend `name=`
 #[cfg(test)]
-fn urlencoded(input: &str) -> String {
+pub fn urlencoded(input: &str) -> String {
+    // Check for @filename (starts with @)
+    if let Some(filename) = input.strip_prefix('@') {
+        let data = std::fs::read_to_string(filename).unwrap_or_default();
+        return form_urlencode(&data);
+    }
+    // Check for =content (starts with =) — use as-is
+    if let Some(content) = input.strip_prefix('=') {
+        return content.to_string();
+    }
+    // Check for name@filename (has @ before any =)
+    if let Some(at_pos) = input.find('@') {
+        let eq_pos = input.find('=');
+        if eq_pos.is_none() || at_pos < eq_pos.unwrap_or(usize::MAX) {
+            let name = &input[..at_pos];
+            let filename = &input[at_pos + 1..];
+            let data = std::fs::read_to_string(filename).unwrap_or_default();
+            return format!("{}={}", name, form_urlencode(&data));
+        }
+    }
+    // name=content or plain content
     if let Some((name, value)) = input.split_once('=') {
-        let encoded = percent_encode(value);
+        let encoded = form_urlencode(value);
         format!("{name}={encoded}")
     } else {
-        percent_encode(input)
+        form_urlencode(input)
     }
 }
 
@@ -2476,6 +2505,7 @@ pub fn curl_urlencode(input: &str) -> String {
 }
 
 /// Percent-encode a string per RFC 3986 (unreserved characters are not encoded).
+#[cfg(test)]
 pub fn percent_encode(input: &str) -> String {
     let mut result = String::with_capacity(input.len());
     for byte in input.bytes() {
@@ -2493,8 +2523,36 @@ pub fn percent_encode(input: &str) -> String {
     result
 }
 
-/// Hex lookup table for percent encoding.
+/// Form-URL-encode a string (application/x-www-form-urlencoded).
+///
+/// Like `percent_encode` but encodes spaces as `+` instead of `%20`,
+/// matching curl's `--data-urlencode` and `--url-query` behavior.
+/// Uses lowercase hex digits to match curl's output.
+pub fn form_urlencode(input: &str) -> String {
+    let mut result = String::with_capacity(input.len());
+    for byte in input.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                result.push(byte as char);
+            }
+            b' ' => {
+                result.push('+');
+            }
+            _ => {
+                result.push('%');
+                result.push(char::from(HEX_CHARS_LOWER[(byte >> 4) as usize]));
+                result.push(char::from(HEX_CHARS_LOWER[(byte & 0x0F) as usize]));
+            }
+        }
+    }
+    result
+}
+
+/// Hex lookup table for percent encoding (uppercase, used by `percent_encode`).
 const HEX_CHARS: [u8; 16] = *b"0123456789ABCDEF";
+
+/// Hex lookup table for percent encoding (lowercase, used by `form_urlencode`).
+const HEX_CHARS_LOWER: [u8; 16] = *b"0123456789abcdef";
 
 /// Extract filename from URL for `-O/--remote-name`.
 ///
@@ -4481,19 +4539,20 @@ mod tests {
 
     #[test]
     fn urlencoded_basic() {
-        assert_eq!(urlencoded("hello world"), "hello%20world");
+        // form_urlencode uses + for spaces (matching curl's --data-urlencode)
+        assert_eq!(urlencoded("hello world"), "hello+world");
     }
 
     #[test]
     fn urlencoded_with_name() {
-        assert_eq!(urlencoded("key=hello world"), "key=hello%20world");
+        assert_eq!(urlencoded("key=hello world"), "key=hello+world");
     }
 
     #[test]
     fn urlencoded_special_chars() {
         // Input has '=' so it splits: name="a&b", value="c" → "a&b=c"
         assert_eq!(urlencoded("a&b=c"), "a&b=c");
-        // Without '=', the whole string is encoded
+        // Without '=', the whole string is encoded (lowercase hex)
         assert_eq!(urlencoded("a&b"), "a%26b");
     }
 
@@ -5396,7 +5455,7 @@ mod tests {
             "http://example.com",
             &["a=1".to_string(), "b=hello world".to_string()],
         );
-        assert!(result.starts_with("http://example.com?a=1&b=hello%20world"));
+        assert!(result.starts_with("http://example.com?a=1&b=hello+world"));
     }
 
     #[test]

--- a/crates/urlx-cli/src/transfer.rs
+++ b/crates/urlx-cli/src/transfer.rs
@@ -6,8 +6,7 @@
 use std::process::ExitCode;
 
 use crate::args::{
-    parse_args, parse_proto_spec, percent_encode, print_usage, print_version, CliOptions,
-    ParseResult,
+    parse_args, parse_proto_spec, print_usage, print_version, CliOptions, ParseResult,
 };
 use crate::output::{
     content_disposition_filename, format_headers, format_write_out, http_status_text,
@@ -372,6 +371,46 @@ fn strip_url_credentials(url: &str) -> String {
     }
 }
 
+/// Percent-encode a credential string for embedding in a URL's userinfo.
+///
+/// Encodes characters that are not safe in RFC 3986 userinfo:
+/// unreserved chars (A-Z, a-z, 0-9, `-`, `_`, `.`, `~`) and sub-delims
+/// (except `@` and `:`) are left as-is; everything else is percent-encoded.
+fn percent_encode_credential(input: &str) -> String {
+    let mut result = String::with_capacity(input.len());
+    for byte in input.bytes() {
+        match byte {
+            b'A'..=b'Z'
+            | b'a'..=b'z'
+            | b'0'..=b'9'
+            | b'-'
+            | b'_'
+            | b'.'
+            | b'~'
+            | b'!'
+            | b'$'
+            | b'&'
+            | b'\''
+            | b'('
+            | b')'
+            | b'*'
+            | b'+'
+            | b','
+            | b';'
+            | b'=' => {
+                result.push(byte as char);
+            }
+            _ => {
+                const HEX: &[u8; 16] = b"0123456789ABCDEF";
+                result.push('%');
+                result.push(HEX[(byte >> 4) as usize] as char);
+                result.push(HEX[(byte & 0x0F) as usize] as char);
+            }
+        }
+    }
+    result
+}
+
 /// URL-decode a percent-encoded string.
 fn url_decode(s: &str) -> String {
     let mut result = String::with_capacity(s.len());
@@ -401,26 +440,56 @@ fn url_decode(s: &str) -> String {
     result
 }
 
-/// Append query parameters to a URL string.
+/// Append query parameters to a URL string (implements curl's `--url-query`).
 ///
-/// Each query string is appended with `&` if the URL already has a `?`,
-/// or with `?` if it doesn't. Values containing `=` are used as-is;
-/// plain values are URL-encoded.
+/// Supports the following formats (matching curl):
+/// - `content` — form-urlencode entire string, append
+/// - `=content` — append content as-is (no encoding)
+/// - `name=content` — form-urlencode only the content, append `name=encoded`
+/// - `@filename` — read file, form-urlencode contents, append
+/// - `name@filename` — read file, form-urlencode contents, append `name=encoded`
+/// - `+content` — content is already encoded, append as-is (strip `+` prefix)
 pub fn append_url_queries(url: &str, queries: &[String]) -> String {
+    use crate::args::form_urlencode;
+
     let mut result = url.to_string();
     for query in queries {
         let separator = if result.contains('?') { '&' } else { '?' };
         result.push(separator);
-        if query.contains('=') {
-            // name=value format: encode only the value
-            if let Some((name, value)) = query.split_once('=') {
+
+        if let Some(already_encoded) = query.strip_prefix('+') {
+            // +content: already encoded, use as-is
+            result.push_str(already_encoded);
+        } else if let Some(filename) = query.strip_prefix('@') {
+            // @filename: read file, encode contents
+            let data = std::fs::read_to_string(filename).unwrap_or_default();
+            result.push_str(&form_urlencode(&data));
+        } else if let Some(at_pos) = query.find('@') {
+            let eq_pos = query.find('=');
+            if eq_pos.is_none() || at_pos < eq_pos.unwrap_or(usize::MAX) {
+                // name@filename: read file, encode contents, prepend name=
+                let name = &query[..at_pos];
+                let filename = &query[at_pos + 1..];
+                let data = std::fs::read_to_string(filename).unwrap_or_default();
                 result.push_str(name);
                 result.push('=');
-                result.push_str(&percent_encode(value));
+                result.push_str(&form_urlencode(&data));
+            } else {
+                // name=content (with @ in content): encode value only
+                // unwrap_or: split_once guaranteed to succeed since eq_pos was Some
+                let (name, value) = query.split_once('=').unwrap_or((query, ""));
+                result.push_str(name);
+                result.push('=');
+                result.push_str(&form_urlencode(value));
             }
+        } else if let Some((name, value)) = query.split_once('=') {
+            // name=value: encode only the value
+            result.push_str(name);
+            result.push('=');
+            result.push_str(&form_urlencode(value));
         } else {
-            // Plain string: use as-is (already encoded or literal)
-            result.push_str(query);
+            // Plain string: encode the whole thing
+            result.push_str(&form_urlencode(query));
         }
     }
     result
@@ -1079,31 +1148,25 @@ pub fn run(args: &[String]) -> ExitCode {
                 || url.starts_with("pop3://")
                 || url.starts_with("pop3s://")
             {
-                // Percent-encode special chars in credentials for URL embedding
-                // (curl compat: test 895/896 — `"`, `{`, `}` in credentials)
-                let encode_userinfo = |s: &str| -> String {
-                    let mut out = String::with_capacity(s.len());
-                    for c in s.chars() {
-                        match c {
-                            '"' => out.push_str("%22"),
-                            '{' => out.push_str("%7B"),
-                            '}' => out.push_str("%7D"),
-                            '@' => out.push_str("%40"),
-                            ':' => out.push_str("%3A"),
-                            _ => out.push(c),
-                        }
+                // Reject credentials with special characters only when --login-options
+                // is used (curl compat: test 896). Without --login-options, percent-encode
+                // special chars so they survive URL embedding (curl compat: tests 800, 847).
+                let has_bad_char = |s: &str| s.contains('"') || s.contains('{') || s.contains('}');
+                if (has_bad_char(user) || has_bad_char(pass))
+                    && opts.easy.get_login_options().is_some()
+                {
+                    if !opts.silent || opts.show_error {
+                        eprintln!("curl: (3) URL using bad/illegal format or missing URL");
                     }
-                    out
-                };
-                let encoded_user = encode_userinfo(user);
-                let encoded_pass = encode_userinfo(pass);
+                    return ExitCode::from(3);
+                }
                 let base_url = strip_url_credentials(&url);
                 let scheme_end = base_url.find("://").map_or(0, |p| p + 3);
                 let new_url = format!(
                     "{}{}:{}@{}",
                     &base_url[..scheme_end],
-                    encoded_user,
-                    encoded_pass,
+                    percent_encode_credential(user),
+                    percent_encode_credential(pass),
                     &base_url[scheme_end..]
                 );
                 if let Err(e) = opts.easy.url(&new_url) {
@@ -2584,8 +2647,8 @@ pub fn run_multi(
                     let new_url = format!(
                         "{}{}:{}@{}",
                         &base_url[..scheme_end],
-                        user,
-                        pass,
+                        percent_encode_credential(user),
+                        percent_encode_credential(pass),
                         &base_url[scheme_end..]
                     );
                     let _ = easy.url(&new_url);


### PR DESCRIPTION
## Summary

- **Tests 800, 847**: Percent-encode credentials with special characters (`"`, `{`, `}`) when embedding in IMAP URLs instead of blanket-rejecting them. Only reject when `--login-options` is also used (preserves test 896 behavior).
- **Tests 815, 816**: Preserve original case of `-X` custom commands by setting `custom_request_target` on the Easy handle during arg parsing and clearing it on `--next` reset. Previously `STORE 123 +Flags \Deleted` was uppercased to `STORE 123 +FLAGS \DELETED`.
- **Test 1221**: Implement proper `--url-query` format support including `@file`, `name@file`, and `+encoded` syntax. Switch to form-URL-encoding (spaces as `+`, lowercase hex) for both `--url-query` and `--data-urlencode` to match curl behavior.
- **Test 897**: Capture IMAP protocol transcript using `tokio::task_local!` for `-D` header dump support. Strips FETCH body content from transcript so only protocol framing appears.
- **Test 795**: Add cross-protocol HTTP-to-IMAP redirect support in the redirect loop, clearing IMAP protocol headers and body from output.

## Test plan

- [x] All 7 target tests pass: `runtests.pl 795 800 815 816 847 897 1221`
- [x] Test 896 (--login-options rejection) still passes
- [x] `cargo test` passes (all 876+ tests)
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean
- [ ] Full regression suite (tests 1-1400) — no new failures