### PR TITLE
fix(http): --fail hangs on HTTP/1.0 response without Content-Length (test 24)

### DIFF
--- a/crates/liburlx/src/easy.rs
+++ b/crates/liburlx/src/easy.rs
@@ -2934,6 +2934,7 @@ impl Easy {
             self.allowed_protocols.as_deref(),
             &mut self.ftp_session,
             self.netrc_content.as_deref(),
+            self.fail_on_error,
         );
 
         // Apply total transfer timeout if set.
@@ -3095,6 +3096,7 @@ async fn perform_transfer(
     allowed_protocols: Option<&[String]>,
     ftp_session: &mut Option<crate::protocol::ftp::FtpSession>,
     netrc_content: Option<&str>,
+    fail_on_error: bool,
 ) -> Result<Response, Error> {
     let transfer_start = Instant::now();
     let original_url = url.clone();
@@ -3387,6 +3389,7 @@ async fn perform_transfer(
             raw,
             ftp_session,
             redirected_from_http,
+            fail_on_error,
         ))
         .await?;
 
@@ -3485,6 +3488,7 @@ async fn perform_transfer(
                         raw,
                         ftp_session,
                         redirected_from_http,
+                        fail_on_error,
                     ))
                     .await?;
                 }
@@ -3642,6 +3646,7 @@ async fn perform_transfer(
                                 raw,
                                 ftp_session,
                                 redirected_from_http,
+                                fail_on_error,
                             ))
                             .await?;
 
@@ -3751,6 +3756,7 @@ async fn perform_transfer(
                                         raw,
                                         ftp_session,
                                         redirected_from_http,
+                                        fail_on_error,
                                     ))
                                     .await?;
                                 }
@@ -3847,6 +3853,7 @@ async fn perform_transfer(
                                 raw,
                                 ftp_session,
                                 redirected_from_http,
+                                fail_on_error,
                             ))
                             .await?;
                         }
@@ -3957,6 +3964,7 @@ async fn perform_transfer(
                                         raw,
                                         ftp_session,
                                         redirected_from_http,
+                                        fail_on_error,
                                     ))
                                     .await?;
                                 }
@@ -4047,6 +4055,7 @@ async fn perform_transfer(
                             raw,
                             ftp_session,
                             redirected_from_http,
+                            fail_on_error,
                         ))
                         .await?;
                     }
@@ -4162,6 +4171,7 @@ async fn perform_transfer(
                                     raw,
                                     ftp_session,
                                     redirected_from_http,
+                                    fail_on_error,
                                 ))
                                 .await?;
                             }
@@ -4277,6 +4287,7 @@ async fn perform_transfer(
                                     raw,
                                     ftp_session,
                                     redirected_from_http,
+                                    fail_on_error,
                                 ))
                                 .await?;
                             }
@@ -4375,6 +4386,7 @@ async fn perform_transfer(
                                         raw,
                                         ftp_session,
                                         redirected_from_http,
+                                        fail_on_error,
                                     ))
                                     .await?;
 
@@ -4476,6 +4488,7 @@ async fn perform_transfer(
                                                     raw,
                                                     ftp_session,
                                                     redirected_from_http,
+                                                    fail_on_error,
                                                 ))
                                                 .await?;
                                             }
@@ -4577,6 +4590,7 @@ async fn perform_transfer(
                                             raw,
                                             ftp_session,
                                             redirected_from_http,
+                                            fail_on_error,
                                         ))
                                         .await?;
                                     }
@@ -4722,6 +4736,7 @@ async fn perform_transfer(
                                         raw,
                                         ftp_session,
                                         redirected_from_http,
+                                        fail_on_error,
                                     ))
                                     .await?;
                                 }
@@ -4843,6 +4858,7 @@ async fn perform_transfer(
                                     raw,
                                     ftp_session,
                                     redirected_from_http,
+                                    fail_on_error,
                                 ))
                                 .await?;
                             }
@@ -5218,6 +5234,7 @@ async fn perform_transfer(
                         raw,
                         ftp_session,
                         true,
+                        fail_on_error,
                     ))
                     .await;
 
