### PR TITLE
docs: update README with current test suite results (93.4%)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ---
 
-urlx is a from-scratch rewrite of [curl](https://curl.se/) in Rust. Zero `unsafe` outside the FFI boundary. Built on [tokio](https://tokio.rs/) and [rustls](https://github.com/rustls/rustls) — no OpenSSL. **92% of curl's own test suite passes against urlx** (1,171 / 1,273 tests).
+urlx is a from-scratch rewrite of [curl](https://curl.se/) in Rust. Zero `unsafe` outside the FFI boundary. Built on [tokio](https://tokio.rs/) and [rustls](https://github.com/rustls/rustls) — no OpenSSL. **93.4% of curl's own test suite passes against urlx** (1,173 / 1,327 tests, tests 1–1400).
 
 ## Highlights
 
@@ -25,7 +25,7 @@ urlx is a from-scratch rewrite of [curl](https://curl.se/) in Rust. Zero `unsafe
 - **Drop-in C library** — `liburlx-ffi` exposes the libcurl C ABI so existing C/C++ programs can link against it
 - **Idiomatic Rust API** — `liburlx` provides a clean async/sync API modeled on curl's Easy/Multi handles
 - **Broad protocol support** — HTTP/1.1, HTTP/2, HTTP/3 (QUIC), FTP/FTPS, SFTP/SCP, WebSocket, SMTP, IMAP, POP3, MQTT, DICT, TFTP
-- **2,600+ tests** — unit, integration (against real servers), property-based, and fuzz harnesses
+- **2,655 tests** — unit, integration (against real servers), property-based, and fuzz harnesses
 - **Async core** — tokio runtime with a blocking `Easy` wrapper and native async `Multi` API
 
 ## Quick Start


### PR DESCRIPTION
## Summary

- Update curl test suite pass rate from 92% (1,171/1,273) to **93.4%** (1,173/1,327 tests, tests 1–1400)
- Update Rust test count from "2,600+" to **2,655** tests

These numbers match the current project status documented in CLAUDE.md (last updated 2026-03-19).

## Test plan

- [ ] Verify README displays correct pass rate (93.4%) and test counts
- [ ] Confirm numbers match CLAUDE.md project status section

🤖 Generated with [Claude Code](https://claude.com/claude-code)