### PR TITLE
fix(cli): properly reset per-operation state across --next boundaries

### DIFF
--- a/crates/urlx-cli/src/args.rs
+++ b/crates/urlx-cli/src/args.rs
@@ -7036,7 +7036,7 @@ mod tests {
         assert!(opts.had_next);
 
         // First group should have only cookie_a
-        let first_easy = opts.per_url_easy[0].as_ref().expect("first URL should have Easy");
+        let first_easy = opts.per_url_easy[0].as_ref().unwrap();
         let first_cookie = first_easy
             .header_list()
             .iter()
@@ -7045,7 +7045,7 @@ mod tests {
         assert_eq!(first_cookie.as_deref(), Some("cookie_a=1"));
 
         // Second group should have only cookie_b (not cookie_a)
-        let second_easy = opts.per_url_easy[1].as_ref().expect("second URL should have Easy");
+        let second_easy = opts.per_url_easy[1].as_ref().unwrap();
         let second_cookie = second_easy
             .header_list()
             .iter()


### PR DESCRIPTION
## Summary

- Fix `--next` handler to reset additional per-operation options that were leaking across request groups: `inline_cookies`, `url_queries`, `get_mode`, `is_upload`/`upload_filename`/`upload_file_path`, `auto_resume`/`resume_check`/`resume_offset`
- Apply inline cookies and deferred `--json` headers to the Easy handle **before** saving `per_url_easy`, so the last `--next` group's Easy handle includes these headers
- Add 5 unit tests verifying that `--next` properly resets per-operation state

## Test plan

- [x] Curl tests 386, 430, 431, 432 pass (`scripts/run-curl-tests.sh 386 430 431 432`)
- [x] All 345 urlx-cli unit tests pass (`cargo test --package urlx-cli`)
- [x] No regressions in curl tests 1-100 and 300-500
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets` clean (only pre-existing `expect()` in test code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)