### PR TITLE
feat(cli): advertise zstd and brotli in --version features output

### DIFF
--- a/crates/urlx-cli/src/args.rs
+++ b/crates/urlx-cli/src/args.rs
@@ -183,7 +183,7 @@ pub fn print_version() {
     println!("curl {version} ({arch}-{os}) libcurl/{version} rustls",);
     println!("Release-Date: 2026-03-16");
     println!("Protocols: dict file ftp ftps http https imap imaps mqtt pop3 pop3s scp sftp smtp smtps ws wss");
-    println!("Features: alt-svc AsynchDNS cookies Digest HSTS HTTP2 HTTP3 HTTPS-proxy IPv6 Largefile libz NTLM SSL UnixSockets");
+    println!("Features: alt-svc AsynchDNS brotli cookies Digest HSTS HTTP2 HTTP3 HTTPS-proxy IPv6 Largefile libz NTLM SSL UnixSockets zstd");
 }
 
 /// Print usage information to stderr.


### PR DESCRIPTION
## Summary

- Add `zstd` and `brotli` to the `Features:` line in `--version` output so curl's test runner (`runtests.pl`) recognizes these decompression capabilities
- The zstd/brotli decompression logic was already fully implemented; only the version string was missing the feature advertisements
- Enables curl tests **396** (HTTP GET with zstd content encoding) and **397** (HTTP GET with zstd compressed content larger than `CURL_MAX_WRITE_SIZE`), which were previously skipped

## Test plan

- [x] curl test 396 passes
- [x] curl test 397 passes
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets` passes
- [x] No regressions on existing tests (verified tests 220, 224, 230, 339)

🤖 Generated with [Claude Code](https://claude.com/claude-code)