### PR TITLE
test(http): add regression test for --fail hang on HTTP/1.0 without Content-Length (test 24)

### DIFF
--- a/crates/liburlx/tests/fail_on_error.rs
+++ b/crates/liburlx/tests/fail_on_error.rs
@@ -134,3 +134,52 @@ async fn fail_on_error_toggle() {
     let response = easy.perform_async().await.unwrap();
     assert_eq!(response.status(), 404);
 }
+
+/// Regression test for curl test 24: `--fail` should not hang when the server
+/// sends an HTTP/1.0 response without Content-Length and keeps the connection open.
+///
+/// Without the fix, urlx would wait for EOF to determine body end, which never
+/// comes because the server holds the TCP connection open. With `fail_on_error`,
+/// urlx must skip reading the body entirely when status >= 400.
+#[tokio::test]
+async fn fail_on_error_http10_no_content_length_no_hang() {
+    use std::time::Duration;
+    use tokio::io::AsyncReadExt;
+    use tokio::io::AsyncWriteExt;
+    use tokio::net::TcpListener;
+
+    // Start a raw TCP server that sends HTTP/1.0 404 without Content-Length
+    // and keeps the connection open (simulating curl test 24 scenario).
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+
+    let server_task = tokio::spawn(async move {
+        if let Ok((mut stream, _)) = listener.accept().await {
+            // Read the request (consume it)
+            let mut buf = [0u8; 4096];
+            let _ = stream.read(&mut buf).await;
+
+            // Send HTTP/1.0 404 without Content-Length, keep connection open
+            let response = b"HTTP/1.0 404 BAD BOY\r\nContent-Type: text/html\r\n\r\nNot found.\n";
+            let _ = stream.write_all(response).await;
+            let _ = stream.flush().await;
+
+            // Keep the connection open for a long time (simulating the hang scenario)
+            tokio::time::sleep(Duration::from_secs(30)).await;
+        }
+    });
+
+    let mut easy = liburlx::Easy::new();
+    easy.url(&format!("http://127.0.0.1:{port}/test")).unwrap();
+    easy.fail_on_error(true);
+    // Set a timeout so the test doesn't hang forever if the fix regresses
+    easy.timeout(Duration::from_secs(5));
+
+    let result = easy.perform_async().await;
+    // Should return an HTTP error (status 404 with fail_on_error), NOT a timeout
+    assert!(result.is_err(), "404 with fail_on_error should error");
+    let err_msg = result.unwrap_err().to_string();
+    assert!(err_msg.contains("HTTP error 404"), "Expected HTTP 404 error, got: {err_msg}");
+
+    server_task.abort();
+}


### PR DESCRIPTION
## Summary

- Add a regression test for the --fail hang on HTTP/1.0 responses without Content-Length (curl test 24)
- Uses a raw TCP server that sends HTTP/1.0 404 without Content-Length and keeps the connection open
- Verifies that `fail_on_error` causes urlx to skip body reading and return immediately with an HTTP 404 error, rather than hanging forever waiting for EOF

The fix itself was already merged in #63 (commit 76bfc2f). This PR adds a Rust-level regression test to prevent the issue from recurring.

## Test plan

- [x] New test `fail_on_error_http10_no_content_length_no_hang` passes
- [x] All existing `fail_on_error` tests pass (9 in fail_on_error.rs, 15 in fail_on_error_integration.rs)
- [x] Clippy clean, formatting correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)