### PR TITLE
fix(http): propagate --fail flag to Easy handle (test 24)

### DIFF
--- a/crates/urlx-cli/src/transfer.rs
+++ b/crates/urlx-cli/src/transfer.rs
@@ -1748,6 +1748,13 @@ pub fn run(args: &[String]) -> ExitCode {
         }
     }
 
+    // Propagate --fail flag to the Easy handle so the HTTP protocol handler
+    // can skip body reading on error status (avoids hang on HTTP/1.0 responses
+    // without Content-Length; curl compat: test 24).
+    if opts.fail_on_error {
+        opts.easy.fail_on_error(true);
+    }
+
     let result = perform_with_retry(&mut opts);
 
     // Save cookie jar after transfer (even on error)
@@ -2740,6 +2747,11 @@ pub fn run_multi(
         });
 
     let mut easy = template.clone();
+    // Propagate fail_on_error to the Easy handle so the HTTP protocol handler
+    // can skip body reading on error status (curl compat: test 24).
+    if fail_on_error {
+        easy.fail_on_error(true);
+    }
     let mut last_exit = ExitCode::SUCCESS;
     // Track HTTP version downgrade across requests (curl compat: test 1074).
     // When server responds with HTTP/1.0, subsequent requests should also use HTTP/1.0.
@@ -3487,6 +3499,9 @@ fn run_multi_parallel(
 
     for url in urls {
         let mut easy = template.clone();
+        if fail_on_error {
+            easy.fail_on_error(true);
+        }
         if let Err(e) = easy.url(url) {
             if !silent || show_error {
                 eprintln!("curl: error parsing URL '{url}': {e}");


### PR DESCRIPTION
## Summary

- Propagate the CLI's `--fail` / `fail_on_error` flag to the `Easy` handle so the HTTP/1.x protocol handler can skip body reading on error status codes
- Fixes curl test 24 hang: HTTP/1.0 404 response without `Content-Length` caused urlx to wait for EOF indefinitely
- Applied to all three code paths: single-URL, multi-URL sequential, and multi-URL parallel

## Root Cause

`opts.fail_on_error` was set to `true` when `--fail` was parsed, but `opts.easy.fail_on_error(true)` was never called. The `Easy` handle's field stayed at its default (`false`), so `h1.rs` line 768 (`let fail_skip = fail_on_error && ph.status >= 400`) never triggered, and the body read loop hung on HTTP/1.0 responses without `Content-Length`.

## Test plan

- [x] `cargo build` succeeds
- [x] `cargo fmt --check` passes
- [x] `cargo clippy` passes  
- [x] `cargo test` — all 331 tests + 8 doc-tests pass
- [ ] `./scripts/run-curl-tests.sh 24` passes (requires curl test infra)
- [ ] No regressions on previously passing curl tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)