### PR TITLE
fix(smtp,imap,pop3): MIME multipart, encoders, headers, HTTP CONNECT proxy

### DIFF
--- a/crates/liburlx/src/easy.rs
+++ b/crates/liburlx/src/easy.rs
@@ -1204,6 +1204,63 @@ impl Easy {
         self.multipart.get_or_insert_with(MultipartForm::new).set_smtp_mode(val);
     }
 
+    /// Open a nested multipart container (for `=(;type=...` syntax).
+    pub fn form_open_container(&mut self, content_type: &str) -> usize {
+        self.multipart.get_or_insert_with(MultipartForm::new).open_multipart_container(content_type)
+    }
+
+    /// Add a part to a previously opened multipart container.
+    pub fn form_add_to_container(
+        &mut self,
+        container_idx: usize,
+        data: &[u8],
+        content_type: Option<&str>,
+        filename: Option<&str>,
+        custom_headers: Vec<String>,
+        encoder: Option<&str>,
+    ) {
+        self.multipart.get_or_insert_with(MultipartForm::new).add_part_to_container(
+            container_idx,
+            data,
+            content_type,
+            filename,
+            custom_headers,
+            encoder,
+        );
+    }
+
+    /// Add a part with custom headers and optional encoder.
+    pub fn form_add_with_options(
+        &mut self,
+        name: &str,
+        data: &[u8],
+        content_type: Option<&str>,
+        filename: Option<&str>,
+        custom_headers: Vec<String>,
+        encoder: Option<&str>,
+    ) {
+        self.multipart.get_or_insert_with(MultipartForm::new).add_part_with_options(
+            name,
+            data,
+            content_type,
+            filename,
+            custom_headers,
+            encoder,
+        );
+    }
+
+    /// Validate multipart encoders (check 7-bit constraint).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if 7-bit encoded content has 8-bit bytes.
+    pub fn validate_form_encoders(&self) -> Result<(), crate::error::Error> {
+        if let Some(ref multipart) = self.multipart {
+            multipart.validate_encoders()?;
+        }
+        Ok(())
+    }
+
     /// Set a byte range for the request.
     ///
     /// Sends a `Range: bytes=<range>` header. Format examples:
