### PR TITLE
fix(http): HEAD request body suppression for HTTP/0.9 (test 1144)

### DIFF
--- a/crates/liburlx/src/protocol/http/h1.rs
+++ b/crates/liburlx/src/protocol/http/h1.rs
@@ -564,6 +564,11 @@ where
         if !http09_allowed {
             return Err(Error::Http("unsupported HTTP version in response".to_string()));
         }
+        // HEAD + HTTP/0.9: no status line means we can't distinguish headers from body,
+        // which is a weird server reply for HEAD (curl compat: test 1144)
+        if is_head {
+            return Err(Error::Http("Weird server reply".to_string()));
+        }
         // Read remaining body to EOF
         let mut body = body_prefix;
         let mut tmp = [0u8; 8192];


### PR DESCRIPTION
## Summary
- Return `CURLE_WEIRD_SERVER_REPLY` (exit code 8) when a HEAD request receives an HTTP/0.9 response (raw data with no status line)
- Previously the HTTP/0.9 code path unconditionally read and returned body data, ignoring that HEAD requests should suppress body output
- Matches curl behavior: HEAD expects headers, so a headerless HTTP/0.9 response is a weird server reply

## Test plan
- [ ] curl test 1144 passes (HEAD + HTTP/0.9 → error 8, empty output)
- [ ] No regressions in existing HTTP/0.9 tests (1172, 1174)
- [ ] No regressions in HEAD request tests

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)