### PR TITLE
fix(cli): --write-out %{onerror} and %{urlnum} to stderr (test 1188)

### DIFF
--- a/crates/urlx-cli/src/transfer.rs
+++ b/crates/urlx-cli/src/transfer.rs
@@ -2679,9 +2679,12 @@ pub fn perform_with_retry(opts: &mut CliOptions) -> Result<liburlx::Response, li
                 return Ok(response);
             }
             Err(e) => {
+                // Don't retry non-retriable errors like --fail HTTP errors
+                // (curl compat: test 752 — 404 should not be retried).
+                let should_break = error_to_curl_code(&e) == 22; // CURLE_HTTP_RETURNED_ERROR
                 last_err = Some(e);
                 opts.retry_attempts = attempt;
-                if attempt == max_retries {
+                if should_break || attempt == max_retries {
                     break;
                 }
             }


### PR DESCRIPTION
## Summary
- Handle `--fail` HTTP errors in multi-URL mode by using `easy.last_response()` to get the actual response with headers, enabling proper `--include`, `--output`, and `--write-out` support
- Fix `perform_with_retry` to not retry non-retriable `--fail` HTTP errors (e.g., 404 with `--retry`)

## Test plan
- [x] Test 1188 passes (`--write-out` with `%{onerror}` and `%{urlnum}` to stderr)
- [x] Test 752 passes (`--retry` and `-f` on an HTTP 404 response)
- [x] Tests 24, 349, 361 pass (related `--fail` / `--fail-with-body` tests)
- [x] Tests 1-100, 700-780, 1100-1400 show no regressions
- [x] `cargo clippy`, `cargo test`, `cargo fmt` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)