@@ -2554,17 +2611,38 @@ impl Easy {
 
         if let Some(ref mut multipart) = self.multipart {
             let is_smtp = url.scheme() == "smtp" || url.scheme() == "smtps";
+            let is_imap = url.scheme() == "imap" || url.scheme() == "imaps";
 
-            // For SMTP, enable smtp_mode so the MIME headers are in the body
-            if is_smtp {
+            // For SMTP and IMAP APPEND, enable smtp_mode so the MIME headers are in the body
+            if is_smtp || is_imap {
                 multipart.set_smtp_mode(true);
+                // Collect -H headers for inclusion in the MIME preamble (curl compat: tests 646, 648)
+                // These headers go into the MIME body, not the SMTP envelope.
+                // Exclude Content-Type (handled separately) and internal headers.
+                let mime_headers: Vec<(String, String)> = headers
+                    .iter()
+                    .filter(|(k, _)| {
+                        !k.eq_ignore_ascii_case("content-type")
+                            && !k.starts_with('_')
+                            && !k.eq_ignore_ascii_case("user-agent")
+                            && !k.eq_ignore_ascii_case("accept")
+                    })
+                    .cloned()
+                    .collect();
+                if !mime_headers.is_empty() {
+                    multipart.set_smtp_headers(mime_headers);
+                }
             }
 
             // Check if user provided a custom Content-Type (use "attachment" disposition)
             let ct_idx = headers.iter().position(|(k, _)| k.eq_ignore_ascii_case("content-type"));
             if let Some(idx) = ct_idx {
                 // User provided Content-Type — use "attachment" disposition (curl compat: test 277)
-                if !is_smtp {
+                // Exception: if the user-provided Content-Type is multipart/form-data (possibly
+                // with params like charset), keep "form-data" disposition (curl compat: test 669)
+                let ct_is_formdata =
+                    headers[idx].1.trim().to_lowercase().starts_with("multipart/form-data");
+                if !is_smtp && !ct_is_formdata {
                     multipart.set_use_attachment(true);
                 }
                 let mut ct_value = headers.remove(idx).1;
@@ -2576,7 +2654,15 @@ impl Easy {
                 headers.push(("Content-Type".to_string(), multipart.content_type()));
             }
 
-            // Multipart form: encode body and set content-type header
+            // Validate encoders (7-bit check — curl compat: test 649).
+            // For SMTP, defer validation to the DATA phase.
+            if !is_smtp {
+                multipart.validate_encoders()?;
+            }
+
+            // Multipart form: encode body and set content-type header.
+            // For SMTP, encode even if there's a 7-bit error — the SMTP handler
+            // will abort after DATA is sent (curl compat: test 649).
             effective_body = Some(multipart.encode());
             // Default to POST for multipart
             effective_method = self.method.clone().unwrap_or_else(|| "POST".to_string());
@@ -5340,18 +5426,27 @@ async fn do_single_request(
                 password: header_creds.as_ref().map(|(_, p)| p.as_str()),
                 login_options: effective_login_opts.as_deref(),
             };
-            let smtp_use_ssl = if url.scheme() == "smtps" {
-                // Implicit TLS: signal with a special value
-                crate::protocol::ftp::UseSsl::All
-            } else {
-                use_ssl
-            };
+            let smtp_use_ssl =
+                if url.scheme() == "smtps" { crate::protocol::ftp::UseSsl::All } else { use_ssl };
+            // HTTP CONNECT proxy tunnel for email protocols (curl compat: tests 1319-1321)
+            let tunnel_stream = establish_email_proxy_tunnel(
+                proxy,
+                http_proxy_tunnel,
+                proxy_credentials,
+                proxy_headers,
+                verbose,
+                proxy_http_10,
+                headers,
+                url,
+            )
+            .await?;
             return crate::protocol::smtp::send_mail(
                 url,
                 mail_data,
                 &smtp_config,
                 smtp_use_ssl,
                 tls_config,
+                tunnel_stream,
             )
             .await;
         }
@@ -5362,9 +5457,19 @@ async fn do_single_request(
                 .or_else(|| extract_login_options_from_url(url));
             let imap_use_ssl =
                 if url.scheme() == "imaps" { crate::protocol::ftp::UseSsl::All } else { use_ssl };
-            // curl uses 'A' + N for IMAP tags where N is the connection number.
-            // Direct IMAP = 'A' (first connection), redirect from HTTP = 'B' (second connection).
             let tag_prefix = if redirected_from_http { 'B' } else { 'A' };
+            // HTTP CONNECT proxy tunnel for email protocols (curl compat: tests 1319-1321)
+            let tunnel_stream = establish_email_proxy_tunnel(
+                proxy,
+                http_proxy_tunnel,
+                proxy_credentials,
+                proxy_headers,
+                verbose,
+                proxy_http_10,
+                headers,
+                url,
+            )
+            .await?;
             return crate::protocol::imap::fetch(
                 url,
                 method,
@@ -5378,6 +5483,7 @@ async fn do_single_request(
                 tag_prefix,
                 imap_use_ssl,
                 tls_config,
+                tunnel_stream,
             )
             .await;
         }
@@ -5396,6 +5502,18 @@ async fn do_single_request(
                 .or_else(|| extract_login_options_from_url(url));
             let pop3_use_ssl =
                 if url.scheme() == "pop3s" { crate::protocol::ftp::UseSsl::All } else { use_ssl };
+            // HTTP CONNECT proxy tunnel for email protocols (curl compat: tests 1319-1321)
+            let tunnel_stream = establish_email_proxy_tunnel(
+                proxy,
+                http_proxy_tunnel,
+                proxy_credentials,
+                proxy_headers,
+                verbose,
+                proxy_http_10,
+                headers,
+                url,
+            )
+            .await?;
             return crate::protocol::pop3::retrieve(
                 url,
                 creds_tuple,
@@ -5407,6 +5525,7 @@ async fn do_single_request(
                 sasl_authzid,
                 pop3_use_ssl,
                 tls_config,
+                tunnel_stream,
             )
             .await;
         }
@@ -6655,6 +6774,81 @@ enum ConnectTunnelResult<S> {
 ///
 /// Sends a CONNECT request to the proxy and validates the 200 response
 /// before returning the stream for TLS negotiation.
+/// Establish an HTTP CONNECT proxy tunnel for email protocols (SMTP, IMAP, POP3).
+///
+/// Returns `Some(TcpStream)` if a proxy is configured with tunnel mode,
+/// `None` if no proxy is needed (direct connection).
+#[allow(clippy::too_many_arguments)]
+async fn establish_email_proxy_tunnel(
+    proxy: Option<&crate::url::Url>,
+    http_proxy_tunnel: bool,
+    proxy_credentials: Option<&ProxyAuthCredentials>,
+    proxy_headers: &[(String, String)],
+    verbose: bool,
+    proxy_http_10: bool,
+    headers: &[(String, String)],
+    target_url: &crate::url::Url,
+) -> Result<Option<tokio::net::TcpStream>, Error> {
+    let proxy_url = match proxy {
+        Some(p) if http_proxy_tunnel => p,
+        _ => return Ok(None),
+    };
+
+    let proxy_scheme = proxy_url.scheme();
+    if proxy_scheme != "http" && proxy_scheme != "https" {
+        return Ok(None);
+    }
+
+    let (proxy_host, proxy_port) = proxy_url.host_and_port()?;
+    let (target_host, target_port) = target_url.host_and_port()?;
+
+    let proxy_addr = format!("{proxy_host}:{proxy_port}");
+    let tcp = tokio::net::TcpStream::connect(&proxy_addr).await.map_err(Error::Connect)?;
+
+    let result = establish_connect_tunnel(
+        tcp,
+        &target_host,
+        target_port,
+        headers,
+        proxy_credentials,
+        proxy_headers,
+        verbose,
+        proxy_http_10,
+    )
+    .await?;
+
+    match result {
+        ConnectTunnelResult::Connected { stream, .. } => Ok(Some(stream)),
+        ConnectTunnelResult::Failed { status, .. } => {
+            Err(Error::Http(format!("CONNECT tunnel failed: {status}")))
+        }
+        ConnectTunnelResult::NeedReconnect { .. } => {
+            // Reconnect and try again (proxy closed connection after 407)
+            let tcp2 = tokio::net::TcpStream::connect(&proxy_addr).await.map_err(Error::Connect)?;
+            let result2 = establish_connect_tunnel(
+                tcp2,
+                &target_host,
+                target_port,
+                headers,
+                proxy_credentials,
+                proxy_headers,
+                verbose,
+                proxy_http_10,
+            )
+            .await?;
+            match result2 {
+                ConnectTunnelResult::Connected { stream, .. } => Ok(Some(stream)),
+                ConnectTunnelResult::Failed { status, .. } => {
+                    Err(Error::Http(format!("CONNECT tunnel failed: {status}")))
+                }
+                ConnectTunnelResult::NeedReconnect { .. } => {
+                    Err(Error::Http("CONNECT tunnel: too many reconnects".to_string()))
+                }
+            }
+        }
+    }
+}
+
 /// Handles 407 Proxy Authentication Required for Digest and NTLM auth.
 ///
 /// The stream type is generic to support both plain TCP (HTTP proxy) and

--- a/crates/liburlx/src/protocol/http/multipart.rs
+++ b/crates/liburlx/src/protocol/http/multipart.rs
@@ -28,6 +28,8 @@ pub struct MultipartForm {
     smtp_mode: bool,
     /// Filename escape mode.
     escape_mode: FilenameEscapeMode,
+    /// Extra headers to include in the SMTP MIME preamble (from `-H` flags).
+    smtp_headers: Vec<(String, String)>,
 }
 
 /// A single part in a multipart form.
@@ -41,6 +43,14 @@ struct Part {
     sub_files: Vec<SubFile>,
     /// Whether the content type was explicitly set (vs guessed from filename).
     explicit_type: bool,
+    /// Custom headers for this part (e.g., `headers=X-Custom: value`).
+    custom_headers: Vec<String>,
+    /// Transfer encoding (e.g., `quoted-printable`, `base64`, `7bit`).
+    encoder: Option<String>,
+    /// Nested multipart sub-parts (for `=(;type=multipart/...` syntax).
+    subparts: Vec<Self>,
+    /// Whether this is a nested multipart container.
+    is_multipart_container: bool,
 }
 
 /// A file within a multipart/mixed sub-part.
@@ -61,6 +71,7 @@ impl MultipartForm {
             use_attachment: false,
             smtp_mode: false,
             escape_mode: FilenameEscapeMode::default(),
+            smtp_headers: Vec::new(),
         }
     }
 
@@ -73,6 +84,7 @@ impl MultipartForm {
             use_attachment: false,
             smtp_mode: false,
             escape_mode: FilenameEscapeMode::default(),
+            smtp_headers: Vec::new(),
         }
     }
 
@@ -93,6 +105,11 @@ impl MultipartForm {
         self.escape_mode = mode;
     }
 
+    /// Set extra headers for the SMTP MIME preamble (from `-H` flags).
+    pub fn set_smtp_headers(&mut self, headers: Vec<(String, String)>) {
+        self.smtp_headers = headers;
+    }
+
     /// Add a text field to the form.
     pub fn field(&mut self, name: &str, value: &str) {
         self.parts.push(Part {
@@ -102,6 +119,10 @@ impl MultipartForm {
             data: value.as_bytes().to_vec(),
             sub_files: Vec::new(),
             explicit_type: false,
+            custom_headers: Vec::new(),
+            encoder: None,
+            subparts: Vec::new(),
+            is_multipart_container: false,
         });
     }
 
@@ -114,6 +135,10 @@ impl MultipartForm {
             data: value.as_bytes().to_vec(),
             sub_files: Vec::new(),
             explicit_type: true,
+            custom_headers: Vec::new(),
+            encoder: None,
+            subparts: Vec::new(),
+            is_multipart_container: false,
         });
     }
 
@@ -142,6 +167,10 @@ impl MultipartForm {
             data,
             sub_files: Vec::new(),
             explicit_type: false,
+            custom_headers: Vec::new(),
+            encoder: None,
+            subparts: Vec::new(),
+            is_multipart_container: false,
         });
 
         Ok(())
@@ -156,6 +185,10 @@ impl MultipartForm {
             data: data.to_vec(),
             sub_files: Vec::new(),
             explicit_type: false,
+            custom_headers: Vec::new(),
+            encoder: None,
+            subparts: Vec::new(),
+            is_multipart_container: false,
         });
     }
 
@@ -170,6 +203,10 @@ impl MultipartForm {
             data: data.to_vec(),
             sub_files: Vec::new(),
             explicit_type: false,
+            custom_headers: Vec::new(),
+            encoder: None,
+            subparts: Vec::new(),
+            is_multipart_container: false,
         });
     }
 
