### PR TITLE
fix(http): use crate version for default User-Agent (tests 386, 430-432)

### DIFF
--- a/crates/liburlx/src/easy.rs
+++ b/crates/liburlx/src/easy.rs
@@ -6024,7 +6024,10 @@ async fn do_single_request(
                     let ua = headers
                         .iter()
                         .find(|(k, _)| k.eq_ignore_ascii_case("user-agent"))
-                        .map_or_else(|| "curl/0.1.0".to_string(), |(_, v)| v.clone());
+                        .map_or_else(
+                            || concat!("curl/", env!("CARGO_PKG_VERSION")).to_string(),
+                            |(_, v)| v.clone(),
+                        );
                     Some(crate::protocol::ftp::FtpProxyConfig::HttpConnect {
                         host: ph,
                         port: pp,
@@ -8039,7 +8042,11 @@ where
                 let _ = write!(connect_req, "{name}: {value}\r\n");
             }
             None => {
-                connect_req.push_str("User-Agent: curl/0.1.0\r\n");
+                connect_req.push_str(concat!(
+                    "User-Agent: curl/",
+                    env!("CARGO_PKG_VERSION"),
+                    "\r\n"
+                ));
             }
         }
     }

--- a/crates/liburlx/src/protocol/http/h1.rs
+++ b/crates/liburlx/src/protocol/http/h1.rs
@@ -196,7 +196,7 @@ where
             let _ = write!(req, "{name}: {value}\r\n");
         }
         None => {
-            req.push_str("User-Agent: curl/0.1.0\r\n");
+            req.push_str(concat!("User-Agent: curl/", env!("CARGO_PKG_VERSION"), "\r\n"));
         }
     }
 

--- a/crates/liburlx/src/protocol/http/h2.rs
+++ b/crates/liburlx/src/protocol/http/h2.rs
@@ -158,7 +158,7 @@ pub async fn send_request(
 
     let has_user_agent = custom_headers.iter().any(|(k, _)| k.eq_ignore_ascii_case("user-agent"));
     if !has_user_agent {
-        builder = builder.header("user-agent", "curl/0.1.0");
+        builder = builder.header("user-agent", concat!("curl/", env!("CARGO_PKG_VERSION")));
     }
 
     let has_accept = custom_headers.iter().any(|(k, _)| k.eq_ignore_ascii_case("accept"));

--- a/crates/liburlx/src/protocol/http/h3.rs
+++ b/crates/liburlx/src/protocol/http/h3.rs
@@ -173,7 +173,7 @@ pub async fn request(
 
     let has_user_agent = custom_headers.iter().any(|(k, _)| k.eq_ignore_ascii_case("user-agent"));
     if !has_user_agent {
-        builder = builder.header("user-agent", "curl/0.1.0");
+        builder = builder.header("user-agent", concat!("curl/", env!("CARGO_PKG_VERSION")));
     }
 
     let has_accept = custom_headers.iter().any(|(k, _)| k.eq_ignore_ascii_case("accept"));


### PR DESCRIPTION
## Summary
- Fixed default User-Agent string in HTTP/1.1, HTTP/2, HTTP/3, and CONNECT proxy code from hardcoded `curl/0.1.0` to `concat!("curl/", env!("CARGO_PKG_VERSION"))` so it always matches the actual crate version
- This fixes `--next` + `--config` chaining where subsequent request groups (after `--next` resets headers) fell back to the stale `0.1.0` default instead of `0.2.2`

## Test plan
- [x] curl tests 386, 430, 431, 432 now pass (were all failing due to User-Agent mismatch after `--next`)
- [x] `cargo fmt` and `cargo clippy` clean
- [x] All 925 liburlx lib tests pass
- [x] All 336 urlx-cli tests pass
- [x] No regressions in curl test suite (tests 1-50 and 380-440 verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)