@@ -5345,6 +5362,7 @@ async fn do_single_request(
     raw: bool,
     ftp_session: &mut Option<crate::protocol::ftp::FtpSession>,
     redirected_from_http: bool,
+    fail_on_error: bool,
 ) -> Result<Response, Error> {
     // Handle non-HTTP schemes directly
     match url.scheme() {
@@ -5879,6 +5897,7 @@ async fn do_single_request(
                 http09_allowed,
                 deadline,
                 raw,
+                fail_on_error,
             )
             .await;
 
@@ -6020,6 +6039,7 @@ async fn do_single_request(
             http09_allowed,
             deadline,
             raw,
+            fail_on_error,
         )
         .await?;
         let time_starttransfer = request_start.elapsed();
@@ -6352,6 +6372,7 @@ async fn do_single_request(
                         http09_allowed,
                         deadline,
                         raw,
+                        fail_on_error,
                     )
                     .await?;
                     let time_starttransfer = request_start.elapsed();
@@ -6487,6 +6508,7 @@ async fn do_single_request(
                     http09_allowed,
                     deadline,
                     raw,
+                    fail_on_error,
                 )
                 .await?;
                 let time_starttransfer = request_start.elapsed();
@@ -6643,6 +6665,7 @@ async fn do_single_request(
                     http09_allowed,
                     deadline,
                     raw,
+                    fail_on_error,
                 )
                 .await?;
                 let time_starttransfer = request_start.elapsed();
@@ -6763,6 +6786,7 @@ async fn do_single_request(
                     http09_allowed,
                     deadline,
                     raw,
+                    fail_on_error,
                 )
                 .await?;
                 let time_starttransfer = request_start.elapsed();

--- a/crates/liburlx/src/protocol/http/h1.rs
+++ b/crates/liburlx/src/protocol/http/h1.rs
@@ -87,6 +87,7 @@ pub async fn request<S>(
     http09_allowed: bool,
     deadline: Option<tokio::time::Instant>,
     raw: bool,
+    fail_on_error: bool,
 ) -> Result<(Response, bool), Error>
 where
     S: AsyncRead + AsyncWrite + Unpin,
@@ -762,8 +763,15 @@ where
         && ph.headers.get("location").is_some_and(|v| !v.trim().is_empty())
         && !ph.headers.contains_key("content-length")
         && !ph.headers.get("transfer-encoding").is_some_and(|te| te_contains_chunked(te));
-    let no_body =
-        is_head || ph.status == 204 || ph.status == 304 || range_failed || is_redirect_no_cl;
+    // When fail_on_error is set and the status is >= 400, skip body read to avoid
+    // hanging on HTTP/1.0 responses without Content-Length (curl compat: test 24).
+    let fail_skip = fail_on_error && ph.status >= 400;
+    let no_body = is_head
+        || ph.status == 204
+        || ph.status == 304
+        || range_failed
+        || is_redirect_no_cl
+        || fail_skip;
 
     // Read body with download rate limiting
     let mut recv_limiter = RateLimiter::for_recv(speed_limits);
@@ -2568,6 +2576,7 @@ mod tests {
             true,
             None,
             false,
+            false,
         )
         .await
         .unwrap();
@@ -2612,6 +2621,7 @@ mod tests {
             false,
             true,
             None,
+            false,
             false,
         )
         .await
@@ -2662,6 +2672,7 @@ mod tests {
             true,
             None,
             false,
+            false,
         )
         .await
         .unwrap();
@@ -2705,6 +2716,7 @@ mod tests {
             false,
             true,
             None,
+            false,
             false,
         )
         .await
@@ -2750,6 +2762,7 @@ mod tests {
             false,
             true,
             None,
+            false,
             false,
         )
         .await
@@ -2800,6 +2813,7 @@ mod tests {
             false,
             true,
             None,
+            false,
             false,
         )
         .await
@@ -2857,6 +2871,7 @@ mod tests {
             false,
             true,
             None,
+            false,
             false,
         )
         .await
@@ -2929,6 +2944,7 @@ mod tests {
             true,
             None,
             false,
+            false,
         )
         .await
         .unwrap();
@@ -2981,6 +2997,7 @@ mod tests {
             true,
             None,
             false,
+            false,
         )
         .await
         .unwrap();
@@ -3032,6 +3049,7 @@ mod tests {
             true,
             None,
             false,
+            false,
         )
         .await
         .unwrap();
@@ -3081,6 +3099,7 @@ mod tests {
             true,
             None,
             false,
+            false,
         )
         .await
         .unwrap();
@@ -3121,6 +3140,7 @@ mod tests {
             false,
             true,
             None,
+            false,
             false,
         )
         .await
@@ -3169,6 +3189,7 @@ mod tests {
             true,
             None,
             false,
+            false,
         )
         .await
         .unwrap();
@@ -3215,6 +3236,7 @@ mod tests {
             false,
             true,
             None,
+            false,
             false,
         )
         .await
@@ -3287,6 +3309,7 @@ mod tests {
             true,
             None,
             false,
+            false,
         )
         .await
         .unwrap();
@@ -3351,6 +3374,7 @@ mod tests {
             true,
             None,
             false,
+            false,
         )
         .await
         .unwrap();
@@ -3398,6 +3422,7 @@ mod tests {
             false,
             true,
             None,
+            false,
             false,
         )
         .await
@@ -3447,6 +3472,7 @@ mod tests {
             true,
             None,
             false,
+            false,
         )
         .await
         .unwrap();
@@ -3490,6 +3516,7 @@ mod tests {
                 false,
                 true,
                 None,
+                false,
                 false,
             ),
         )
@@ -3537,6 +3564,7 @@ mod tests {
                 false,
                 true,
                 None,
+                false,
                 false,
             ),
         )
@@ -3613,6 +3641,7 @@ mod tests {
             false,
             true,
             None,
+            false,
             false,
         )
         .await


### PR DESCRIPTION
## Summary

- When `--fail` / `fail_on_error` is set and HTTP status >= 400, skip reading the response body in `h1::request()` to avoid hanging on HTTP/1.0 responses without `Content-Length`
- Threads `fail_on_error` flag from `Easy::perform()` → `perform_transfer()` → `do_single_request()` → `h1::request()`
- Adds `fail_skip` condition to the `no_body` check in the H1 body reading logic

## Test plan

- [x] `cargo check` passes
- [x] `cargo clippy` passes (no warnings)
- [x] `cargo fmt` applied
- [x] All 314 existing Rust tests pass
- [ ] curl test 24 passes: `./scripts/run-curl-tests.sh 24`
- [ ] No regressions on previously passing tests (especially test 150 — NTLM + `--fail`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)