@@ -188,6 +225,10 @@ impl MultipartForm {
             data: data.to_vec(),
             sub_files: Vec::new(),
             explicit_type: true,
+            custom_headers: Vec::new(),
+            encoder: None,
+            subparts: Vec::new(),
+            is_multipart_container: false,
         });
     }
 
@@ -206,6 +247,82 @@ impl MultipartForm {
             data: Vec::new(),
             sub_files,
             explicit_type: false,
+            custom_headers: Vec::new(),
+            encoder: None,
+            subparts: Vec::new(),
+            is_multipart_container: false,
+        });
+    }
+
+    /// Begin a nested multipart container (for `=(;type=multipart/alternative` syntax).
+    ///
+    /// Returns the index of the container part. Use `close_multipart_container` to
+    /// finalize it, or `add_part_to_container` to add subparts.
+    pub fn open_multipart_container(&mut self, content_type: &str) -> usize {
+        let idx = self.parts.len();
+        self.parts.push(Part {
+            name: String::new(),
+            filename: None,
+            content_type: Some(content_type.to_string()),
+            data: Vec::new(),
+            sub_files: Vec::new(),
+            explicit_type: true,
+            custom_headers: Vec::new(),
+            encoder: None,
+            subparts: Vec::new(),
+            is_multipart_container: true,
+        });
+        idx
+    }
+
+    /// Add a subpart to a previously opened multipart container.
+    pub fn add_part_to_container(
+        &mut self,
+        container_idx: usize,
+        data: &[u8],
+        content_type: Option<&str>,
+        filename: Option<&str>,
+        custom_headers: Vec<String>,
+        encoder: Option<&str>,
+    ) {
+        let part = Part {
+            name: String::new(),
+            filename: filename.map(ToString::to_string),
+            content_type: content_type.map(ToString::to_string),
+            data: data.to_vec(),
+            sub_files: Vec::new(),
+            explicit_type: content_type.is_some(),
+            custom_headers,
+            encoder: encoder.map(ToString::to_string),
+            subparts: Vec::new(),
+            is_multipart_container: false,
+        };
+        if let Some(container) = self.parts.get_mut(container_idx) {
+            container.subparts.push(part);
+        }
+    }
+
+    /// Add a part with custom headers and optional encoder.
+    pub fn add_part_with_options(
+        &mut self,
+        name: &str,
+        data: &[u8],
+        content_type: Option<&str>,
+        filename: Option<&str>,
+        custom_headers: Vec<String>,
+        encoder: Option<&str>,
+    ) {
+        self.parts.push(Part {
+            name: name.to_string(),
+            filename: filename.map(ToString::to_string),
+            content_type: content_type.map(ToString::to_string),
+            data: data.to_vec(),
+            sub_files: Vec::new(),
+            explicit_type: content_type.is_some(),
+            custom_headers,
+            encoder: encoder.map(ToString::to_string),
+            subparts: Vec::new(),
+            is_multipart_container: false,
         });
     }
 
@@ -251,6 +368,16 @@ impl MultipartForm {
         } else {
             "form-data"
         }
+    }
+
+    /// Build the encoded multipart body, validating 7-bit constraints for SMTP.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if 7-bit encoded content has 8-bit bytes.
+    pub fn encode_checked(&self) -> Result<Vec<u8>, Error> {
+        self.validate_encoders()?;
+        Ok(self.encode())
     }
 
     /// Build the encoded multipart body.
