### PR TITLE
fix(http): prevent body_error overwrite during decompression (test 223)

### DIFF
--- a/crates/liburlx/src/easy.rs
+++ b/crates/liburlx/src/easy.rs
@@ -6869,6 +6869,14 @@ fn maybe_decompress_inner(mut response: Response, accept_encoding: bool, raw: bo
         return response;
     }
 
+    // If the body reader already detected an error (e.g., bad_content_encoding
+    // from incremental encoding check, or transfer closed), skip decompression
+    // entirely to avoid overwriting the original error. The body is preserved
+    // as-is so callers can inspect or discard it. (curl compat: test 223)
+    if response.body_error().is_some() {
+        return response;
+    }
+
     // Transfer-Encoding decompression (hop-by-hop): always decompress regardless of
     // --compressed flag. Chunked is already handled at the framing layer; here we
     // handle gzip/deflate/br/zstd that may appear alongside chunked.
@@ -10350,5 +10358,57 @@ mod tests {
                 || err_msg.contains("not yet supported"),
             "unexpected error: {err_msg}"
         );
+    }
+
+    #[test]
+    fn maybe_decompress_preserves_existing_body_error() {
+        // When body_error is already set (e.g., from incremental encoding
+        // check in read_exact_body), decompression should be skipped entirely
+        // to avoid overwriting the original error. curl compat: test 223.
+        let mut headers = std::collections::HashMap::new();
+        headers.insert("content-encoding".to_string(), "deflate".to_string());
+        let broken_body = vec![0x58, 0xdb, 0x6e, 0xe3]; // broken deflate
+        let mut resp = crate::protocol::http::response::Response::new(
+            200,
+            headers,
+            broken_body.clone(),
+            "http://example.com".to_string(),
+        );
+        resp.set_body_error(Some("bad_content_encoding".to_string()));
+
+        let result = maybe_decompress_inner(resp, true, false);
+        assert_eq!(
+            result.body_error(),
+            Some("bad_content_encoding"),
+            "body_error should be preserved"
+        );
+        assert_eq!(result.body(), &broken_body, "body should not be modified");
+    }
+
+    #[test]
+    fn maybe_decompress_preserves_transfer_closed_error() {
+        // When body_error is "transfer closed..." (exit 18), decompression
+        // must not overwrite it with "bad_content_encoding" (exit 61).
+        let mut headers = std::collections::HashMap::new();
+        headers.insert("content-encoding".to_string(), "gzip".to_string());
+        // Partial gzip body (valid magic but truncated — decompression would fail)
+        let partial_body = vec![0x1f, 0x8b, 0x08, 0x00, 0x00];
+        let mut resp = crate::protocol::http::response::Response::new(
+            200,
+            headers,
+            partial_body.clone(),
+            "http://example.com".to_string(),
+        );
+        resp.set_body_error(Some(
+            "transfer closed with outstanding read data remaining".to_string(),
+        ));
+
+        let result = maybe_decompress_inner(resp, true, false);
+        assert_eq!(
+            result.body_error(),
+            Some("transfer closed with outstanding read data remaining"),
+            "body_error should not be overwritten by decompression failure"
+        );
+        assert_eq!(result.body(), &partial_body, "body should not be modified");
     }
 }

--- a/crates/liburlx/src/protocol/http/h1.rs
+++ b/crates/liburlx/src/protocol/http/h1.rs
@@ -803,8 +803,15 @@ where
         {
             Ok((body, eof, trailers, raw_trailers)) => (body, eof, trailers, raw_trailers, None),
             Err(Error::PartialBody { partial_body, message }) => {
-                // Chunked decode error with partial data — return headers + partial body
-                (partial_body, true, HashMap::new(), Vec::new(), Some(message))
+                // Bad content encoding: discard partial body — it contains raw compressed
+                // data that failed decompression and must not be output
+                // (curl compat: test 223 — broken deflate produces no body output).
+                if message == "bad_content_encoding" {
+                    (Vec::new(), true, HashMap::new(), Vec::new(), Some(message))
+                } else {
+                    // Other partial body errors: return headers + partial body
+                    (partial_body, true, HashMap::new(), Vec::new(), Some(message))
+                }
             }
             Err(e) => {
                 // Other body read errors — return headers only


### PR DESCRIPTION
## Summary
- Skip decompression in `maybe_decompress_inner` when `body_error` is already set from the body reading stage, preventing incorrect error code overwriting
- Discard partial body data when `bad_content_encoding` is detected (broken compressed data should not be output)
- Add unit tests verifying that body_error preservation works correctly for both encoding errors and transfer errors

## Test plan
- [x] curl test 223 passes (broken deflate with Content-Length mismatch)
- [x] curl tests 220-222, 224-230 pass (compression regression check)
- [x] curl tests 314-316 pass (brotli compression)
- [x] curl tests 376, 387 pass (encoding chain edge cases)
- [x] All 852 Rust unit tests pass
- [x] `cargo clippy -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)