### PR TITLE
feat(http): add brotli decompression support (tests 314, 315, 316)

### DIFF
--- a/crates/liburlx/src/protocol/http/h1.rs
+++ b/crates/liburlx/src/protocol/http/h1.rs
@@ -1761,6 +1761,18 @@ where
         });
     }
 
+    // Determine if the encoding can be checked incrementally (gzip/deflate)
+    // or requires stall-based detection (brotli/zstd).
+    // Brotli and zstd decompressors can't distinguish truncated valid data from
+    // corrupt data on partial streams, so we use a stall timeout instead.
+    let outermost = encoding
+        .rsplit(',')
+        .map(str::trim)
+        .find(|s| !s.is_empty() && !s.eq_ignore_ascii_case("identity"))
+        .unwrap_or_else(|| encoding.trim());
+    let needs_stall_detection =
+        outermost.eq_ignore_ascii_case("br") || outermost.eq_ignore_ascii_case("zstd");
+
     while body.len() < content_length {
         let remaining = content_length - body.len();
         // Read in reasonably-sized chunks to allow incremental checking
@@ -1769,15 +1781,45 @@ where
 
         // Use read() (not read_exact) so we process whatever data is available
         let read_fut = stream.read(&mut chunk_buf);
-        let result = if let Some(dl) = deadline {
-            match tokio::time::timeout_at(dl, read_fut).await {
-                Ok(inner) => inner,
-                Err(_) => {
+
+        // For brotli/zstd: if we already have data and the next read stalls,
+        // try decompression to detect corrupt encoding without blocking forever
+        // (curl compat: test 315 — broken brotli with Content-Length > actual data).
+        let stall_deadline = if needs_stall_detection && !body.is_empty() {
+            Some(tokio::time::Instant::now() + std::time::Duration::from_millis(500))
+        } else {
+            None
+        };
+
+        // Use the earlier of: transfer deadline, stall deadline
+        let effective_deadline = match (deadline, stall_deadline) {
+            (Some(d), Some(s)) => Some(d.min(s)),
+            (d, s) => d.or(s),
+        };
+
+        let result = if let Some(dl) = effective_deadline {
+            if let Ok(inner) = tokio::time::timeout_at(dl, read_fut).await {
+                inner
+            } else {
+                // Check if this was a stall timeout (not the transfer deadline)
+                let is_stall = stall_deadline.is_some_and(|s| deadline.is_none_or(|d| s <= d));
+                if is_stall {
+                    // Stall detected: try decompressing accumulated data.
+                    // If decompression succeeds, the compressed stream is
+                    // complete despite Content-Length mismatch — return data.
+                    // If decompression fails, it's corrupt encoding.
+                    if super::decompress::decompress(&body, encoding).is_ok() {
+                        return Ok(body);
+                    }
                     return Err(Error::PartialBody {
-                        message: "transfer closed with outstanding read data remaining".to_string(),
+                        message: "bad_content_encoding".to_string(),
                         partial_body: body,
                     });
                 }
+                return Err(Error::PartialBody {
+                    message: "transfer closed with outstanding read data remaining".to_string(),
+                    partial_body: body,
+                });
             }
         } else {
             read_fut.await

--- a/crates/urlx-cli/src/args.rs
+++ b/crates/urlx-cli/src/args.rs
@@ -183,7 +183,7 @@ pub fn print_version() {
     println!("curl {version} ({arch}-{os}) libcurl/{version} rustls",);
     println!("Release-Date: 2026-03-16");
     println!("Protocols: dict file ftp ftps http https imap imaps mqtt pop3 pop3s scp sftp smtp smtps ws wss");
-    println!("Features: alt-svc AsynchDNS cookies Digest HSTS HTTP2 HTTP3 HTTPS-proxy IPv6 Largefile libz NTLM SSL UnixSockets");
+    println!("Features: alt-svc AsynchDNS brotli cookies Digest HSTS HTTP2 HTTP3 HTTPS-proxy IPv6 Largefile libz NTLM SSL UnixSockets zstd");
 }
 
 /// Print usage information to stderr.


### PR DESCRIPTION
## Summary

- Advertise `brotli` and `zstd` in the `--version` Features output so curl's test runner recognizes support and runs brotli tests
- Fix broken brotli detection (test 315) by adding stall-based corruption detection in the incremental body reader for brotli/zstd encodings

The brotli decompression code was already fully implemented (via the `brotli` crate), but tests 314-316 were skipped because the version output didn't list `brotli` as a feature.

Test 315 (broken brotli with Content-Length > actual data) required special handling: unlike gzip/deflate, brotli decompressors can't distinguish truncated valid data from corrupt data on partial streams. The fix adds stall detection — when a read stalls for 500ms on brotli/zstd content, full decompression is attempted to detect corruption without blocking forever.

## Test plan

- [x] All 3 brotli tests pass: 314, 315, 316
- [x] No regressions on related decompression tests: 220, 223, 224, 230, 319
- [x] Full Rust test suite passes (2,655 tests)
- [x] `cargo clippy` clean, `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)