@@ -368,47 +495,32 @@ impl MultipartForm {
         // MIME headers
         body.extend_from_slice(b"Content-Type: multipart/mixed; boundary=");
         body.extend_from_slice(self.boundary.as_bytes());
-        body.extend_from_slice(b"\r\nMime-Version: 1.0\r\n\r\n");
+        body.extend_from_slice(b"\r\nMime-Version: 1.0\r\n");
 
-        for part in &self.parts {
-            // Boundary delimiter
-            body.extend_from_slice(b"--");
-            body.extend_from_slice(self.boundary.as_bytes());
-            body.extend_from_slice(b"\r\n");
-
-            // For SMTP: text parts (no filename) have no Content-Disposition.
-            // File parts have Content-Disposition: attachment; filename="..."
-            if let Some(ref filename) = part.filename {
-                body.extend_from_slice(b"Content-Disposition: attachment; filename=\"");
-                // SMTP always uses backslash escaping for filenames
-                let escaped = escape_filename_backslash(filename);
-                body.extend_from_slice(escaped.as_bytes());
-                body.extend_from_slice(b"\"\r\n");
-            }
-
-            // Content-Type header only when explicitly set (not guessed)
-            if part.explicit_type {
-                if let Some(ref ct) = part.content_type {
-                    body.extend_from_slice(b"Content-Type: ");
-                    body.extend_from_slice(ct.as_bytes());
-                    body.extend_from_slice(b"\r\n");
-                }
-            }
-
-            // Empty line separating headers from body
-            body.extend_from_slice(b"\r\n");
-
-            // Part body
-            body.extend_from_slice(&part.data);
+        // Extra headers from -H flags (curl compat: tests 646, 648)
+        for (name, value) in &self.smtp_headers {
+            body.extend_from_slice(name.as_bytes());
+            body.extend_from_slice(b": ");
+            body.extend_from_slice(value.as_bytes());
             body.extend_from_slice(b"\r\n");
         }
 
-        // Closing boundary
-        body.extend_from_slice(b"--");
-        body.extend_from_slice(self.boundary.as_bytes());
-        body.extend_from_slice(b"--\r\n");
+        body.extend_from_slice(b"\r\n");
+
+        encode_smtp_parts(&mut body, &self.parts, &self.boundary);
 
         body
+    }
+
+    /// Validate that all parts with `7bit` encoder contain only 7-bit ASCII data.
+    ///
+    /// Returns `Err` if any 7-bit encoded part contains 8-bit bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Transfer`] with code 26 if 8-bit data is found in a 7-bit part.
+    pub fn validate_encoders(&self) -> Result<(), Error> {
+        validate_parts_7bit(&self.parts)
     }
 }
 
@@ -416,6 +528,186 @@ impl Default for MultipartForm {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// Recursively encode SMTP parts into the given buffer.
+fn encode_smtp_parts(body: &mut Vec<u8>, parts: &[Part], boundary: &str) {
+    for part in parts {
+        // Nested multipart container
+        if part.is_multipart_container {
+            let sub_boundary = generate_boundary();
+            body.extend_from_slice(b"--");
+            body.extend_from_slice(boundary.as_bytes());
+            body.extend_from_slice(b"\r\n");
+
+            // Content-Type with sub-boundary
+            if let Some(ref ct) = part.content_type {
+                body.extend_from_slice(b"Content-Type: ");
+                body.extend_from_slice(ct.as_bytes());
+                body.extend_from_slice(b"; boundary=");
+                body.extend_from_slice(sub_boundary.as_bytes());
+                body.extend_from_slice(b"\r\n");
+            }
+
+            body.extend_from_slice(b"\r\n");
+
+            // Encode subparts with the sub-boundary
+            encode_smtp_parts(body, &part.subparts, &sub_boundary);
+
+            body.extend_from_slice(b"\r\n");
+            continue;
+        }
+
+        // Boundary delimiter
+        body.extend_from_slice(b"--");
+        body.extend_from_slice(boundary.as_bytes());
+        body.extend_from_slice(b"\r\n");
+
+        // For SMTP: text parts (no filename) have no Content-Disposition.
+        // File parts have Content-Disposition: attachment; filename="..."
+        if let Some(ref filename) = part.filename {
+            body.extend_from_slice(b"Content-Disposition: attachment; filename=\"");
+            let escaped = escape_filename_backslash(filename);
+            body.extend_from_slice(escaped.as_bytes());
+            body.extend_from_slice(b"\"\r\n");
+        }
+
+        // Content-Type header only when explicitly set (not guessed)
+        if part.explicit_type {
+            if let Some(ref ct) = part.content_type {
+                body.extend_from_slice(b"Content-Type: ");
+                body.extend_from_slice(ct.as_bytes());
+                body.extend_from_slice(b"\r\n");
+            }
+        }
+
+        // Content-Transfer-Encoding header
+        if let Some(ref enc) = part.encoder {
+            body.extend_from_slice(b"Content-Transfer-Encoding: ");
+            body.extend_from_slice(enc.as_bytes());
+            body.extend_from_slice(b"\r\n");
+        } else if part.explicit_type && !part.is_multipart_container {
+            // SMTP default: 8bit for non-multipart parts with explicit content type
+            body.extend_from_slice(b"Content-Transfer-Encoding: 8bit\r\n");
+        }
+
+        // Custom headers
+        for header in &part.custom_headers {
+            body.extend_from_slice(header.as_bytes());
+            body.extend_from_slice(b"\r\n");
+        }
+
+        // Empty line separating headers from body
+        body.extend_from_slice(b"\r\n");
+
+        // Part body (apply encoding if specified)
+        if let Some(ref enc) = part.encoder {
+            match enc.as_str() {
+                "base64" => {
+                    let encoded = encode_base64(&part.data);
+                    body.extend_from_slice(encoded.as_bytes());
+                }
+                "quoted-printable" => {
+                    let encoded = encode_quoted_printable(&part.data);
+                    body.extend_from_slice(encoded.as_bytes());
+                }
+                _ => {
+                    // 7bit, 8bit, binary — pass through
+                    body.extend_from_slice(&part.data);
+                }
+            }
+        } else {
+            body.extend_from_slice(&part.data);
+        }
+        body.extend_from_slice(b"\r\n");
+    }
+
+    // Closing boundary
+    body.extend_from_slice(b"--");
+    body.extend_from_slice(boundary.as_bytes());
+    body.extend_from_slice(b"--\r\n");
+}
+
+/// Validate 7-bit encoding constraint recursively.
+fn validate_parts_7bit(parts: &[Part]) -> Result<(), Error> {
+    for part in parts {
+        if part.encoder.as_deref() == Some("7bit") && part.data.iter().any(|&b| b > 127) {
+            return Err(Error::Transfer {
+                code: 26,
+                message: "7-bit encoding applied to 8-bit data".to_string(),
+            });
+        }
+        validate_parts_7bit(&part.subparts)?;
+    }
+    Ok(())
+}
+
+/// Encode data as base64, wrapping at 76 characters per line.
+fn encode_base64(data: &[u8]) -> String {
+    use std::fmt::Write as _;
+
+    const CHARS: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+    let mut result = String::new();
+    let mut line_len = 0;
+
+    let mut i = 0;
+    while i < data.len() {
+        let remaining = data.len() - i;
+        let b0 = data[i];
+        let b1 = if remaining > 1 { data[i + 1] } else { 0 };
+        let b2 = if remaining > 2 { data[i + 2] } else { 0 };
+
+        let c0 = CHARS[(b0 >> 2) as usize] as char;
+        let c1 = CHARS[(((b0 & 0x03) << 4) | (b1 >> 4)) as usize] as char;
+        let c2 = if remaining > 1 {
+            CHARS[(((b1 & 0x0F) << 2) | (b2 >> 6)) as usize] as char
+        } else {
+            '='
+        };
+        let c3 = if remaining > 2 { CHARS[(b2 & 0x3F) as usize] as char } else { '=' };
+
+        let _ = write!(result, "{c0}{c1}{c2}{c3}");
+        line_len += 4;
+
+        if line_len >= 76 {
+            result.push_str("\r\n");
+            line_len = 0;
+        }
+
+        i += 3;
+    }
+
+    // Don't add trailing CRLF — caller handles that
+    result
+}
+
+/// Encode data as quoted-printable (RFC 2045).
+fn encode_quoted_printable(data: &[u8]) -> String {
+    let mut result = String::new();
+    let mut line_len = 0;
+
+    for &byte in data {
+        let encoded = if byte == b'\t' || ((32..=126).contains(&byte) && byte != b'=') {
+            // Printable ASCII (except '=') — pass through
+            String::from(byte as char)
+        } else {
+            // Encode as =XX
+            format!("={byte:02X}")
+        };
+
+        // Soft line break before exceeding 76 chars
+        // (76 - 1 for potential = soft break marker)
+        if line_len + encoded.len() > 75 {
+            result.push_str("=\r\n");
+            line_len = 0;
+        }
+
+        result.push_str(&encoded);
+        line_len += encoded.len();
+    }
+
+    result
 }
 
 /// Backslash-escape a filename (for SMTP MIME).

--- a/crates/liburlx/src/protocol/imap.rs
+++ b/crates/liburlx/src/protocol/imap.rs
@@ -360,6 +360,7 @@ pub async fn fetch(
     tag_prefix: char,
     use_ssl: UseSsl,
     tls_config: &crate::tls::TlsConfig,
+    pre_connected: Option<tokio::net::TcpStream>,
 ) -> Result<Response, Error> {
     // Reject URLs with CR or LF in the path (curl compat: test 829).
     // Check BEFORE credentials or connection setup.
@@ -403,8 +404,12 @@ pub async fn fetch(
                 }
             })
             .unwrap_or(&host);
