### PR TITLE
fix(imap): --login-options AUTH=* with special char credentials (test 895)

### DIFF
--- a/crates/liburlx/src/protocol/imap.rs
+++ b/crates/liburlx/src/protocol/imap.rs
@@ -551,6 +551,10 @@ async fn fetch_inner(
         let forced = login_options
             .and_then(|lo| lo.strip_prefix("AUTH=").or_else(|| lo.strip_prefix("auth=")));
 
+        // AUTH=* means "try any available mechanism" — treat as no forced mechanism
+        // (curl compat: test 895).
+        let forced = forced.and_then(|f| if f == "*" { None } else { Some(f) });
+
         // Check if forced mechanism is +LOGIN (plain LOGIN command, not SASL AUTHENTICATE LOGIN)
         let force_login_cmd = forced
             .is_some_and(|f| f.eq_ignore_ascii_case("+LOGIN") || f.eq_ignore_ascii_case("LOGIN"));
@@ -766,6 +770,8 @@ pub async fn fetch_multi(
     if !is_preauth {
         let forced = login_options
             .and_then(|lo| lo.strip_prefix("AUTH=").or_else(|| lo.strip_prefix("auth=")));
+        // AUTH=* means "try any available mechanism" (curl compat: test 895).
+        let forced = forced.and_then(|f| if f == "*" { None } else { Some(f) });
         let force_login_cmd = forced
             .is_some_and(|f| f.eq_ignore_ascii_case("+LOGIN") || f.eq_ignore_ascii_case("LOGIN"));
 

--- a/crates/urlx-cli/src/transfer.rs
+++ b/crates/urlx-cli/src/transfer.rs
@@ -1326,11 +1326,19 @@ pub fn run(args: &[String]) -> ExitCode {
                 || url.starts_with("pop3s://")
             {
                 // Reject credentials with special characters only when --login-options
-                // is used (curl compat: test 896). Without --login-options, percent-encode
+                // is used with a specific mechanism (curl compat: test 896).
+                // AUTH=* means "try any available" and should NOT reject special chars
+                // (curl compat: test 895). Without --login-options, percent-encode
                 // special chars so they survive URL embedding (curl compat: tests 800, 847, 988).
                 let has_bad_char = |s: &str| s.contains('"') || s.contains('{') || s.contains('}');
+                let is_wildcard_auth = opts
+                    .easy
+                    .get_login_options()
+                    .and_then(|lo| lo.strip_prefix("AUTH=").or_else(|| lo.strip_prefix("auth=")))
+                    .is_some_and(|m| m == "*");
                 if (has_bad_char(user) || has_bad_char(pass))
                     && opts.easy.get_login_options().is_some()
+                    && !is_wildcard_auth
                 {
                     if !opts.silent || opts.show_error {
                         eprintln!("curl: (3) URL using bad/illegal format or missing URL");


### PR DESCRIPTION
## Summary
- Fix `--login-options 'AUTH=*'` failing with exit code 3 when credentials contain special characters (`"`, `{`, `}`)
- `AUTH=*` means "try any available auth mechanism" (wildcard) and should not trigger the credential rejection that exists for specific forced mechanisms
- Normalize `AUTH=*` to `None` (no forced mechanism) in the IMAP protocol handler so `should_try()` correctly tries all server-advertised mechanisms

## Changes
- `crates/urlx-cli/src/transfer.rs`: Skip credential special-char rejection when login-options is `AUTH=*` (curl compat: test 895, preserves test 896 behavior)
- `crates/liburlx/src/protocol/imap.rs`: Normalize `AUTH=*` wildcard to `None` in both single-fetch and multi-fetch paths

## Test plan
- [x] `cargo build --release` passes
- [x] `cargo clippy --all-targets --all-features` passes (no warnings)
- [x] `cargo fmt -- --check` passes
- [x] All 20 IMAP unit tests pass
- [x] Full test suite (2,655 Rust tests) passes
- [ ] curl test 895 should now pass (IMAP with `AUTH=*` and `-u '"user:sec"ret{'`)
- [ ] curl test 896 should still pass (unknown mechanism still returns exit 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)