### PR TITLE
fix(cli): produce -w write-out output for unsupported protocol URLs

### DIFF
--- a/crates/urlx-cli/src/transfer.rs
+++ b/crates/urlx-cli/src/transfer.rs
@@ -3022,6 +3022,31 @@ pub fn run_multi(
                 if !silent || show_error {
                     eprintln!("curl: (1) Protocol \"{scheme}\" not supported");
                 }
+                // Still produce write-out for unsupported protocols (curl compat: tests 423, 424)
+                if let Some(wo) = write_out {
+                    let dummy_response = liburlx::Response::new(
+                        0,
+                        std::collections::HashMap::new(),
+                        Vec::new(),
+                        url.clone(),
+                    );
+                    let ctx = WriteOutContext {
+                        urlnum: i,
+                        exitcode: 1,
+                        errormsg: format!("Protocol \"{scheme}\" not supported"),
+                        had_error: true,
+                        ..WriteOutContext::default()
+                    };
+                    let _ = output_response_with_context(
+                        &dummy_response,
+                        None,
+                        Some(wo),
+                        false,
+                        silent,
+                        true,
+                        &ctx,
+                    );
+                }
                 let exit_code = ExitCode::from(1_u8);
                 if fail_early {
                     return exit_code;


### PR DESCRIPTION
## Summary
- When using `--write-out` (`-w`) with URLs that have unsupported schemes (e.g., `h55p://`), the write-out output was silently skipped instead of being produced with parsed URL components
- Added write-out handling in the unsupported protocol error path in `transfer.rs`, matching the existing pattern used for invalid URLs and failed transfers
- Passes curl tests 423 and 424

## Test plan
- [x] curl test 423 (`-w` with `url.*` variables) passes
- [x] curl test 424 (`-w` with `urle.*` variables) passes
- [x] Related tests 196 and 760 still pass (no regressions)
- [x] `cargo test -p urlx-cli` — all 314 tests pass
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)