-    let addr = format!("{resolved_host}:{port}");
-    let tcp = tokio::net::TcpStream::connect(&addr).await.map_err(Error::Connect)?;
+    let tcp = if let Some(stream) = pre_connected {
+        stream
+    } else {
+        let addr = format!("{resolved_host}:{port}");
+        tokio::net::TcpStream::connect(&addr).await.map_err(Error::Connect)?
+    };
     let mut tags = TagCounter::new(tag_prefix);
 
     // Establish connection with appropriate TLS mode.
@@ -1116,10 +1121,11 @@ async fn dispatch_imap_operation<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
         Ok(Some(resp))
     }
 
-    // Upload via -T: IMAP APPEND command.
+    // Upload via -T or -F: IMAP APPEND command.
     // Check this BEFORE custom_request, since -T sets method=PUT and
     // custom_request="PUT", but we want APPEND behavior, not a literal "PUT" cmd.
-    let is_upload = method == "PUT" && body.is_some();
+    // -F (multipart) also triggers APPEND (method=POST, curl compat: test 647).
+    let is_upload = (method == "PUT" || method == "POST") && body.is_some();
     if is_upload {
         if let Some(upload_data) = body {
             if !has_mailbox {

--- a/crates/liburlx/src/protocol/pop3.rs
+++ b/crates/liburlx/src/protocol/pop3.rs
@@ -88,6 +88,53 @@ pub async fn read_multiline<S: AsyncRead + Unpin>(
     Ok(lines)
 }
 
+/// Read POP3 multiline response preserving original line endings.
+///
+/// Unlike `read_multiline`, this preserves the server's line ending style
+/// (LF vs CRLF) in the output. Used for RETR data output where curl
+/// preserves the wire format (curl compat: test 1319).
+async fn read_multiline_raw<S: AsyncRead + Unpin>(
+    stream: &mut BufReader<S>,
+) -> Result<Vec<u8>, Error> {
+    let mut body = Vec::new();
+
+    loop {
+        let mut line = String::new();
+        let bytes_read = stream
+            .read_line(&mut line)
+            .await
+            .map_err(|e| Error::Http(format!("POP3 read error: {e}")))?;
+
+        if bytes_read == 0 {
+            return Err(Error::Http("POP3 connection closed during multi-line read".to_string()));
+        }
+
+        // Check for terminator: line is ".\r\n" or ".\n"
+        let check = line.trim_end_matches('\n').trim_end_matches('\r');
+        if check == "." {
+            break;
+        }
+
+        // Byte-stuffing: leading dot is removed
+        if let Some(destuffed) = check.strip_prefix('.') {
+            // Remove leading dot, preserve the rest including original line ending
+            body.extend_from_slice(destuffed.as_bytes());
+            // Re-attach original line ending
+            if line.ends_with("\r\n") {
+                body.extend_from_slice(b"\r\n");
+            } else if line.ends_with('\n') {
+                body.push(b'\n');
+            }
+        } else {
+            // No byte-stuffing — output line as-is, preserving original line endings
+            // (curl compat: test 1319 — curl passes through POP3 data verbatim)
+            body.extend_from_slice(line.as_bytes());
+        }
+    }
+
+    Ok(body)
+}
+
 /// Read the POP3 server greeting, skipping any banner lines.
 ///
 /// The greeting must start with `+OK` or `-ERR`.
@@ -239,6 +286,7 @@ pub async fn retrieve(
     sasl_authzid: Option<&str>,
     use_ssl: UseSsl,
     tls_config: &crate::tls::TlsConfig,
+    pre_connected: Option<tokio::net::TcpStream>,
 ) -> Result<Response, Error> {
     // Reject URLs with CR/LF (curl returns exit code 3, test 875)
     let raw_url = url.as_str();
@@ -271,8 +319,12 @@ pub async fn retrieve(
     let use_implicit_tls = url.scheme() == "pop3s";
     let use_starttls = !use_implicit_tls && use_ssl != UseSsl::None;
 
-    let addr = format!("{host}:{port}");
-    let tcp = tokio::net::TcpStream::connect(&addr).await.map_err(Error::Connect)?;
+    let tcp = if let Some(stream) = pre_connected {
+        stream
+    } else {
+        let addr = format!("{host}:{port}");
+        tokio::net::TcpStream::connect(&addr).await.map_err(Error::Connect)?
+    };
 
     // Establish connection with appropriate TLS mode.
     // For STLS (POP3's STARTTLS), we use concrete types for the initial
@@ -452,12 +504,8 @@ pub async fn retrieve(
             let _ = read_response(&mut reader).await;
             return Err(Error::Protocol(8));
         }
-        let lines = read_multiline(&mut reader).await?;
-        let mut body_str = lines.join("\r\n");
-        if !body_str.is_empty() {
-            body_str.push_str("\r\n");
-        }
-        let body = body_str.into_bytes();
+        // Use raw read to preserve original line endings (curl compat: test 1319)
+        let body = read_multiline_raw(&mut reader).await?;
 
         // QUIT
         send_command(&mut writer, "QUIT").await?;

--- a/crates/liburlx/src/protocol/smtp.rs
+++ b/crates/liburlx/src/protocol/smtp.rs
@@ -261,6 +261,7 @@ pub async fn send_mail(
     config: &SmtpConfig<'_>,
     use_ssl: UseSsl,
     tls_config: &crate::tls::TlsConfig,
+    pre_connected: Option<tokio::net::TcpStream>,
 ) -> Result<crate::protocol::http::response::Response, Error> {
     let (host, port) = url.host_and_port()?;
 
@@ -298,8 +299,12 @@ pub async fn send_mail(
     let use_starttls = !use_implicit_tls && use_ssl != UseSsl::None;
 
     // Connect to SMTP server (with optional TLS for smtps://)
-    let addr = format!("{host}:{port}");
-    let tcp = tokio::net::TcpStream::connect(&addr).await.map_err(Error::Connect)?;
+    let tcp = if let Some(stream) = pre_connected {
+        stream
+    } else {
+        let addr = format!("{host}:{port}");
+        tokio::net::TcpStream::connect(&addr).await.map_err(Error::Connect)?
+    };
 
     // Establish connection with appropriate TLS mode.
     // For STARTTLS, we use concrete types for the initial negotiation (greeting,
@@ -799,6 +804,15 @@ async fn do_send_mail<S: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
         )));
     }
 
+    // Check for 7-bit encoding violations in the body (curl compat: test 649).
+    // This check happens after DATA so the SMTP protocol commands are captured.
+    if check_7bit_violation(mail_data) {
+        return Err(Error::Transfer {
+            code: 26,
+            message: "7-bit encoding applied to 8-bit data".to_string(),
+        });
+    }
+
     // Send message body with proper line handling
     write_smtp_data(writer, mail_data, config.crlf).await?;
 
@@ -813,6 +827,47 @@ async fn do_send_mail<S: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
     }
 
     Ok(())
+}
+
+/// Check if a MIME body has `Content-Transfer-Encoding: 7bit` followed by 8-bit data.
+///
+/// Scans the body for `Content-Transfer-Encoding: 7bit` headers and validates
+/// that the corresponding part data contains only 7-bit ASCII bytes.
+fn check_7bit_violation(data: &[u8]) -> bool {
+    let text = String::from_utf8_lossy(data);
+    // Split on boundary delimiters (lines starting with --)
+    let mut in_7bit_part = false;
+    let mut past_headers = false;
+
+    for line in text.split('\n') {
+        let trimmed = line.trim_end_matches('\r');
+
+        // Boundary delimiter resets state
+        if trimmed.starts_with("--") {
+            in_7bit_part = false;
+            past_headers = false;
+            continue;
+        }
+
+        // Empty line = end of headers
+        if trimmed.is_empty() && !past_headers {
+            past_headers = true;
+            continue;
+        }
+
+        // Check for CTE: 7bit header
+        if !past_headers && trimmed.eq_ignore_ascii_case("Content-Transfer-Encoding: 7bit") {
+            in_7bit_part = true;
+            continue;
+        }
+
+        // If we're in a 7bit part body, check for 8-bit bytes
+        if in_7bit_part && past_headers && line.as_bytes().iter().any(|&b| b > 127) {
+            return true;
+        }
+    }
+
+    false
 }
 
 /// Write SMTP DATA body, handling dot-stuffing and optional CRLF conversion.

--- a/crates/urlx-cli/src/args.rs
+++ b/crates/urlx-cli/src/args.rs
@@ -708,6 +708,8 @@ fn parse_args_options_with_depth(args: &[String], config_depth: u32) -> Result<C
     // Track whether any per-request option was set in the current --next group.
     // Used to distinguish "no-op --next" from "badly used --next" (curl compat: tests 422, 430).
     let mut group_has_options = false;
+    // Stack for nested multipart containers (`-F "=(;type=..."` / `-F "=)"`)
+    let mut mime_container_stack: Vec<usize> = Vec::new();
     while i < args.len() {
         // No per-iteration tracking needed here — group_has_options is set
         // by specific URL-consuming options (-O, -I, -d, -T, etc.) below.
@@ -1027,7 +1029,9 @@ fn parse_args_options_with_depth(args: &[String], config_depth: u32) -> Result<C
             "-F" | "--form" => {
                 i += 1;
                 let val = require_arg(args, i, "-F")?;
-                if let Err(msg) = parse_form_field(&mut opts.easy, val) {
+                if let Err(msg) =
+                    parse_form_field_ext(&mut opts.easy, val, &mut mime_container_stack, false)
+                {
                     eprintln!("curl: {msg}");
                     // Exit code 26 = CURLE_READ_ERROR (file not found / read error)
                     return Err(26);
@@ -2674,8 +2678,14 @@ fn unescape(s: &str) -> String {
     result
 }
 
-/// Helper to require an argument value for an option flag.
-/// Parse a `-F name=value` form field with full curl syntax.
+/// Parse a `-F name=value` form field (simple wrapper for backward compatibility).
+#[allow(dead_code)]
+fn parse_form_field(easy: &mut liburlx::Easy, val: &str) -> Result<(), String> {
+    let mut stack = Vec::new();
+    parse_form_field_ext(easy, val, &mut stack, false)
+}
+
+/// Parse a `-F name=value` form field with full curl MIME API syntax.
 ///
 /// Supports:
 /// - `name=value` — text field
@@ -2683,14 +2693,50 @@ fn unescape(s: &str) -> String {
 /// - `name=@filepath;type=mime` — file with custom Content-Type
 /// - `name=@filepath;filename=custom` — file with custom filename
 /// - `name=@"filepath"` — quoted file path
-/// - Complex backslash escaping in filenames
-fn parse_form_field(easy: &mut liburlx::Easy, val: &str) -> Result<(), String> {
+/// - `=(;type=multipart/alternative` — open nested multipart container
+/// - `=)` — close nested multipart container
+/// - `;encoder=base64` — Content-Transfer-Encoding
+/// - `;headers=Header: value` — custom part header
+/// - `;headers=@file` or `;headers=<file` — headers from file
+#[allow(clippy::too_many_lines)]
+fn parse_form_field_ext(
+    easy: &mut liburlx::Easy,
+    val: &str,
+    container_stack: &mut Vec<usize>,
+    _form_string: bool,
+) -> Result<(), String> {
     let (name, value) =
         val.split_once('=').ok_or_else(|| format!("invalid form field format: {val}"))?;
 
+    // Handle multipart container open: "=(;type=multipart/alternative"
+    if let Some(rest) = value.strip_prefix('(') {
+        let mut content_type = "multipart/mixed".to_string();
+        // Parse modifiers after '('
+        if let Some(mods) = rest.strip_prefix(';') {
+            let parts: Vec<&str> = mods.split(';').collect();
+            for part in parts {
+                let trimmed = part.trim();
+                if let Some(t) = trimmed.strip_prefix("type=") {
+                    content_type = t.to_string();
+                }
+            }
+        }
+        let idx = easy.form_open_container(&content_type);
+        container_stack.push(idx);
+        return Ok(());
+    }
+
+    // Handle multipart container close: "=)"
+    if value == ")" {
+        if container_stack.is_empty() {
+            return Err("unmatched =) — no open multipart container".to_string());
+        }
+        let _ = container_stack.pop();
+        return Ok(());
+    }
+
     if let Some(rest) = value.strip_prefix('@') {
-        // File upload — parse filepath and optional ;type= ;filename= modifiers
-        // Check for comma-separated multi-file syntax (commas outside quotes split files)
+        // File upload — parse filepath and optional modifiers
         let file_specs = split_comma_file_specs(rest);
 
         if file_specs.len() > 1 {
@@ -2721,19 +2767,23 @@ fn parse_form_field(easy: &mut liburlx::Easy, val: &str) -> Result<(), String> {
 
             let mut custom_type: Option<String> = None;
             let mut custom_filename: Option<String> = None;
+            let mut custom_headers: Vec<String> = Vec::new();
+            let mut encoder: Option<String> = None;
 
-            // Parse semicolon-separated modifiers
             for modifier in modifiers {
                 if let Some(t) = modifier.strip_prefix("type=") {
                     custom_type = Some(t.to_string());
                 } else if let Some(f) = modifier.strip_prefix("filename=") {
                     custom_filename = Some(unescape_form_filename(f));
                 } else if let Some(f) = modifier.strip_prefix("format=") {
-                    // format= appends to type: e.g., type=text/x-null;format=x-curl
                     if let Some(ref mut ct) = custom_type {
                         ct.push_str(";format=");
                         ct.push_str(f);
                     }
+                } else if let Some(h) = modifier.strip_prefix("headers=") {
+                    parse_headers_modifier(h, &mut custom_headers)?;
+                } else if let Some(e) = modifier.strip_prefix("encoder=") {
+                    encoder = Some(e.to_string());
                 }
             }
 
@@ -2755,15 +2805,36 @@ fn parse_form_field(easy: &mut liburlx::Easy, val: &str) -> Result<(), String> {
                 .unwrap_or_default();
             let display_filename = custom_filename.unwrap_or_else(|| original_filename.clone());
 
-            if let Some(ref ct) = custom_type {
-                easy.form_file_with_type(name, &display_filename, ct, &data);
-            } else {
-                // Guess content type from the original filepath, not the custom filename
-                easy.form_file_with_type(
-                    name,
-                    &display_filename,
-                    &liburlx::guess_form_content_type(&original_filename),
+            if custom_headers.is_empty() && encoder.is_none() && container_stack.is_empty() {
+                // Simple path — use existing API
+                if let Some(ref ct) = custom_type {
+                    easy.form_file_with_type(name, &display_filename, ct, &data);
+                } else {
+                    // No explicit type — use form_file_data which sets explicit_type=false.
+                    // In SMTP/IMAP mode, Content-Type is only output for explicit types.
+                    // For HTTP, Content-Type is always output (explicit_type=false still
+                    // outputs a guessed type in the non-SMTP encode path).
+                    easy.form_file_data(name, &display_filename, &data);
+                }
+            } else if let Some(&container_idx) = container_stack.last() {
+                // Inside a nested container
+                easy.form_add_to_container(
+                    container_idx,
                     &data,
+                    custom_type.as_deref(),
+                    Some(&display_filename),
+                    custom_headers,
+                    encoder.as_deref(),
+                );
+            } else {
+                // Top-level part with custom headers/encoder
+                easy.form_add_with_options(
+                    name,
+                    &data,
+                    custom_type.as_deref(),
+                    Some(&display_filename),
+                    custom_headers,
+                    encoder.as_deref(),
                 );
             }
         }
@@ -2791,12 +2862,14 @@ fn parse_form_field(easy: &mut liburlx::Easy, val: &str) -> Result<(), String> {
         // The value can be quoted: "..." — in which case the closing quote ends the value
         // and modifiers follow after a `;`.
         let (raw_value, modifiers) = parse_text_value_and_modifiers(value);
-        // curl strips leading whitespace from unquoted text field values (curl compat: test 186)
+        // curl strips leading whitespace from unquoted text field values (curl compat: tests 186, 646)
         let field_value =
             if value.starts_with('"') { raw_value } else { raw_value.trim_start().to_string() };
 
         let mut custom_type: Option<String> = None;
         let mut custom_filename: Option<String> = None;
+        let mut custom_headers: Vec<String> = Vec::new();
+        let mut encoder: Option<String> = None;
 
         for modifier in &modifiers {
             let trimmed = modifier.trim();
@@ -2804,6 +2877,10 @@ fn parse_form_field(easy: &mut liburlx::Easy, val: &str) -> Result<(), String> {
                 custom_type = Some(t.to_string());
             } else if let Some(f) = trimmed.strip_prefix("filename=") {
                 custom_filename = Some(unescape_form_filename(f));
+            } else if let Some(h) = trimmed.strip_prefix("headers=") {
+                parse_headers_modifier(h, &mut custom_headers)?;
+            } else if let Some(e) = trimmed.strip_prefix("encoder=") {
+                encoder = Some(e.to_string());
             }
         }
 
@@ -2817,6 +2894,8 @@ fn parse_form_field(easy: &mut liburlx::Easy, val: &str) -> Result<(), String> {
                 if !trimmed.starts_with("type=")
                     && !trimmed.starts_with("filename=")
                     && !trimmed.starts_with("format=")
+                    && !trimmed.starts_with("headers=")
+                    && !trimmed.starts_with("encoder=")
                     && !trimmed.is_empty()
                 {
                     // Unknown modifier after type — append as Content-Type sub-param
@@ -2826,12 +2905,31 @@ fn parse_form_field(easy: &mut liburlx::Easy, val: &str) -> Result<(), String> {
             }
         }
 
-        if let Some(ref filename) = custom_filename {
-            // Text value with filename → file-like part
+        if !container_stack.is_empty() {
+            // Inside a nested container — add as subpart
+            let container_idx = *container_stack.last().unwrap_or(&0);
+            easy.form_add_to_container(
+                container_idx,
+                field_value.as_bytes(),
+                custom_type.as_deref(),
+                custom_filename.as_deref(),
+                custom_headers,
+                encoder.as_deref(),
+            );
+        } else if !custom_headers.is_empty() || encoder.is_some() {
+            // Top-level with custom headers/encoder
+            easy.form_add_with_options(
+                name,
+                field_value.as_bytes(),
+                custom_type.as_deref(),
+                custom_filename.as_deref(),
+                custom_headers,
+                encoder.as_deref(),
+            );
+        } else if let Some(ref filename) = custom_filename {
             if let Some(ref ct) = custom_type {
                 easy.form_file_with_type(name, filename, ct, field_value.as_bytes());
             } else {
-                // No explicit type → don't set Content-Type (curl compat: SMTP test 1187)
                 easy.form_file_no_type(name, filename, field_value.as_bytes());
             }
         } else if let Some(ref ct) = custom_type {
@@ -2842,6 +2940,67 @@ fn parse_form_field(easy: &mut liburlx::Easy, val: &str) -> Result<(), String> {
     }
 
     Ok(())
+}
+
+/// Parse a `headers=` modifier value.
+///
+/// Supports:
+/// - `headers=Header-Name: value` — inline header
+/// - `headers=@filename` or `headers=<filename` — headers from file
+fn parse_headers_modifier(value: &str, headers: &mut Vec<String>) -> Result<(), String> {
+    if let Some(path) = value.strip_prefix('@').or_else(|| value.strip_prefix('<')) {
+        // Headers from file
+        let contents = std::fs::read_to_string(path)
+            .map_err(|e| format!("error reading headers file: {e}"))?;
+        read_header_file_contents(&contents, headers);
+    } else {
+        // Inline header
+        headers.push(value.to_string());
+    }
+    Ok(())
+}
+
+/// Read headers from file contents (curl format).
+///
+/// Lines starting with `#` are comments. Header folding (continuation with space/tab)
+/// is supported. Blank lines are ignored.
+fn read_header_file_contents(contents: &str, headers: &mut Vec<String>) {
+    let mut current_header: Option<String> = None;
+
+    for line in contents.lines() {
+        // Skip comment lines (starting with #)
+        if line.starts_with('#') {
+            continue;
+        }
+        // Skip empty lines
+        if line.trim().is_empty() {
+            // Flush current header
+            if let Some(h) = current_header.take() {
+                headers.push(h);
+            }
+            continue;
+        }
+        // Folded header (continuation line starts with space or tab)
+        if line.starts_with(' ') || line.starts_with('\t') {
+            if let Some(ref mut h) = current_header {
+                // Fold: join with single space, trim the leading whitespace from continuation
+                h.push(' ');
+                h.push_str(line.trim());
+                continue;
+            }
+        }
+        // New header — flush previous
+        if let Some(h) = current_header.take() {
+            headers.push(h);
+        }
+        // Strip trailing whitespace and \r
+        let trimmed = line.trim_end().trim_end_matches('\r');
+        current_header = Some(trimmed.to_string());
+    }
+    // Flush last header
+    if let Some(h) = current_header {
+        headers.push(h);
+    }
 }
 
 /// Split comma-separated file specs, respecting quoted paths.
@@ -2918,7 +3077,7 @@ fn parse_text_value_and_modifiers(s: &str) -> (String, Vec<String>) {
     }
 }
 
-/// Find the position of the first `;` that starts a known modifier (type=, filename=, format=).
+/// Find the position of the first `;` that starts a known modifier.
 fn find_first_modifier_semicolon(s: &str) -> Option<usize> {
     let bytes = s.as_bytes();
     let mut i = 0;
@@ -2928,6 +3087,8 @@ fn find_first_modifier_semicolon(s: &str) -> Option<usize> {
             if rest.starts_with("type=")
                 || rest.starts_with("filename=")
                 || rest.starts_with("format=")
+                || rest.starts_with("headers=")
+                || rest.starts_with("encoder=")
             {
                 return Some(i);
             }

--- a/crates/urlx-cli/src/transfer.rs
+++ b/crates/urlx-cli/src/transfer.rs
@@ -1951,6 +1951,19 @@ pub fn run(args: &[String]) -> ExitCode {
                 eprintln!();
             }
 
+            // SFTP post-quote errors: output the downloaded data before
+            // reporting the error (curl compat: test 609)
+            if let liburlx::Error::SshQuoteErrorWithData { ref response, .. } = e {
+                let _ = output_response(
+                    response.as_ref(),
+                    opts.output_file.as_deref(),
+                    opts.write_out.as_deref(),
+                    false, // no include headers for SFTP
+                    opts.silent,
+                    false,
+                );
+            }
+
             // Output last response data on error (curl compat — headers/body before error)
             if let Some(resp) = opts.easy.last_response() {
                 // For redirect responses (max-redirects exceeded), only output headers


### PR DESCRIPTION
## Summary
- Add MIME multipart nested container support (`=(;type=...` / `=)` syntax) for curl's -F MIME API
- Add `encoder=` parameter (quoted-printable, base64, 7bit) for -F fields with Content-Transfer-Encoding
- Add `headers=` parameter for custom part headers (inline and from file)
- Add HTTP CONNECT proxy tunneling for SMTP, IMAP, POP3 protocols
- Fix SFTP post-quote error data output in single-URL path (test 609)
- Fix HTTP multipart Content-Type with charset parameter keeping form-data disposition (test 669)
- Fix IMAP APPEND with multipart/MIME body via -F flags (test 647)
- Fix POP3 output line ending preservation matching wire format (test 1319)
- Fix SMTP -H header injection into MIME preamble (tests 646, 648)
- Add 7-bit encoding validation after SMTP DATA command (test 649)

## Test plan
- [x] All 9 curl tests pass: 609, 646, 647, 648, 649, 669, 1319, 1320, 1321
- [x] `cargo test` — all Rust tests pass
- [x] `cargo clippy` — no warnings
- [x] `cargo fmt` — clean