### PR TITLE
fix(cli): --write-out %{onerror} and %{urlnum} to stderr

### DIFF
--- a/crates/liburlx-ffi/src/lib.rs
+++ b/crates/liburlx-ffi/src/lib.rs
@@ -4899,7 +4899,7 @@ fn error_to_curlcode(err: &liburlx::Error) -> CURLcode {
                 CURLcode::CURLE_UNSUPPORTED_PROTOCOL
             } else if msg.contains("resolve") || msg.contains("DNS") {
                 CURLcode::CURLE_COULDNT_RESOLVE_HOST
-            } else if msg.contains("HTTP error") && msg.contains("fail_on_error") {
+            } else if msg.contains("The requested URL returned error") {
                 CURLcode::CURLE_HTTP_RETURNED_ERROR
             } else if msg.contains("aborted by") || msg.contains("callback") {
                 CURLcode::CURLE_ABORTED_BY_CALLBACK
@@ -5365,7 +5365,7 @@ mod tests {
     fn error_code_http_returned_error() {
         assert_eq!(
             error_to_curlcode(&liburlx::Error::Http(
-                "HTTP error 404 (fail_on_error enabled)".to_string()
+                "The requested URL returned error: 404".to_string()
             )),
             CURLcode::CURLE_HTTP_RETURNED_ERROR
         );

--- a/crates/liburlx/src/easy.rs
+++ b/crates/liburlx/src/easy.rs
@@ -3174,7 +3174,7 @@ impl Easy {
         // Check fail_on_error: HTTP status >= 400 becomes an error
         if self.fail_on_error && response.status() >= 400 {
             return Err(Error::Http(format!(
-                "HTTP error {} (fail_on_error enabled)",
+                "The requested URL returned error: {}",
                 response.status()
             )));
         }

--- a/crates/liburlx/tests/fail_on_error.rs
+++ b/crates/liburlx/tests/fail_on_error.rs
@@ -179,7 +179,7 @@ async fn fail_on_error_http10_no_content_length_no_hang() {
     // Should return an HTTP error (status 404 with fail_on_error), NOT a timeout
     assert!(result.is_err(), "404 with fail_on_error should error");
     let err_msg = result.unwrap_err().to_string();
-    assert!(err_msg.contains("HTTP error 404"), "Expected HTTP 404 error, got: {err_msg}");
+    assert!(err_msg.contains("returned error: 404"), "Expected HTTP 404 error, got: {err_msg}");
 
     server_task.abort();
 }

--- a/crates/urlx-cli/src/transfer.rs
+++ b/crates/urlx-cli/src/transfer.rs
@@ -2477,7 +2477,7 @@ pub fn error_to_curl_code(err: &liburlx::Error) -> u8 {
                 52 // CURLE_GOT_NOTHING
             } else if msg.contains("too many redirects") || msg.contains("Too many redirects") {
                 47 // CURLE_TOO_MANY_REDIRECTS
-            } else if msg.contains("fail_on_error") {
+            } else if msg.contains("The requested URL returned error") {
                 22 // CURLE_HTTP_RETURNED_ERROR
             } else if msg.contains("unsupported protocol")
                 || msg.contains("Unsupported protocol")


### PR DESCRIPTION
## Summary

- Fixed `--write-out` `%{errormsg}` variable producing wrong text for `--fail` HTTP errors
- Changed fail_on_error error message from `"HTTP error NNN (fail_on_error enabled)"` to `"The requested URL returned error: NNN"` to match curl's format
- Updated pattern matching in CLI error-to-code mapper and FFI error mapper to match new message format

The root cause was that `Easy::perform_async()` returns an `Err` with the message `"HTTP error 404 (fail_on_error enabled)"` when `--fail` is set and HTTP status >= 400. The `run_multi` function's `Err` branch uses `curl_error_message()` which passes through this message as-is for `%{errormsg}`. Curl expects `"The requested URL returned error: 404"`.

## Test plan

- [x] Manual test confirms correct stderr output: `0 says 22 The requested URL returned error: 404`
- [x] All workspace tests pass (`cargo test --workspace`)
- [x] `cargo fmt --check` and `cargo clippy` pass
- [ ] curl test 1188 passes via `scripts/run-curl-tests.sh 1188`

🤖 Generated with [Claude Code](https://claude.com/claude-code)