### PR TITLE
feat(ws): retain WebSocket connections and implement curl-compatible transfers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,11 +21,11 @@ The project is MIT-licensed. The name "urlx" stands for "URL transfer."
 
 ### What Has Been Built
 
-A functional curl replacement covering HTTP/1.0-1.1, HTTP/2, HTTP/3 (QUIC via quinn), TLS (rustls + native-tls + STARTTLS), FTP/FTPS, SSH/SFTP/SCP, WebSocket, MQTT, SMTP, IMAP, POP3, DICT, TFTP, file://, DNS (system + hickory + DoH + DoT + Happy Eyeballs), cookies (Netscape format, domain-indexed, PSL, SameSite), HSTS, proxies (HTTP/SOCKS4/SOCKS4a/SOCKS5/HTTPS tunnel), authentication (Basic, Digest, Bearer, AWS SigV4, NTLMv2, SCRAM-SHA-256, SASL CRAM-MD5/OAUTHBEARER/XOAUTH2/EXTERNAL), connection pooling, rate limiting, multipart form upload, decompression (gzip, deflate, br, zstd), and a C ABI compatibility layer (liburlx-ffi with 57 exported functions).
+A functional curl replacement covering HTTP/1.0-1.1, HTTP/2, HTTP/3 (QUIC via quinn), TLS (rustls + native-tls + STARTTLS), FTP/FTPS, SSH/SFTP/SCP, WebSocket (RFC 6455 client with retained connections, curl-style transfers, connect-only mode, and `curl_ws_send`/`curl_ws_recv`/`curl_ws_meta` FFI), MQTT, SMTP, IMAP, POP3, DICT, TFTP, file://, DNS (system + hickory + DoH + DoT + Happy Eyeballs), cookies (Netscape format, domain-indexed, PSL, SameSite), HSTS, proxies (HTTP/SOCKS4/SOCKS4a/SOCKS5/HTTPS tunnel), authentication (Basic, Digest, Bearer, AWS SigV4, NTLMv2, SCRAM-SHA-256, SASL CRAM-MD5/OAUTHBEARER/XOAUTH2/EXTERNAL), connection pooling, rate limiting, multipart form upload, decompression (gzip, deflate, br, zstd), and a C ABI compatibility layer (liburlx-ffi with 60 exported functions).
 
 **Key stats:**
 - CLI flags: 261 long + 46 short; curl has ~250 long flags
-- FFI: 156 CURLOPT, 49 CURLINFO, 41 CURLcode, 57 exported functions (all with catch_unwind)
+- FFI: 158 CURLOPT, 49 CURLINFO, 43 CURLcode, 60 exported functions (all with catch_unwind)
 - 141 Rust source files, ~72,000 lines of code
 - 4 fuzz harnesses, 9 benchmark groups, 20+ feature flags
 
@@ -35,6 +35,10 @@ A functional curl replacement covering HTTP/1.0-1.1, HTTP/2, HTTP/3 (QUIC via qu
 - FFI returns CURLE_OK for ~15 unimplemented options (should return CURLE_NOT_BUILT_IN)
 - curl_easy_pause() returns OK but does nothing
 - Multi API event loop functions are no-ops (tokio architecture mismatch)
+- curl_ws_recv blocks instead of returning CURLE_AGAIN; curl_ws_meta unavailable inside write callbacks ([#140](https://github.com/jonwiggins/urlx/issues/140))
+- `-T .` / `-T -` read stdin up front instead of streaming during the transfer ([#141](https://github.com/jonwiggins/urlx/issues/141))
+- SOCKS4 proxy user name measured/sent percent-encoded, curl uses decoded form ([#142](https://github.com/jonwiggins/urlx/issues/142))
+- Test 339 (--etag-save, chunked + trailer) is flaky — intermittent exit 56, pre-existing on main ([#143](https://github.com/jonwiggins/urlx/issues/143))
 
 ---
 
@@ -109,19 +113,21 @@ Document every skip with a reason. Skips without rationale are not allowed.
 
 ---
 
-## Remaining Work (as of 2026-03-23)
+## Remaining Work (as of 2026-08-08)
 
-Full test suite run: 1,300 pass / 0 fail / 92 skip (tests 1-1400). **100% pass rate of evaluated tests.**
-25 tests permanently excluded (see `tests/excluded-tests.txt`): 19 source/build analysis + 6 libcurl C API.
+Full test suite run (2026-08-08, macOS): 1,304 of 1,304 runnable tests pass (tests 1-1400 after permanent exclusions and environment-dependent skips; the runnable count varies by machine — the count grew from 1,300 as telnet/LDAP features un-skipped tests). WebSocket test 2300 also passes. **100% pass rate of evaluated tests.**
+53 tests permanently excluded (see `tests/excluded-tests.txt`): 19 source/build analysis + 34 libcurl C API (including WebSocket tests 2301-2304 and 2700-2723, which run C `<tool>` programs against `curl_ws_send`/`curl_ws_recv`).
+
+WebSocket (issue #139) is implemented end to end: `ws::connect_stream` retains the upgraded connection, `WsConnection` provides libcurl-fidelity frame I/O, the CLI performs full curl-style ws:// transfers (test 2300 passes — run with `URLX_EXTRA_FEATURES=Debug ./scripts/run-curl-tests.sh 2300`; the Debug feature is opt-in in `scripts/urlx-as-curl` because advertising it globally would un-skip ~35 unrelated debug-env-var tests), and liburlx-ffi exports `curl_ws_send`/`curl_ws_recv`/`curl_ws_meta` with `CURLOPT_CONNECT_ONLY`/`CURLOPT_WS_OPTIONS`. urlx honors `CURL_ENTROPY` and `CURL_WS_FORCE_ZERO_MASK` for deterministic test keys/masks in all builds.
 Tests 24 and 223 previously hung due to HTTP body read blocking ([#96](https://github.com/jonwiggins/urlx/issues/96), [#97](https://github.com/jonwiggins/urlx/issues/97)) — both are now fixed and passing. Test 24 was fixed by propagating `--fail` to the Easy handle (commit 129e242). Test 223 was fixed by `read_exact_body_with_encoding_check()` which detects corrupt deflate encoding via incremental decompression checking without waiting for full Content-Length.
 1 test (625) fails for SFTP multi-upload — tracked in [#45](https://github.com/jonwiggins/urlx/issues/45).
 
-### Permanently Skipped (25 tests)
+### Permanently Skipped (53 tests)
 
 - Source/build analysis tests (19): 745, 971, 1013, 1014, 1022, 1023, 1026, 1027, 1119, 1135, 1139, 1140, 1165, 1167, 1173, 1177, 1185, 1222, 1279
-- libcurl C API tests (6): 547, 548, 555, 560, 590, 694
+- libcurl C API tests (34): 547, 548, 555, 560, 590, 694, plus the WebSocket `<tool>` tests 2301-2304 and 2700-2723 (their scenarios are covered by Rust integration tests in `crates/liburlx/tests/ws_e2e.rs` and liburlx-ffi unit tests)
 
-All permanently excluded via `tests/excluded-tests.txt`. They verify curl's own source code structure or test libcurl's C API — not applicable to urlx.
+All permanently excluded via `tests/excluded-tests.txt`. They verify curl's own source code structure or test libcurl's C API — not applicable to urlx CLI testing.
 
 ### Missing Features
 
@@ -134,7 +140,7 @@ All permanently excluded via `tests/excluded-tests.txt`. They verify curl's own 
 
 ## Test Suite Progress
 
-1,300 of 1,300 evaluated tests pass (100%). The test suite spans tests 1-1400 with 92 skipped and 25 permanently excluded.
+1,304 of 1,304 evaluated tests pass (100%). The test suite spans tests 1-1400 (plus WebSocket test 2300) with 53 permanently excluded; the number of environment-dependent skips varies by machine.
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,37 +10,39 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aead"
-version = "0.5.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
 dependencies = [
- "crypto-common 0.1.7",
- "generic-array 0.14.7",
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
 ]
 
 [[package]]
 name = "aes"
-version = "0.8.4"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
 dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures",
+ "cipher 0.5.2",
+ "cpubits",
+ "cpufeatures 0.3.0",
+ "zeroize",
 ]
 
 [[package]]
 name = "aes-gcm"
-version = "0.10.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+checksum = "fdf011db2e21ce0d575593d749db5554b47fed37aff429e4dc50bc91ac93a028"
 dependencies = [
  "aead",
  "aes",
- "cipher",
+ "cipher 0.5.2",
  "ctr",
  "ghash",
  "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -153,13 +155,13 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "argon2"
-version = "0.5.3"
+version = "0.6.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+checksum = "7af50940b73bf4e16c15c448a2b121c63f2d68e3e54b6a8731673cb4aa0cdff5"
 dependencies = [
  "base64ct",
  "blake2",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "password-hash",
 ]
 
@@ -188,12 +190,6 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base16ct"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
-
-[[package]]
-name = "base16ct"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
@@ -212,13 +208,13 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bcrypt-pbkdf"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aeac2e1fe888769f34f05ac343bbef98b14d1ffb292ab69d4608b3abc86f2a2"
+checksum = "144e573728da132683b9488acd528274c790e07fc06ff81ee29f9d8f8b1041e0"
 dependencies = [
  "blowfish",
  "pbkdf2",
- "sha2 0.10.9",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -267,11 +263,11 @@ dependencies = [
 
 [[package]]
 name = "blake2"
-version = "0.10.6"
+version = "0.11.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+checksum = "061f1a09225e328e1ffbb378d2d49923c0ca5fee19fb5ac1cc9c1e9d52b93690"
 dependencies = [
- "digest 0.10.7",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -290,25 +286,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
  "hybrid-array",
+ "zeroize",
 ]
 
 [[package]]
 name = "block-padding"
-version = "0.3.3"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
 dependencies = [
- "generic-array 0.14.7",
+ "hybrid-array",
 ]
 
 [[package]]
 name = "blowfish"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
+checksum = "62ce3946557b35e71d1bbe07ec385073ce9eda05043f95de134eb578fcf1a298"
 dependencies = [
  "byteorder",
- "cipher",
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -358,11 +355,11 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cbc"
-version = "0.1.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
 dependencies = [
- "cipher",
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -419,13 +416,15 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.9.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
- "cipher",
- "cpufeatures",
+ "cipher 0.5.2",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+ "zeroize",
 ]
 
 [[package]]
@@ -475,7 +474,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.7",
- "inout",
+ "inout 0.1.4",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
+ "zeroize",
 ]
 
 [[package]]
@@ -518,9 +529,9 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "cmov"
-version = "0.5.0-pre.0"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5417da527aa9bf6a1e10a781231effd1edd3ee82f27d5f8529ac9b279babce96"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "colorchoice"
@@ -567,21 +578,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "core-models"
-version = "0.0.4"
+name = "cpubits"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0940496e5c83c54f3b753d5317daec82e8edac71c33aaa1f666d76f518de2444"
-dependencies = [
- "hax-lib",
- "pastey",
- "rand 0.9.2",
-]
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -658,9 +673,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -679,26 +694,18 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.5"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
 dependencies = [
- "generic-array 0.14.7",
- "rand_core 0.6.4",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "crypto-bigint"
-version = "0.7.0-rc.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37387ceb32048ff590f2cbd24d8b05fffe63c3f69a5cfa089d4f722ca4385a19"
-dependencies = [
+ "cpubits",
  "ctutils",
+ "getrandom 0.4.2",
+ "hybrid-array",
  "num-traits",
- "rand_core 0.10.0-rc-3",
+ "rand_core 0.10.1",
  "serdect",
+ "subtle",
  "zeroize",
 ]
 
@@ -714,53 +721,56 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
+ "getrandom 0.4.2",
  "hybrid-array",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
 name = "crypto-primes"
-version = "0.7.0-pre.6"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79c98a281f9441200b24e3151407a629bfbe720399186e50516da939195e482"
+checksum = "3633a51a39c69ebbaa4feaa694bd83d241e4093901c84a0963b19d9bb3f0cf8f"
 dependencies = [
- "crypto-bigint 0.7.0-rc.18",
- "libm",
- "rand_core 0.10.0-rc-3",
+ "crypto-bigint",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
 name = "ctr"
-version = "0.9.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
 dependencies = [
- "cipher",
+ "cipher 0.5.2",
 ]
 
 [[package]]
 name = "ctutils"
-version = "0.3.2"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758e5ed90be3c8abff7f9a6f37ab7f6d8c59c2210d448b81f3f508134aec84e4"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
+ "subtle",
 ]
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.3"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "curve25519-dalek-derive",
- "digest 0.10.7",
+ "digest 0.11.2",
  "fiat-crypto",
+ "rand_core 0.10.1",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -796,23 +806,12 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "const-oid 0.9.6",
- "pem-rfc7468 0.7.0",
- "zeroize",
-]
-
-[[package]]
-name = "der"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
 dependencies = [
  "const-oid 0.10.2",
- "pem-rfc7468 1.0.0",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -831,7 +830,16 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffdd80ce8ce993de27e9f063a444a4d53ce8e8db4c1f00cc03af5ad5a9867a1e"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
+]
+
+[[package]]
+name = "des"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "916a94e407b54f9034d71dd748234cd1e516ced6284009906ae246f177eafe5a"
+dependencies = [
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -854,7 +862,8 @@ checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -870,39 +879,41 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.16.9"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+checksum = "c0681a4fc24c767085329728d8dfba959af91228aa4610cca4f8ce317ba46ae0"
 dependencies = [
- "der 0.7.10",
- "digest 0.10.7",
+ "der",
+ "digest 0.11.2",
  "elliptic-curve",
  "rfc6979",
- "signature 2.2.0",
- "spki 0.7.3",
+ "signature",
+ "spki",
+ "zeroize",
 ]
 
 [[package]]
 name = "ed25519"
-version = "2.2.3"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
 dependencies = [
- "pkcs8 0.10.2",
- "signature 2.2.0",
+ "pkcs8",
+ "signature",
 ]
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core 0.6.4",
+ "rand_core 0.10.1",
  "serde",
- "sha2 0.10.9",
+ "sha2 0.11.0",
+ "signature",
  "subtle",
  "zeroize",
 ]
@@ -915,20 +926,21 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.8"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+checksum = "9d65aa39b3a5c1c9c1b745c9a019234bb7a21b77abcb4f4d266d706e2d577d65"
 dependencies = [
- "base16ct 0.2.0",
- "crypto-bigint 0.5.5",
- "digest 0.10.7",
+ "base16ct",
+ "crypto-bigint",
+ "crypto-common 0.2.2",
+ "digest 0.11.2",
  "ff",
- "generic-array 0.14.7",
  "group",
  "hkdf",
- "pem-rfc7468 0.7.0",
- "pkcs8 0.10.2",
- "rand_core 0.6.4",
+ "hybrid-array",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.10.1",
  "sec1",
  "subtle",
  "zeroize",
@@ -982,19 +994,19 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ff"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+checksum = "a1f686ab92a9fb0eaf188f6c6c87b89490baa6fdb0db4544ba4dc47f7942489f"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.9"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "filetime"
@@ -1167,7 +1179,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
- "zeroize",
 ]
 
 [[package]]
@@ -1215,19 +1226,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
 name = "ghash"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
 dependencies = [
- "opaque-debug",
  "polyval",
 ]
 
@@ -1239,12 +1252,12 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "group"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+checksum = "7fd1a1c7a5206c5b7a3f5a0d7ccd3ff85d0c8f5133d62a02680255b0004af5f4"
 dependencies = [
  "ff",
- "rand_core 0.6.4",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -1322,43 +1335,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
-name = "hax-lib"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d9ba66d1739c68e0219b2b2238b5c4145f491ebf181b9c6ab561a19352ae86"
-dependencies = [
- "hax-lib-macros",
- "num-bigint",
- "num-traits",
-]
-
-[[package]]
-name = "hax-lib-macros"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ba777a231a58d1bce1d68313fa6b6afcc7966adef23d60f45b8a2b9b688bf1"
-dependencies = [
- "hax-lib-macros-types",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "hax-lib-macros-types"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "867e19177d7425140b417cd27c2e05320e727ee682e98368f88b7194e80ad515"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde",
- "serde_json",
- "uuid",
-]
-
-[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1384,9 +1360,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hex-literal"
-version = "0.4.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
 
 [[package]]
 name = "hickory-proto"
@@ -1443,11 +1419,11 @@ dependencies = [
 
 [[package]]
 name = "hkdf"
-version = "0.12.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
 dependencies = [
- "hmac",
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -1457,6 +1433,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -1506,11 +1491,14 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.8"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8655f91cd07f2b9d0c24137bd650fe69617773435ee5ec83022377777ce65ef1"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
+ "ctutils",
+ "subtle",
  "typenum",
+ "zeroize",
 ]
 
 [[package]]
@@ -1699,39 +1687,29 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "block-padding",
  "generic-array 0.14.7",
 ]
 
 [[package]]
-name = "internal-russh-forked-ssh-key"
-version = "0.6.16+upstream-0.6.7"
+name = "inout"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe44f2bbd99fcb302e246e2d6bcf51aeda346d02a365f80296a07a8c711b6da6"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
- "argon2",
- "bcrypt-pbkdf",
- "digest 0.11.2",
- "ecdsa",
- "ed25519-dalek",
- "hex",
- "hmac",
- "num-bigint-dig",
- "p256",
- "p384",
- "p521",
- "rand_core 0.6.4",
- "rsa",
- "sec1",
- "sha1 0.10.6",
- "sha1 0.11.0-rc.5",
- "sha2 0.10.9",
- "signature 2.2.0",
- "signature 3.0.0-rc.6",
- "ssh-cipher",
- "ssh-encoding",
- "subtle",
- "zeroize",
+ "block-padding",
+ "hybrid-array",
+]
+
+[[package]]
+name = "internal-russh-num-bigint"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae8e22120c32fb4d19ec55fba35015f57095cd95a2e3b732e44457f5915b2ee8"
+dependencies = [
+ "num-integer",
+ "num-traits",
+ "rand 0.10.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1805,13 +1783,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffd9697dc4a9a62e2da93389f34400b77a28f0287711263cabb203b3ccb9c0e4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "kem"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01737161ba802849cfd486b5bd209d38ba4943494c249a8126005170c7621edd"
+dependencies = [
+ "crypto-common 0.2.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin",
-]
 
 [[package]]
 name = "leb128fmt"
@@ -1821,75 +1816,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
-
-[[package]]
-name = "libcrux-intrinsics"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc9ee7ef66569dd7516454fe26de4e401c0c62073929803486b96744594b9632"
-dependencies = [
- "core-models",
- "hax-lib",
-]
-
-[[package]]
-name = "libcrux-ml-kem"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb6a88086bf11bd2ec90926c749c4a427f2e59841437dbdede8cde8a96334ab"
-dependencies = [
- "hax-lib",
- "libcrux-intrinsics",
- "libcrux-platform",
- "libcrux-secrets",
- "libcrux-sha3",
- "libcrux-traits",
- "rand 0.9.2",
- "tls_codec",
-]
-
-[[package]]
-name = "libcrux-platform"
-version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db82d058aa76ea315a3b2092f69dfbd67ddb0e462038a206e1dcd73f058c0778"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "libcrux-secrets"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4dbbf6bc9f2bc0f20dc3bea3e5c99adff3bdccf6d2a40488963da69e2ec307"
-dependencies = [
- "hax-lib",
-]
-
-[[package]]
-name = "libcrux-sha3"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2400bec764d1c75b8a496d5747cffe32f1fb864a12577f0aca2f55a92021c962"
-dependencies = [
- "hax-lib",
- "libcrux-intrinsics",
- "libcrux-platform",
- "libcrux-traits",
-]
-
-[[package]]
-name = "libcrux-traits"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9adfd58e79d860f6b9e40e35127bfae9e5bd3ade33201d1347459011a2add034"
-dependencies = [
- "libcrux-secrets",
- "rand 0.9.2",
-]
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libgssapi"
@@ -1924,12 +1853,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libm"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
 name = "libredox"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1948,16 +1871,16 @@ dependencies = [
  "base64",
  "brotli",
  "bytes",
- "cipher",
+ "cipher 0.4.4",
  "criterion",
- "des",
+ "des 0.8.1",
  "flate2",
  "h2",
  "h3",
  "h3-quinn",
  "hex",
  "hickory-resolver",
- "hmac",
+ "hmac 0.12.1",
  "http",
  "http-body-util",
  "httparse",
@@ -2051,9 +1974,9 @@ dependencies = [
 
 [[package]]
 name = "md5"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+checksum = "7ebb8d8732c6a6df3d8f032a82911cfc747e00efb95cc46e8d0acd5b5b88570c"
 
 [[package]]
 name = "memchr"
@@ -2089,6 +2012,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "ml-kem"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e15f3e5b957493873e396a66914e83e616b6afe335cdef7efe5c6e1216aba66"
+dependencies = [
+ "hybrid-array",
+ "kem",
+ "module-lattice",
+ "pkcs8",
+ "rand_core 0.10.1",
+ "sha3 0.11.0",
+]
+
+[[package]]
+name = "module-lattice"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c61b87c9683ab7cb1c6871d261ad5479b6b10ceb52c4352aaca3b5d35a8febe"
+dependencies = [
+ "ctutils",
+ "hybrid-array",
+ "num-traits",
+]
+
+[[package]]
 name = "moka"
 version = "0.12.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2107,9 +2055,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.29.0"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -2135,23 +2083,6 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
- "rand 0.8.5",
-]
-
-[[package]]
-name = "num-bigint-dig"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
-dependencies = [
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand 0.8.5",
- "serde",
- "smallvec",
 ]
 
 [[package]]
@@ -2166,17 +2097,6 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
  "num-traits",
 ]
 
@@ -2222,12 +2142,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
 name = "openssl"
 version = "0.10.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2267,40 +2181,43 @@ dependencies = [
 
 [[package]]
 name = "p256"
-version = "0.13.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+checksum = "d2c9239b2dbc807adbbe147e8cf72ea7450c3a0aabe62cb8e75ff4ec22e1f72a"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
+ "primefield",
  "primeorder",
- "sha2 0.10.9",
+ "sha2 0.11.0",
 ]
 
 [[package]]
 name = "p384"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+checksum = "d17b851e6b3e378ab4ecb07fa2ed23f4d15f075735f8fec9fa1e7bdce5f8301f"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
+ "fiat-crypto",
+ "primefield",
  "primeorder",
- "sha2 0.10.9",
+ "sha2 0.11.0",
 ]
 
 [[package]]
 name = "p521"
-version = "0.13.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
+checksum = "4ad64cc32c2dc466317c12ee5853e61f159f9eab1fe7efade0395dc2e7b43449"
 dependencies = [
- "base16ct 0.2.0",
+ "base16ct",
  "ecdsa",
  "elliptic-curve",
+ "primefield",
  "primeorder",
- "rand_core 0.6.4",
- "sha2 0.10.9",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -2347,29 +2264,21 @@ dependencies = [
 
 [[package]]
 name = "password-hash"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+checksum = "aab41826031698d6ffcd9cff78ef56ef998e39dc7e5067cdfebe373842d4723b"
 dependencies = [
- "base64ct",
- "rand_core 0.6.4",
- "subtle",
+ "phc",
 ]
 
 [[package]]
-name = "pastey"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
-
-[[package]]
 name = "pbkdf2"
-version = "0.12.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
 dependencies = [
- "digest 0.10.7",
- "hmac",
+ "digest 0.11.2",
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -2380,15 +2289,6 @@ checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
  "base64",
  "serde_core",
-]
-
-[[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
 ]
 
 [[package]]
@@ -2405,6 +2305,16 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "phc"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44dc769b75f93afdddd8c7fa12d685292ddeff1e66f7f0f3a234cf1818afe892"
+dependencies = [
+ "base64ct",
+ "ctutils",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -2424,45 +2334,37 @@ version = "0.8.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "986d2e952779af96ea048f160fd9194e1751b4faea78bcf3ceb456efe008088e"
 dependencies = [
- "der 0.8.0",
- "spki 0.8.0-rc.4",
+ "der",
+ "spki",
 ]
 
 [[package]]
 name = "pkcs5"
-version = "0.7.1"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
+checksum = "63d440a804ec8d6fafbb6b84471e013286658d373248927692ab3366686220ca"
 dependencies = [
  "aes",
+ "aes-gcm",
  "cbc",
- "der 0.7.10",
+ "der",
  "pbkdf2",
+ "rand_core 0.10.1",
  "scrypt",
- "sha2 0.10.9",
- "spki 0.7.3",
+ "sha2 0.11.0",
+ "spki",
 ]
 
 [[package]]
 name = "pkcs8"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
 dependencies = [
- "der 0.7.10",
+ "der",
  "pkcs5",
- "rand_core 0.6.4",
- "spki 0.7.3",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.11.0-rc.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12922b6296c06eb741b02d7b5161e3aaa22864af38dfa025a1a3ba3f68c84577"
-dependencies = [
- "der 0.8.0",
- "spki 0.8.0-rc.4",
+ "rand_core 0.10.1",
+ "spki",
 ]
 
 [[package]]
@@ -2507,24 +2409,23 @@ dependencies = [
 
 [[package]]
 name = "poly1305"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+checksum = "6e2d0073b297041425c7c3df6eb4792d598a15323fe63346852b092eca02904c"
 dependencies = [
- "cpufeatures",
- "opaque-debug",
+ "cpufeatures 0.3.0",
  "universal-hash",
+ "zeroize",
 ]
 
 [[package]]
 name = "polyval"
-version = "0.6.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+checksum = "f0fa31d631f2b2cb2a544d0aa321ce847a94764d701ca2becc411138b93d49cd"
 dependencies = [
- "cfg-if",
- "cpufeatures",
- "opaque-debug",
+ "cpubits",
+ "cpufeatures 0.3.0",
  "universal-hash",
 ]
 
@@ -2569,34 +2470,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "primeorder"
-version = "0.13.6"
+name = "primefield"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+checksum = "c555a6e4eb7d4e158fcb028c835c3b8642206ddc279b5c6b202ef9a8bdb592f4"
+dependencies = [
+ "crypto-bigint",
+ "crypto-common 0.2.2",
+ "ff",
+ "rand_core 0.10.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c9f42978c78a00e3d68f69fc03e57a234debae69da4020a4fb588fcdcd07b06"
 dependencies = [
  "elliptic-curve",
-]
-
-[[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn",
+ "once_cell",
+ "primefield",
+ "serdect",
+ "wnaf",
 ]
 
 [[package]]
@@ -2747,6 +2644,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2786,9 +2694,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0-rc-3"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66ee92bc15280519ef199a274fe0cafff4245d31bc39aaa31c011ad56cb1f05"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xorshift"
@@ -2887,12 +2795,12 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "rfc6979"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+checksum = "b4a459cddafb3fe76b31fd8f1108007566c40301feb64dc7b54656eb7388172b"
 dependencies = [
- "hmac",
- "subtle",
+ "crypto-bigint",
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -2911,28 +2819,28 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.10.0-rc.12"
+version = "0.10.0-rc.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9a2b1eacbc34fbaf77f6f1db1385518446008d49b9f9f59dc9d1340fce4ca9e"
+checksum = "30b2aa4ba0d89f73d1e332df05be0eeab8840351c36ca5654341dfdb57bb3caf"
 dependencies = [
  "const-oid 0.10.2",
- "crypto-bigint 0.7.0-rc.18",
+ "crypto-bigint",
  "crypto-primes",
  "digest 0.11.2",
  "pkcs1",
- "pkcs8 0.11.0-rc.11",
- "rand_core 0.10.0-rc-3",
- "sha2 0.11.0-rc.5",
- "signature 3.0.0-rc.6",
- "spki 0.8.0-rc.4",
+ "pkcs8",
+ "rand_core 0.10.1",
+ "sha2 0.11.0",
+ "signature",
+ "spki",
  "zeroize",
 ]
 
 [[package]]
 name = "russh"
-version = "0.58.0"
+version = "0.62.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30f6ce4f5d5105b934cfb4b8b3028aab4d5dcdff863cb8dda9edd06d39b8c4e8"
+checksum = "da7c230e0ed9cbeb92fbad6c8848985d6df2a1464c0dc247a021abd666e9005e"
 dependencies = [
  "aes",
  "bitflags",
@@ -2940,26 +2848,31 @@ dependencies = [
  "byteorder",
  "bytes",
  "cbc",
+ "cipher 0.5.2",
+ "crypto-bigint",
  "ctr",
  "curve25519-dalek",
  "data-encoding",
  "delegate",
- "der 0.7.10",
- "digest 0.10.7",
+ "der",
+ "digest 0.11.2",
  "ecdsa",
  "ed25519-dalek",
  "elliptic-curve",
  "enum_dispatch",
  "futures",
  "generic-array 1.3.5",
- "getrandom 0.2.17",
+ "getrandom 0.4.2",
+ "ghash",
  "hex-literal",
- "hmac",
- "inout",
- "internal-russh-forked-ssh-key",
- "libcrux-ml-kem",
+ "hmac 0.13.0",
+ "inout 0.2.2",
+ "internal-russh-num-bigint",
+ "keccak",
  "log",
  "md5",
+ "ml-kem",
+ "module-lattice",
  "num-bigint",
  "p256",
  "p384",
@@ -2968,36 +2881,42 @@ dependencies = [
  "pbkdf2",
  "pkcs1",
  "pkcs5",
- "pkcs8 0.10.2",
- "rand 0.9.2",
- "rand_core 0.10.0-rc-3",
+ "pkcs8",
+ "polyval",
+ "rand 0.10.2",
+ "rand_core 0.10.1",
  "ring",
  "rsa",
  "russh-cryptovec",
  "russh-util",
+ "salsa20",
+ "scrypt",
  "sec1",
- "sha1 0.10.6",
- "sha2 0.10.9",
- "signature 2.2.0",
- "spki 0.7.3",
+ "sha1",
+ "sha2 0.11.0",
+ "sha3 0.12.0",
+ "signature",
+ "spki",
  "ssh-encoding",
+ "ssh-key",
  "subtle",
  "thiserror 2.0.18",
  "tokio",
  "typenum",
+ "universal-hash",
  "zeroize",
 ]
 
 [[package]]
 name = "russh-cryptovec"
-version = "0.58.0"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc109749696a6853cf2c3fba3537635264f3519a78a9f43c6b08c91edc024384"
+checksum = "3aec6cb630dbe85d72ffd7bcd95f07e1bd69f9f270ee8adfa1afe443a6331438"
 dependencies = [
  "log",
  "nix",
  "ssh-encoding",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3084,9 +3003,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3113,11 +3032,12 @@ dependencies = [
 
 [[package]]
 name = "salsa20"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+checksum = "2f874456e72520ff1375a06c588eaf074b0f01f9e9e1aada45bd9b7954a6e42c"
 dependencies = [
- "cipher",
+ "cfg-if",
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -3137,25 +3057,26 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scrypt"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+checksum = "d87af57419b594aa23fa95f09f0e06d80d84ba01c26148c43844cad6ff4485f0"
 dependencies = [
+ "cfg-if",
  "pbkdf2",
  "salsa20",
- "sha2 0.10.9",
+ "sha2 0.11.0",
 ]
 
 [[package]]
 name = "sec1"
-version = "0.7.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
 dependencies = [
- "base16ct 0.2.0",
- "der 0.7.10",
- "generic-array 0.14.7",
- "pkcs8 0.10.2",
+ "base16ct",
+ "ctutils",
+ "der",
+ "hybrid-array",
  "subtle",
  "zeroize",
 ]
@@ -3230,29 +3151,18 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9af4a3e75ebd5599b30d4de5768e00b5095d518a79fefc3ecbaf77e665d1ec06"
 dependencies = [
- "base16ct 1.0.0",
+ "base16ct",
  "serde",
 ]
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha1"
-version = "0.11.0-rc.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b167252f3c126be0d8926639c4c4706950f01445900c4b3db0fd7e89fcb750a"
-dependencies = [
- "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "digest 0.11.2",
 ]
 
@@ -3263,19 +3173,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
 [[package]]
 name = "sha2"
-version = "0.11.0-rc.5"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c5f3b1e2dc8aad28310d8410bd4d7e180eca65fca176c52ab00d364475d0024"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "digest 0.11.2",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.2",
+ "keccak",
+]
+
+[[package]]
+name = "sha3"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc9bad02c26382724b2d2692c6f179285e4b54eeecd7968f52a50059c3c11759"
+dependencies = [
+ "digest 0.11.2",
+ "keccak",
+ "sponge-cursor",
 ]
 
 [[package]]
@@ -3296,22 +3227,12 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-dependencies = [
- "digest 0.10.7",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "signature"
-version = "3.0.0-rc.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a96996ccff7dfa16f052bd995b4cecc72af22c35138738dc029f0ead6608d"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 dependencies = [
  "digest 0.11.2",
- "rand_core 0.10.0-rc-3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3353,58 +3274,78 @@ dependencies = [
 ]
 
 [[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
 name = "spki"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
 dependencies = [
  "base64ct",
- "der 0.7.10",
+ "der",
 ]
 
 [[package]]
-name = "spki"
-version = "0.8.0-rc.4"
+name = "sponge-cursor"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8baeff88f34ed0691978ec34440140e1572b68c7dd4a495fd14a3dc1944daa80"
-dependencies = [
- "base64ct",
- "der 0.8.0",
-]
+checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
 
 [[package]]
 name = "ssh-cipher"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caac132742f0d33c3af65bfcde7f6aa8f62f0e991d80db99149eb9d44708784f"
+checksum = "d801accda99469cde6d73da741422610fdf6508a72d9a69d1b55cb241c720597"
 dependencies = [
+ "aead",
  "aes",
  "aes-gcm",
- "cbc",
  "chacha20",
- "cipher",
- "ctr",
+ "cipher 0.5.2",
+ "ctutils",
+ "des 0.9.0",
  "poly1305",
  "ssh-encoding",
- "subtle",
+ "zeroize",
 ]
 
 [[package]]
 name = "ssh-encoding"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb9242b9ef4108a78e8cd1a2c98e193ef372437f8c22be363075233321dd4a15"
+checksum = "7b54d0ed0498daf3f78d82e00e28c8eec9d75a067c4cfbcc7a0f7d0f4077749e"
 dependencies = [
  "base64ct",
  "bytes",
- "pem-rfc7468 0.7.0",
- "sha2 0.10.9",
+ "crypto-bigint",
+ "ctutils",
+ "digest 0.11.2",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "ssh-key"
+version = "0.7.0-rc.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9a32fae177b74a22aa9c5b01bf7e68b33545be32d9e381e248058d2adc15ce3"
+dependencies = [
+ "argon2",
+ "bcrypt-pbkdf",
+ "ctutils",
+ "ed25519-dalek",
+ "hex",
+ "hmac 0.13.0",
+ "p256",
+ "p384",
+ "p521",
+ "rand_core 0.10.1",
+ "rsa",
+ "sec1",
+ "sha1",
+ "sha2 0.11.0",
+ "signature",
+ "ssh-cipher",
+ "ssh-encoding",
+ "zeroize",
 ]
 
 [[package]]
@@ -3570,27 +3511,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
-name = "tls_codec"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
-dependencies = [
- "tls_codec_derive",
- "zeroize",
-]
-
-[[package]]
-name = "tls_codec_derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3714,9 +3634,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unarray"
@@ -3738,12 +3658,12 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "universal-hash"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
 dependencies = [
- "crypto-common 0.1.7",
- "subtle",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -4364,6 +4284,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "wnaf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1"
+dependencies = [
+ "ff",
+ "group",
+ "hybrid-array",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4444,23 +4375,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/crates/liburlx-ffi/include/urlx.h
+++ b/crates/liburlx-ffi/include/urlx.h
@@ -72,6 +72,53 @@ typedef void CURL;
 #define CURLPAUSE_CONT 0
 
 /**
+ * `CURLWS_TEXT` — text frame payload.
+ */
+#define CURLWS_TEXT (1 << 0)
+
+/**
+ * `CURLWS_BINARY` — binary frame payload.
+ */
+#define CURLWS_BINARY (1 << 1)
+
+/**
+ * `CURLWS_CONT` — this is a fragment of a larger message (not the final fragment).
+ */
+#define CURLWS_CONT (1 << 2)
+
+/**
+ * `CURLWS_CLOSE` — close frame.
+ */
+#define CURLWS_CLOSE (1 << 3)
+
+/**
+ * `CURLWS_PING` — ping frame.
+ */
+#define CURLWS_PING (1 << 4)
+
+/**
+ * `CURLWS_OFFSET` — the frame length is declared up front (send only).
+ */
+#define CURLWS_OFFSET (1 << 5)
+
+/**
+ * `CURLWS_PONG` — pong frame.
+ */
+#define CURLWS_PONG (1 << 6)
+
+/**
+ * `CURLWS_RAW_MODE` — `CURLOPT_WS_OPTIONS` bit: deliver and accept raw frame
+ * bytes instead of decoded payloads.
+ */
+#define CURLWS_RAW_MODE (1 << 0)
+
+/**
+ * `CURLWS_NOAUTOPONG` — `CURLOPT_WS_OPTIONS` bit: do not automatically reply
+ * to PING frames with a PONG.
+ */
+#define CURLWS_NOAUTOPONG (1 << 1)
+
+/**
  * `CURLINFO` — info codes for `curl_easy_getinfo`.
  */
 typedef enum CURLINFO {
@@ -179,6 +226,7 @@ typedef enum CURLcode {
     CURLE_UNSUPPORTED_PROTOCOL = 1,
     CURLE_FAILED_INIT = 2,
     CURLE_URL_MALFORMAT = 3,
+    CURLE_NOT_BUILT_IN = 4,
     CURLE_COULDNT_RESOLVE_PROXY = 5,
     CURLE_COULDNT_RESOLVE_HOST = 6,
     CURLE_COULDNT_CONNECT = 7,
@@ -208,6 +256,7 @@ typedef enum CURLcode {
     CURLE_AGAIN = 81,
     CURLE_AUTH_ERROR = 94,
     CURLE_UNRECOVERABLE_POLL = 99,
+    CURLE_TOO_LARGE = 100,
     CURLE_FTP_COULDNT_RETR_FILE = 19,
     CURLE_UPLOAD_FAILED = 25,
     CURLE_LDAP_CANNOT_BIND = 38,
@@ -322,6 +371,8 @@ typedef enum CURLoption {
     CURLOPT_SOCKS5_AUTH = 267,
     CURLOPT_SSL_VERIFYSTATUS = 232,
     CURLOPT_HTTP09_ALLOWED = 285,
+    CURLOPT_CONNECT_ONLY = 141,
+    CURLOPT_WS_OPTIONS = 320,
     CURLOPT_POSTFIELDSIZE_LARGE = 30120,
     CURLOPT_INFILESIZE_LARGE = 30115,
     CURLOPT_MAXFILESIZE_LARGE = 30117,
@@ -429,6 +480,34 @@ typedef struct CurlVersionInfo {
      */
     const char *const *protocols;
 } CurlVersionInfo;
+
+/**
+ * WebSocket frame metadata returned by `curl_ws_recv` and `curl_ws_meta`.
+ *
+ * Equivalent to libcurl's `struct curl_ws_frame`.
+ */
+typedef struct curl_ws_frame {
+    /**
+     * Age of this struct (always zero).
+     */
+    int age;
+    /**
+     * Frame-type flags (`CURLWS_*` bits).
+     */
+    int flags;
+    /**
+     * Offset of this chunk within the frame payload (`curl_off_t`).
+     */
+    int64_t offset;
+    /**
+     * Number of payload bytes still pending after this chunk (`curl_off_t`).
+     */
+    int64_t bytesleft;
+    /**
+     * Number of bytes in the current data chunk.
+     */
+    uintptr_t len;
+} curl_ws_frame;
 
 #ifdef __cplusplus
 extern "C" {
@@ -1044,6 +1123,67 @@ enum CURLMcode curl_multi_socket_action(void *multi,
  * `multi_handle` must be a valid pointer from `curl_multi_init`.
  */
  enum CURLMcode curl_multi_assign(void *_multi_handle, long _sockfd, void *_sockp) ;
+
+/**
+ * `curl_ws_send` — send a WebSocket frame over a connect-only connection.
+ *
+ * Use after a successful `curl_easy_perform` with `CURLOPT_CONNECT_ONLY`
+ * set to 2. `flags` takes `CURLWS_*` bits describing the frame type.
+ *
+ * `fragsize` (the `CURLWS_OFFSET` streaming mode) is not supported: any
+ * non-zero value returns `CURLE_BAD_FUNCTION_ARGUMENT`.
+ *
+ * # Safety
+ *
+ * `curl` must be a valid pointer from `curl_easy_init`. `buffer` must point
+ * to at least `buflen` readable bytes (it may be null only when `buflen` is
+ * zero). `sent` may be null or must be a valid pointer to a `size_t`.
+ */
+
+enum CURLcode curl_ws_send(void *curl,
+                           const void *buffer,
+                           uintptr_t buflen,
+                           uintptr_t *sent,
+                           int64_t fragsize,
+                           unsigned int flags)
+;
+
+/**
+ * `curl_ws_recv` — receive WebSocket payload data from a connect-only
+ * connection.
+ *
+ * Use after a successful `curl_easy_perform` with `CURLOPT_CONNECT_ONLY`
+ * set to 2. On success, `*recv` holds the number of bytes written to
+ * `buffer` and `*metap` (when non-null) points to frame metadata owned by
+ * the handle, valid until the next `curl_ws_recv` call or handle cleanup.
+ * Returns `CURLE_GOT_NOTHING` when the server closed the connection.
+ *
+ * # Safety
+ *
+ * `curl` must be a valid pointer from `curl_easy_init`. `buffer` must point
+ * to at least `buflen` writable bytes (it may be null only when `buflen` is
+ * zero). `recv` must be a valid pointer to a `size_t`. `metap` may be null.
+ */
+
+enum CURLcode curl_ws_recv(void *curl,
+                           void *buffer,
+                           uintptr_t buflen,
+                           uintptr_t *recv,
+                           const struct curl_ws_frame **metap)
+;
+
+/**
+ * `curl_ws_meta` — return frame metadata for the most recent `curl_ws_recv`.
+ *
+ * Returns null if `curl` is null or no `curl_ws_recv` has completed on this
+ * handle. The returned pointer is owned by the handle and stays valid until
+ * the next `curl_ws_recv` call or handle cleanup.
+ *
+ * # Safety
+ *
+ * `curl` must be a valid pointer from `curl_easy_init`, or null.
+ */
+ const struct curl_ws_frame *curl_ws_meta(void *curl) ;
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/crates/liburlx-ffi/src/lib.rs
+++ b/crates/liburlx-ffi/src/lib.rs
@@ -23,10 +23,10 @@
 //!
 //! ## Coverage
 //!
-//! - **156** `CURLOPT` options
+//! - **158** `CURLOPT` options
 //! - **49** `CURLINFO` queries
-//! - **41** `CURLcode` error codes
-//! - **57** exported C functions (all wrapped in `catch_unwind`)
+//! - **43** `CURLcode` error codes
+//! - **60** exported C functions (all wrapped in `catch_unwind`)
 //!
 //! # Safety Invariants
 //!
@@ -66,7 +66,7 @@
 
 #![warn(missing_docs)]
 
-use std::ffi::{c_char, c_long, c_short, c_void, CStr};
+use std::ffi::{c_char, c_int, c_long, c_short, c_uint, c_void, CStr};
 use std::ptr;
 
 // ───────────────────────── CURLcode ─────────────────────────
@@ -80,6 +80,7 @@ pub enum CURLcode {
     CURLE_UNSUPPORTED_PROTOCOL = 1,
     CURLE_FAILED_INIT = 2,
     CURLE_URL_MALFORMAT = 3,
+    CURLE_NOT_BUILT_IN = 4,
     CURLE_COULDNT_RESOLVE_PROXY = 5,
     CURLE_COULDNT_RESOLVE_HOST = 6,
     CURLE_COULDNT_CONNECT = 7,
@@ -109,6 +110,7 @@ pub enum CURLcode {
     CURLE_AGAIN = 81,
     CURLE_AUTH_ERROR = 94,
     CURLE_UNRECOVERABLE_POLL = 99,
+    CURLE_TOO_LARGE = 100,
     CURLE_FTP_COULDNT_RETR_FILE = 19,
     CURLE_UPLOAD_FAILED = 25,
     CURLE_LDAP_CANNOT_BIND = 38,
@@ -229,6 +231,8 @@ pub enum CURLoption {
     CURLOPT_SOCKS5_AUTH = 267,
     CURLOPT_SSL_VERIFYSTATUS = 232,
     CURLOPT_HTTP09_ALLOWED = 285,
+    CURLOPT_CONNECT_ONLY = 141,
+    CURLOPT_WS_OPTIONS = 320,
 
     // Off_t options (CURLOPTTYPE_OFF_T = 30000)
     CURLOPT_POSTFIELDSIZE_LARGE = 30120,
@@ -1311,6 +1315,12 @@ struct EasyHandle {
     rtsp_session_id_cstr: Option<std::ffi::CString>,
     /// When true, include HTTP headers in the body output (`CURLOPT_HEADER`).
     include_headers: bool,
+    /// Metadata of the most recent `curl_ws_recv` chunk. `curl_ws_recv` and
+    /// `curl_ws_meta` hand out a pointer into this field, so it must live as
+    /// long as the handle.
+    ws_frame: curl_ws_frame,
+    /// Whether `ws_frame` holds metadata from a completed `curl_ws_recv`.
+    ws_frame_valid: bool,
 }
 
 // SAFETY: The raw pointers in EasyHandle (write_data, header_data) are
@@ -1354,6 +1364,8 @@ pub extern "C" fn curl_easy_init() -> *mut c_void {
             interleave_data: ptr::null_mut(),
             rtsp_session_id_cstr: None,
             include_headers: false,
+            ws_frame: curl_ws_frame::EMPTY,
+            ws_frame_valid: false,
         });
         Box::into_raw(handle).cast::<c_void>()
     }));
@@ -1418,6 +1430,8 @@ pub unsafe extern "C" fn curl_easy_duphandle(handle: *mut c_void) -> *mut c_void
             interleave_data: h.interleave_data,
             rtsp_session_id_cstr: None,
             include_headers: h.include_headers,
+            ws_frame: curl_ws_frame::EMPTY,
+            ws_frame_valid: false,
         });
         Box::into_raw(dup).cast::<c_void>()
     }));
@@ -1464,6 +1478,8 @@ pub unsafe extern "C" fn curl_easy_reset(handle: *mut c_void) {
         h.interleave_data = ptr::null_mut();
         h.rtsp_session_id_cstr = None;
         h.include_headers = false;
+        h.ws_frame = curl_ws_frame::EMPTY;
+        h.ws_frame_valid = false;
     }));
 }
 
@@ -2046,6 +2062,25 @@ pub unsafe extern "C" fn curl_easy_setopt(
             // CURLOPT_PROXY_SSL_VERIFYPEER = 248
             248 => {
                 h.easy.proxy_ssl_verify_peer(value as c_long != 0);
+                CURLcode::CURLE_OK
+            }
+
+            // CURLOPT_CONNECT_ONLY = 141
+            141 => {
+                // libcurl rejects values outside 0..=2 at setopt time.
+                let mode = value as c_long;
+                if !(0..=2).contains(&mode) {
+                    return CURLcode::CURLE_BAD_FUNCTION_ARGUMENT;
+                }
+                #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                h.easy.set_connect_only(mode as u32);
+                CURLcode::CURLE_OK
+            }
+
+            // CURLOPT_WS_OPTIONS = 320
+            320 => {
+                #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                h.easy.set_ws_options(value as u32);
                 CURLcode::CURLE_OK
             }
 
@@ -3663,6 +3698,9 @@ pub extern "C" fn curl_easy_strerror(code: CURLcode) -> *const c_char {
             CURLcode::CURLE_UNSUPPORTED_PROTOCOL => c"Unsupported protocol",
             CURLcode::CURLE_FAILED_INIT => c"Failed initialization",
             CURLcode::CURLE_URL_MALFORMAT => c"URL using bad/illegal format or missing URL",
+            CURLcode::CURLE_NOT_BUILT_IN => {
+                c"A requested feature, protocol or option was not found built-in in this libcurl due to a build-time decision."
+            }
             CURLcode::CURLE_COULDNT_RESOLVE_PROXY => c"Couldn't resolve proxy name",
             CURLcode::CURLE_COULDNT_RESOLVE_HOST => c"Couldn't resolve host name",
             CURLcode::CURLE_COULDNT_CONNECT => c"Failed to connect to host or proxy",
@@ -3694,6 +3732,7 @@ pub extern "C" fn curl_easy_strerror(code: CURLcode) -> *const c_char {
             CURLcode::CURLE_AGAIN => c"Socket is not ready for send/recv",
             CURLcode::CURLE_AUTH_ERROR => c"An authentication function returned an error",
             CURLcode::CURLE_UNRECOVERABLE_POLL => c"Unrecoverable error in select/poll",
+            CURLcode::CURLE_TOO_LARGE => c"A value or data field grew larger than allowed",
             CURLcode::CURLE_FTP_COULDNT_RETR_FILE => c"FTP: couldn't retrieve (RETR failed)",
             CURLcode::CURLE_UPLOAD_FAILED => c"Upload failed",
             CURLcode::CURLE_LDAP_CANNOT_BIND => c"LDAP bind operation failed",
@@ -4895,6 +4934,223 @@ pub extern "C" fn curl_multi_assign(
     result.unwrap_or(CURLMcode::CURLM_INTERNAL_ERROR)
 }
 
+// ───────────────────────── WebSocket API ─────────────────────────
+
+/// `CURLWS_TEXT` — text frame payload.
+pub const CURLWS_TEXT: c_int = 1 << 0;
+/// `CURLWS_BINARY` — binary frame payload.
+pub const CURLWS_BINARY: c_int = 1 << 1;
+/// `CURLWS_CONT` — this is a fragment of a larger message (not the final fragment).
+pub const CURLWS_CONT: c_int = 1 << 2;
+/// `CURLWS_CLOSE` — close frame.
+pub const CURLWS_CLOSE: c_int = 1 << 3;
+/// `CURLWS_PING` — ping frame.
+pub const CURLWS_PING: c_int = 1 << 4;
+/// `CURLWS_OFFSET` — the frame length is declared up front (send only).
+pub const CURLWS_OFFSET: c_int = 1 << 5;
+/// `CURLWS_PONG` — pong frame.
+pub const CURLWS_PONG: c_int = 1 << 6;
+
+/// `CURLWS_RAW_MODE` — `CURLOPT_WS_OPTIONS` bit: deliver and accept raw frame
+/// bytes instead of decoded payloads.
+pub const CURLWS_RAW_MODE: c_long = 1 << 0;
+/// `CURLWS_NOAUTOPONG` — `CURLOPT_WS_OPTIONS` bit: do not automatically reply
+/// to PING frames with a PONG.
+pub const CURLWS_NOAUTOPONG: c_long = 1 << 1;
+
+/// WebSocket frame metadata returned by `curl_ws_recv` and `curl_ws_meta`.
+///
+/// Equivalent to libcurl's `struct curl_ws_frame`.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+#[allow(non_camel_case_types)]
+pub struct curl_ws_frame {
+    /// Age of this struct (always zero).
+    pub age: c_int,
+    /// Frame-type flags (`CURLWS_*` bits).
+    pub flags: c_int,
+    /// Offset of this chunk within the frame payload (`curl_off_t`).
+    pub offset: i64,
+    /// Number of payload bytes still pending after this chunk (`curl_off_t`).
+    pub bytesleft: i64,
+    /// Number of bytes in the current data chunk.
+    pub len: usize,
+}
+
+impl curl_ws_frame {
+    /// A zeroed frame descriptor (no receive has happened yet).
+    const EMPTY: Self = Self { age: 0, flags: 0, offset: 0, bytesleft: 0, len: 0 };
+}
+
+/// `curl_ws_send` — send a WebSocket frame over a connect-only connection.
+///
+/// Use after a successful `curl_easy_perform` with `CURLOPT_CONNECT_ONLY`
+/// set to 2. `flags` takes `CURLWS_*` bits describing the frame type.
+///
+/// `fragsize` (the `CURLWS_OFFSET` streaming mode) is not supported: any
+/// non-zero value returns `CURLE_BAD_FUNCTION_ARGUMENT`.
+///
+/// # Safety
+///
+/// `curl` must be a valid pointer from `curl_easy_init`. `buffer` must point
+/// to at least `buflen` readable bytes (it may be null only when `buflen` is
+/// zero). `sent` may be null or must be a valid pointer to a `size_t`.
+#[no_mangle]
+pub unsafe extern "C" fn curl_ws_send(
+    curl: *mut c_void,
+    buffer: *const c_void,
+    buflen: usize,
+    sent: *mut usize,
+    fragsize: i64,
+    flags: c_uint,
+) -> CURLcode {
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        if curl.is_null() {
+            return CURLcode::CURLE_BAD_FUNCTION_ARGUMENT;
+        }
+        if buffer.is_null() && buflen > 0 {
+            return CURLcode::CURLE_BAD_FUNCTION_ARGUMENT;
+        }
+        // CURLWS_OFFSET streaming (pre-declared frame length) is not supported.
+        if fragsize != 0 {
+            return CURLcode::CURLE_BAD_FUNCTION_ARGUMENT;
+        }
+
+        // `sent` may be null (libcurl tolerates it with an internal dummy).
+        if !sent.is_null() {
+            // SAFETY: Caller guarantees a non-null sent is a valid size_t pointer
+            unsafe { *sent = 0 };
+        }
+
+        // SAFETY: Caller guarantees curl is from curl_easy_init
+        let h = unsafe { &mut *curl.cast::<EasyHandle>() };
+
+        let payload: &[u8] = if buflen == 0 {
+            &[]
+        } else {
+            // SAFETY: Caller guarantees buffer points to buflen readable bytes
+            unsafe { std::slice::from_raw_parts(buffer.cast::<u8>(), buflen) }
+        };
+
+        match h.easy.ws_send(payload, flags) {
+            Ok(n) => {
+                if !sent.is_null() {
+                    // SAFETY: Caller guarantees a non-null sent is a valid
+                    // size_t pointer
+                    unsafe { *sent = n };
+                }
+                CURLcode::CURLE_OK
+            }
+            Err(ref e) => error_to_curlcode(e),
+        }
+    }));
+    result.unwrap_or(CURLcode::CURLE_SEND_ERROR)
+}
+
+/// `curl_ws_recv` — receive WebSocket payload data from a connect-only
+/// connection.
+///
+/// Use after a successful `curl_easy_perform` with `CURLOPT_CONNECT_ONLY`
+/// set to 2. On success, `*recv` holds the number of bytes written to
+/// `buffer` and `*metap` (when non-null) points to frame metadata owned by
+/// the handle, valid until the next `curl_ws_recv` call or handle cleanup.
+/// Returns `CURLE_GOT_NOTHING` when the server closed the connection.
+///
+/// # Safety
+///
+/// `curl` must be a valid pointer from `curl_easy_init`. `buffer` must point
+/// to at least `buflen` writable bytes (it may be null only when `buflen` is
+/// zero). `recv` must be a valid pointer to a `size_t`. `metap` may be null.
+#[no_mangle]
+pub unsafe extern "C" fn curl_ws_recv(
+    curl: *mut c_void,
+    buffer: *mut c_void,
+    buflen: usize,
+    recv: *mut usize,
+    metap: *mut *const curl_ws_frame,
+) -> CURLcode {
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        if curl.is_null() || recv.is_null() {
+            return CURLcode::CURLE_BAD_FUNCTION_ARGUMENT;
+        }
+        if buffer.is_null() && buflen > 0 {
+            return CURLcode::CURLE_BAD_FUNCTION_ARGUMENT;
+        }
+
+        // SAFETY: Caller guarantees recv is a valid size_t pointer
+        unsafe { *recv = 0 };
+        if !metap.is_null() {
+            // SAFETY: Caller guarantees a non-null metap is a valid pointer;
+            // libcurl guarantees *metap is NULL on failure.
+            unsafe { *metap = ptr::null() };
+        }
+
+        // SAFETY: Caller guarantees curl is from curl_easy_init
+        let h = unsafe { &mut *curl.cast::<EasyHandle>() };
+
+        let buf: &mut [u8] = if buflen == 0 {
+            &mut []
+        } else {
+            // SAFETY: Caller guarantees buffer points to buflen writable bytes
+            unsafe { std::slice::from_raw_parts_mut(buffer.cast::<u8>(), buflen) }
+        };
+
+        match h.easy.ws_recv(buf) {
+            Ok(Some((n, meta))) => {
+                // SAFETY: Caller guarantees recv is a valid size_t pointer
+                unsafe { *recv = n };
+                #[allow(clippy::cast_possible_wrap)]
+                let frame = curl_ws_frame {
+                    age: 0,
+                    flags: meta.flags as c_int,
+                    offset: meta.offset as i64,
+                    bytesleft: meta.bytesleft as i64,
+                    len: meta.len,
+                };
+                h.ws_frame = frame;
+                h.ws_frame_valid = true;
+                if !metap.is_null() {
+                    // SAFETY: Caller guarantees metap (when non-null) is a
+                    // valid pointer to a *const curl_ws_frame. The stored
+                    // pointer aims into the Box-allocated handle, so it stays
+                    // valid until the handle is cleaned up.
+                    unsafe { *metap = std::ptr::from_ref(&h.ws_frame) };
+                }
+                CURLcode::CURLE_OK
+            }
+            Ok(None) => CURLcode::CURLE_GOT_NOTHING,
+            Err(ref e) => error_to_curlcode(e),
+        }
+    }));
+    result.unwrap_or(CURLcode::CURLE_RECV_ERROR)
+}
+
+/// `curl_ws_meta` — return frame metadata for the most recent `curl_ws_recv`.
+///
+/// Returns null if `curl` is null or no `curl_ws_recv` has completed on this
+/// handle. The returned pointer is owned by the handle and stays valid until
+/// the next `curl_ws_recv` call or handle cleanup.
+///
+/// # Safety
+///
+/// `curl` must be a valid pointer from `curl_easy_init`, or null.
+#[no_mangle]
+pub unsafe extern "C" fn curl_ws_meta(curl: *mut c_void) -> *const curl_ws_frame {
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        if curl.is_null() {
+            return ptr::null();
+        }
+        // SAFETY: Caller guarantees curl is from curl_easy_init
+        let h = unsafe { &*curl.cast::<EasyHandle>() };
+        if h.ws_frame_valid {
+            std::ptr::from_ref(&h.ws_frame)
+        } else {
+            ptr::null()
+        }
+    }));
+    result.unwrap_or(ptr::null())
+}
+
 // ───────────────────────── Error mapping ─────────────────────────
 
 /// Convert a liburlx error to a `CURLcode`.
@@ -4927,12 +5183,18 @@ fn error_to_curlcode(err: &liburlx::Error) -> CURLcode {
         liburlx::Error::RtspCseqError(_) => CURLcode::CURLE_RTSP_CSEQ_ERROR,
         liburlx::Error::RtspSessionError(_) => CURLcode::CURLE_RTSP_SESSION_ERROR,
         liburlx::Error::Transfer { code, .. } => match *code {
+            1 => CURLcode::CURLE_UNSUPPORTED_PROTOCOL,
+            4 => CURLcode::CURLE_NOT_BUILT_IN,
             8 => CURLcode::CURLE_FTP_WEIRD_SERVER_REPLY,
+            22 => CURLcode::CURLE_HTTP_RETURNED_ERROR,
             38 => CURLcode::CURLE_LDAP_CANNOT_BIND,
             39 => CURLcode::CURLE_LDAP_SEARCH_FAILED,
             43 => CURLcode::CURLE_BAD_FUNCTION_ARGUMENT,
+            52 => CURLcode::CURLE_GOT_NOTHING,
+            55 => CURLcode::CURLE_SEND_ERROR,
             85 => CURLcode::CURLE_RTSP_CSEQ_ERROR,
             86 => CURLcode::CURLE_RTSP_SESSION_ERROR,
+            100 => CURLcode::CURLE_TOO_LARGE,
             _ => CURLcode::CURLE_RECV_ERROR,
         },
         _ => CURLcode::CURLE_RECV_ERROR,
@@ -7980,6 +8242,247 @@ mod tests {
         };
         assert_eq!(code, CURLcode::CURLE_OK);
         assert_eq!(auth, 0);
+        unsafe { curl_easy_cleanup(handle) };
+    }
+
+    // ───────────────────────── WebSocket API ─────────────────────────
+
+    #[test]
+    fn ws_setopt_connect_only_and_ws_options() {
+        let handle = curl_easy_init();
+        // CURLOPT_CONNECT_ONLY = 141
+        let code = unsafe { curl_easy_setopt(handle, 141, 2 as *const c_void) };
+        assert_eq!(code, CURLcode::CURLE_OK);
+        // Any value is accepted at setopt time (matching libcurl);
+        // dangling::<c_void>() has address 1 (alignment of c_void)
+        let code = unsafe { curl_easy_setopt(handle, 141, std::ptr::dangling::<c_void>()) };
+        assert_eq!(code, CURLcode::CURLE_OK);
+        // CURLOPT_WS_OPTIONS = 320, value 1 = CURLWS_RAW_MODE
+        let code = unsafe { curl_easy_setopt(handle, 320, std::ptr::dangling::<c_void>()) };
+        assert_eq!(code, CURLcode::CURLE_OK);
+        unsafe { curl_easy_cleanup(handle) };
+    }
+
+    #[test]
+    fn ws_meta_fresh_handle_is_null() {
+        let handle = curl_easy_init();
+        let meta = unsafe { curl_ws_meta(handle) };
+        assert!(meta.is_null());
+        unsafe { curl_easy_cleanup(handle) };
+    }
+
+    #[test]
+    fn ws_meta_null_handle_is_null() {
+        let meta = unsafe { curl_ws_meta(ptr::null_mut()) };
+        assert!(meta.is_null());
+    }
+
+    #[test]
+    fn ws_send_recv_without_connection() {
+        let handle = curl_easy_init();
+        let mut sent: usize = 0;
+        let code =
+            unsafe { curl_ws_send(handle, c"x".as_ptr().cast::<c_void>(), 1, &raw mut sent, 0, 1) };
+        assert_eq!(code, CURLcode::CURLE_SEND_ERROR);
+
+        let mut buf = [0u8; 16];
+        let mut nread: usize = 0;
+        let code = unsafe {
+            curl_ws_recv(
+                handle,
+                buf.as_mut_ptr().cast::<c_void>(),
+                buf.len(),
+                &raw mut nread,
+                ptr::null_mut(),
+            )
+        };
+        assert_eq!(code, CURLcode::CURLE_UNSUPPORTED_PROTOCOL);
+        unsafe { curl_easy_cleanup(handle) };
+    }
+
+    #[test]
+    fn ws_send_bad_arguments() {
+        let handle = curl_easy_init();
+        let mut sent: usize = 0;
+        let payload = c"x";
+
+        // Null curl handle
+        let code = unsafe {
+            curl_ws_send(ptr::null_mut(), payload.as_ptr().cast::<c_void>(), 1, &raw mut sent, 0, 1)
+        };
+        assert_eq!(code, CURLcode::CURLE_BAD_FUNCTION_ARGUMENT);
+
+        // Null sent pointer is tolerated (libcurl uses an internal dummy);
+        // the call proceeds and fails only because no connection exists.
+        let code = unsafe {
+            curl_ws_send(handle, payload.as_ptr().cast::<c_void>(), 1, ptr::null_mut(), 0, 1)
+        };
+        assert_eq!(code, CURLcode::CURLE_SEND_ERROR);
+
+        // Null buffer with non-zero length
+        let code = unsafe { curl_ws_send(handle, ptr::null(), 1, &raw mut sent, 0, 1) };
+        assert_eq!(code, CURLcode::CURLE_BAD_FUNCTION_ARGUMENT);
+
+        // Non-zero fragsize (CURLWS_OFFSET streaming) is unsupported
+        let code = unsafe {
+            curl_ws_send(handle, payload.as_ptr().cast::<c_void>(), 1, &raw mut sent, 5, 1)
+        };
+        assert_eq!(code, CURLcode::CURLE_BAD_FUNCTION_ARGUMENT);
+
+        unsafe { curl_easy_cleanup(handle) };
+    }
+
+    #[test]
+    fn ws_recv_bad_arguments() {
+        let handle = curl_easy_init();
+        let mut buf = [0u8; 16];
+        let mut nread: usize = 0;
+
+        // Null curl handle
+        let code = unsafe {
+            curl_ws_recv(
+                ptr::null_mut(),
+                buf.as_mut_ptr().cast::<c_void>(),
+                buf.len(),
+                &raw mut nread,
+                ptr::null_mut(),
+            )
+        };
+        assert_eq!(code, CURLcode::CURLE_BAD_FUNCTION_ARGUMENT);
+
+        // Null recv pointer
+        let code = unsafe {
+            curl_ws_recv(
+                handle,
+                buf.as_mut_ptr().cast::<c_void>(),
+                buf.len(),
+                ptr::null_mut(),
+                ptr::null_mut(),
+            )
+        };
+        assert_eq!(code, CURLcode::CURLE_BAD_FUNCTION_ARGUMENT);
+
+        // Null buffer with non-zero length
+        let code =
+            unsafe { curl_ws_recv(handle, ptr::null_mut(), 16, &raw mut nread, ptr::null_mut()) };
+        assert_eq!(code, CURLcode::CURLE_BAD_FUNCTION_ARGUMENT);
+
+        unsafe { curl_easy_cleanup(handle) };
+    }
+
+    #[test]
+    fn ws_connect_only_round_trip() {
+        use std::io::{Read, Write};
+
+        // Mock WebSocket server: complete the upgrade handshake, send a TEXT
+        // frame "hello", then read the client's masked TEXT frame and close.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = std::thread::spawn(move || -> Vec<u8> {
+            let (mut stream, _) = listener.accept().unwrap();
+            stream.set_read_timeout(Some(std::time::Duration::from_secs(10))).unwrap();
+
+            // Read the upgrade request until the blank line
+            let mut req = Vec::new();
+            let mut byte = [0u8; 1];
+            while !req.ends_with(b"\r\n\r\n") {
+                if stream.read(&mut byte).unwrap() == 0 {
+                    break;
+                }
+                req.extend_from_slice(&byte);
+            }
+
+            // 101 reply plus an unmasked TEXT frame "hello" (0x81 0x05)
+            stream
+                .write_all(
+                    b"HTTP/1.1 101 Switching to WebSockets\r\n\
+                      Upgrade: websocket\r\n\
+                      Connection: Upgrade\r\n\
+                      Sec-WebSocket-Accept: x\r\n\r\n\
+                      \x81\x05hello",
+                )
+                .unwrap();
+
+            // Client TEXT frame "world": 2 header + 4 mask + 5 payload bytes
+            let mut frame = [0u8; 11];
+            stream.read_exact(&mut frame).unwrap();
+            frame.to_vec()
+            // Dropping the stream closes the connection
+        });
+
+        let handle = curl_easy_init();
+        let url = std::ffi::CString::new(format!("ws://127.0.0.1:{port}/")).unwrap();
+        let code = unsafe { curl_easy_setopt(handle, 10002, url.as_ptr().cast::<c_void>()) };
+        assert_eq!(code, CURLcode::CURLE_OK);
+        // CURLOPT_CONNECT_ONLY = 141, mode 2 = WebSocket handshake only
+        let code = unsafe { curl_easy_setopt(handle, 141, 2 as *const c_void) };
+        assert_eq!(code, CURLcode::CURLE_OK);
+
+        let code = unsafe { curl_easy_perform(handle) };
+        assert_eq!(code, CURLcode::CURLE_OK);
+
+        // Receive "hello" with TEXT flags and populated metadata
+        let mut buf = [0u8; 256];
+        let mut nread: usize = 0;
+        let mut metap: *const curl_ws_frame = ptr::null();
+        let code = unsafe {
+            curl_ws_recv(
+                handle,
+                buf.as_mut_ptr().cast::<c_void>(),
+                buf.len(),
+                &raw mut nread,
+                &raw mut metap,
+            )
+        };
+        assert_eq!(code, CURLcode::CURLE_OK);
+        assert_eq!(nread, 5);
+        assert_eq!(&buf[..5], b"hello");
+        assert!(!metap.is_null());
+        // SAFETY: metap points into the handle, valid until the next recv
+        let meta = unsafe { &*metap };
+        assert_eq!(meta.age, 0);
+        assert_eq!(meta.flags, CURLWS_TEXT);
+        assert_eq!(meta.offset, 0);
+        assert_eq!(meta.bytesleft, 0);
+        assert_eq!(meta.len, 5);
+
+        // Send a TEXT frame "world"
+        let mut sent: usize = 0;
+        #[allow(clippy::cast_sign_loss)]
+        let text_flag = CURLWS_TEXT as c_uint;
+        let code = unsafe {
+            curl_ws_send(handle, b"world".as_ptr().cast::<c_void>(), 5, &raw mut sent, 0, text_flag)
+        };
+        assert_eq!(code, CURLcode::CURLE_OK);
+        assert_eq!(sent, 5);
+
+        // curl_ws_meta reports the last received frame
+        let meta = unsafe { curl_ws_meta(handle) };
+        assert!(!meta.is_null());
+        // SAFETY: meta points into the handle
+        assert_eq!(unsafe { (*meta).flags }, CURLWS_TEXT);
+
+        // Verify the server received a masked TEXT frame carrying "world"
+        let frame = server.join().unwrap();
+        assert_eq!(frame[0], 0x81, "FIN + TEXT opcode");
+        assert_eq!(frame[1], 0x85, "mask bit + length 5");
+        let mask = [frame[2], frame[3], frame[4], frame[5]];
+        let payload: Vec<u8> =
+            frame[6..].iter().enumerate().map(|(i, b)| b ^ mask[i % 4]).collect();
+        assert_eq!(payload, b"world");
+
+        // Server has closed the connection: recv reports GOT_NOTHING
+        let code = unsafe {
+            curl_ws_recv(
+                handle,
+                buf.as_mut_ptr().cast::<c_void>(),
+                buf.len(),
+                &raw mut nread,
+                ptr::null_mut(),
+            )
+        };
+        assert_eq!(code, CURLcode::CURLE_GOT_NOTHING);
+
         unsafe { curl_easy_cleanup(handle) };
     }
 }

--- a/crates/liburlx/Cargo.toml
+++ b/crates/liburlx/Cargo.toml
@@ -65,7 +65,7 @@ tokio-rustls = { version = "0.26", optional = true, default-features = false, fe
 quinn = { version = "0.11", optional = true, default-features = false, features = ["ring", "runtime-tokio", "rustls"] }
 h3 = { version = "0.0.8", optional = true }
 h3-quinn = { version = "0.0.10", optional = true }
-russh = { version = "0.58", optional = true, default-features = false, features = ["ring", "rsa"] }
+russh = { version = "0.62", optional = true, default-features = false, features = ["ring", "rsa"] }
 russh-sftp = { version = "2.1", optional = true }
 flate2 = { version = "1", optional = true }
 brotli = { version = "7", optional = true }

--- a/crates/liburlx/src/auth/aws_sigv4.rs
+++ b/crates/liburlx/src/auth/aws_sigv4.rs
@@ -244,7 +244,7 @@ fn derive_signing_key(
     provider: &str,
 ) -> Vec<u8> {
     let k_secret =
-        format!("{provider_upper}4{secret_key}", provider_upper = provider.to_uppercase(),);
+        format!("{provider_upper}4{secret_key}", provider_upper = provider.to_uppercase());
     let k_date = hmac_sha256(k_secret.as_bytes(), date.as_bytes());
     let k_region = hmac_sha256(&k_date, region.as_bytes());
     let k_service = hmac_sha256(&k_region, service.as_bytes());

--- a/crates/liburlx/src/cookie.rs
+++ b/crates/liburlx/src/cookie.rs
@@ -193,7 +193,7 @@ impl CookieJar {
         // When over the limit, drop the newest cookies (highest creation_index).
         if matching.len() > MAX_COOKIE_SEND {
             // Sort by creation_index ASC to find oldest, then take first 150
-            matching.sort_by(|a, b| a.creation_index.cmp(&b.creation_index));
+            matching.sort_by_key(|c| c.creation_index);
             matching.truncate(MAX_COOKIE_SEND);
             // Re-sort in curl's output order
             matching.sort_by(|a, b| {
@@ -404,7 +404,7 @@ impl CookieJar {
                 c.expires.is_none_or(|exp| now < exp)
             })
             .collect();
-        sorted.sort_by(|a, b| b.creation_index.cmp(&a.creation_index));
+        sorted.sort_by_key(|c| std::cmp::Reverse(c.creation_index));
 
         for cookie in sorted {
             let domain_str = if cookie.http_only {

--- a/crates/liburlx/src/easy.rs
+++ b/crates/liburlx/src/easy.rs
@@ -94,6 +94,18 @@ pub struct Easy {
     #[cfg(feature = "http2")]
     h2_pool: crate::pool::H2Pool,
     share: Option<crate::share::Share>,
+    /// `CURLOPT_CONNECT_ONLY` mode: 0 = full transfer, 2 = stop after the
+    /// WebSocket handshake and retain the connection for `ws_send`/`ws_recv`.
+    connect_only: u32,
+    /// WebSocket behavior bits (`CURLOPT_WS_OPTIONS`): see
+    /// [`crate::protocol::ws::ws_options`].
+    ws_options_bits: u32,
+    /// WebSocket connection retained by a `connect_only == 2` perform.
+    ws_conn: Option<crate::protocol::ws::WsConnection>,
+    /// Runtime kept alive for sync WebSocket I/O after a `connect_only`
+    /// perform (the per-perform runtime would drop the connection's I/O
+    /// registrations with it).
+    ws_runtime: Option<tokio::runtime::Runtime>,
     http_version: HttpVersion,
     /// Allow HTTP/0.9 responses (default: false, curl compat).
     http09_allowed: bool,
@@ -426,6 +438,12 @@ impl Clone for Easy {
             #[cfg(feature = "http2")]
             h2_pool: crate::pool::H2Pool::new(),
             share: self.share.clone(),
+            connect_only: self.connect_only,
+            ws_options_bits: self.ws_options_bits,
+            // A live WebSocket connection and its runtime are not clonable;
+            // the clone starts without one.
+            ws_conn: None,
+            ws_runtime: None,
             http_version: self.http_version,
             http09_allowed: self.http09_allowed,
             expect_100_timeout: self.expect_100_timeout,
@@ -567,6 +585,10 @@ impl Easy {
             #[cfg(feature = "http2")]
             h2_pool: crate::pool::H2Pool::new(),
             share: None,
+            connect_only: 0,
+            ws_options_bits: 0,
+            ws_conn: None,
+            ws_runtime: None,
             http_version: HttpVersion::None,
             http09_allowed: false,
             expect_100_timeout: None,
@@ -2734,6 +2756,24 @@ impl Easy {
     /// Returns errors for connection failures, TLS errors, HTTP protocol
     /// errors, timeouts, and other transfer problems.
     pub fn perform(&mut self) -> Result<Response, Error> {
+        // A connect-only WebSocket perform must keep its runtime alive:
+        // dropping it would deregister the retained connection's I/O and
+        // make ws_send/ws_recv unusable.
+        let ws_connect_only = self.connect_only == 2
+            && self.url.as_ref().is_some_and(|u| matches!(u.scheme(), "ws" | "wss"));
+        if ws_connect_only {
+            let rt = match self.ws_runtime.take() {
+                Some(rt) => rt,
+                None => tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .map_err(|e| Error::Http(format!("failed to create runtime: {e}")))?,
+            };
+            let result = rt.block_on(self.perform_async());
+            self.ws_runtime = Some(rt);
+            return result;
+        }
+
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
@@ -2744,6 +2784,85 @@ impl Easy {
         // For multi-URL async usage, the caller is responsible for calling ftp_quit().
         rt.block_on(self.ftp_quit());
         result
+    }
+
+    /// Set the connect-only mode (libcurl `CURLOPT_CONNECT_ONLY`).
+    ///
+    /// Mode 2 performs the WebSocket upgrade handshake and retains the
+    /// connection on this handle for [`ws_send`](Self::ws_send) /
+    /// [`ws_recv`](Self::ws_recv) instead of running a full transfer. Mode 1
+    /// (raw TCP/TLS connect-only) is not supported and causes
+    /// [`perform`](Self::perform) to fail.
+    pub const fn set_connect_only(&mut self, mode: u32) {
+        self.connect_only = mode;
+    }
+
+    /// Set WebSocket behavior options (libcurl `CURLOPT_WS_OPTIONS` bits;
+    /// see [`crate::protocol::ws::ws_options`]).
+    pub const fn set_ws_options(&mut self, bits: u32) {
+        self.ws_options_bits = bits;
+    }
+
+    /// Access the WebSocket connection retained by a connect-only perform.
+    ///
+    /// Async callers drive the connection directly with its async methods;
+    /// sync callers can use [`ws_send`](Self::ws_send) /
+    /// [`ws_recv`](Self::ws_recv) instead.
+    pub const fn ws_connection(&mut self) -> Option<&mut crate::protocol::ws::WsConnection> {
+        self.ws_conn.as_mut()
+    }
+
+    /// Take ownership of the WebSocket connection retained by a
+    /// connect-only perform, leaving the handle without one.
+    pub const fn take_ws_connection(&mut self) -> Option<crate::protocol::ws::WsConnection> {
+        self.ws_conn.take()
+    }
+
+    /// Send a WebSocket frame on the retained connection (sync wrapper;
+    /// libcurl `curl_ws_send` semantics — see
+    /// [`WsConnection::send`](crate::protocol::ws::WsConnection::send)).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if no connection is retained (perform with
+    /// [`set_connect_only`](Self::set_connect_only) mode 2 first) or the
+    /// send fails.
+    pub fn ws_send(&mut self, payload: &[u8], flags: u32) -> Result<usize, Error> {
+        let (Some(rt), Some(conn)) = (self.ws_runtime.as_ref(), self.ws_conn.as_mut()) else {
+            // curl_ws_send without a connection fails with CURLE_SEND_ERROR.
+            return Err(Error::Transfer {
+                code: 55, // CURLE_SEND_ERROR
+                message: "No associated WebSocket connection".to_string(),
+            });
+        };
+        rt.block_on(conn.send(payload, flags))
+    }
+
+    /// Receive WebSocket payload data on the retained connection (sync
+    /// wrapper; libcurl `curl_ws_recv` semantics — see
+    /// [`WsConnection::recv`](crate::protocol::ws::WsConnection::recv)).
+    /// Returns `Ok(None)` when the server closed the connection.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if no connection is retained (perform with
+    /// [`set_connect_only`](Self::set_connect_only) mode 2 first) or the
+    /// receive fails.
+    pub fn ws_recv(
+        &mut self,
+        buf: &mut [u8],
+    ) -> Result<Option<(usize, crate::protocol::ws::WsFrameMeta)>, Error> {
+        let (Some(rt), Some(conn)) = (self.ws_runtime.as_ref(), self.ws_conn.as_mut()) else {
+            return Err(ws_not_connected());
+        };
+        rt.block_on(conn.recv(buf))
+    }
+
+    /// Metadata of the most recent [`ws_recv`](Self::ws_recv) chunk
+    /// (libcurl `curl_ws_meta`).
+    #[must_use]
+    pub fn ws_meta(&self) -> Option<&crate::protocol::ws::WsFrameMeta> {
+        self.ws_conn.as_ref().map(crate::protocol::ws::WsConnection::last_meta)
     }
 
     /// Perform the transfer and return the response (async).
@@ -2783,6 +2902,21 @@ impl Easy {
                     allowed.join(",")
                 )));
             }
+        }
+
+        // A new perform supersedes any previously retained WebSocket
+        // connection; drop it so ws_send/ws_recv cannot use a stale one.
+        self.ws_conn = None;
+
+        // CONNECT_ONLY is only implemented for WebSocket handshakes (mode 2).
+        if self.connect_only != 0
+            && (self.connect_only != 2 || !matches!(url.scheme(), "ws" | "wss"))
+        {
+            return Err(Error::Transfer {
+                code: 4, // CURLE_NOT_BUILT_IN
+                message: "CONNECT_ONLY is only supported for WebSocket upgrades (mode 2)"
+                    .to_string(),
+            });
         }
 
         // Build effective headers, body, and method considering multipart and range
@@ -3165,6 +3299,9 @@ impl Easy {
             &self.rtsp_headers,
             self.netrc_content.as_deref(),
             self.fail_on_error,
+            self.connect_only == 2,
+            self.ws_options_bits,
+            &mut self.ws_conn,
         );
 
         // Apply total transfer timeout if set.
@@ -3238,6 +3375,17 @@ impl Easy {
 impl Default for Easy {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// Error returned by WebSocket operations when no connection is retained.
+///
+/// Matches libcurl, where `curl_ws_send`/`curl_ws_recv` without a
+/// connect-only WebSocket connection fail with `CURLE_UNSUPPORTED_PROTOCOL`.
+fn ws_not_connected() -> Error {
+    Error::Transfer {
+        code: 1, // CURLE_UNSUPPORTED_PROTOCOL
+        message: "WebSocket not connected: perform with connect-only mode 2 first".to_string(),
     }
 }
 
@@ -3333,7 +3481,42 @@ async fn perform_transfer(
     rtsp_headers: &[(String, String)],
     netrc_content: Option<&str>,
     fail_on_error: bool,
+    ws_connect_only: bool,
+    ws_options_bits: u32,
+    ws_conn_out: &mut Option<crate::protocol::ws::WsConnection>,
 ) -> Result<Response, Error> {
+    // WebSocket connect-only mode: perform the upgrade handshake, retain the
+    // connection for ws_send/ws_recv, and skip the transfer pipeline.
+    if ws_connect_only && matches!(url.scheme(), "ws" | "wss") {
+        let effective_proxy = proxy.filter(|_| !should_bypass_proxy(url, noproxy));
+        let ws_options = crate::protocol::ws::WsConnectOptions {
+            proxy: effective_proxy,
+            proxy_auth: proxy_credentials.map(|c| (c.username.as_str(), c.password.as_str())),
+            connect_timeout,
+        };
+        let handshake = crate::protocol::ws::connect_stream(url, headers, tls_config, &ws_options);
+        let (response, stream) = match deadline {
+            Some(d) => tokio::time::timeout_at(d, handshake)
+                .await
+                .map_err(|_| Error::Timeout(Duration::from_secs(0)))??,
+            None => handshake.await?,
+        };
+        // Record the handshake response so CURLINFO_RESPONSE_CODE reflects
+        // it even when the upgrade is refused.
+        if let Ok(mut guard) = last_resp_store.lock() {
+            *guard = Some(response.clone());
+        }
+        if response.status() != 101 {
+            return Err(Error::Transfer {
+                code: 22, // CURLE_HTTP_RETURNED_ERROR
+                message: format!("Refused WebSocket upgrade: {}", response.status()),
+            });
+        }
+        *ws_conn_out =
+            Some(crate::protocol::ws::WsConnection::new(stream, response.clone(), ws_options_bits));
+        return Ok(response);
+    }
+
     let transfer_start = Instant::now();
     let original_url = url.clone();
     let mut current_url = url.clone();
@@ -4363,14 +4546,12 @@ async fn perform_transfer(
                         }
                     }
                     #[cfg(not(feature = "gss-api"))]
-                    Some(AuthMethod::Negotiate) => {
-                        if verbose {
-                            #[allow(clippy::print_stderr)]
-                            {
-                                eprintln!(
-                                    "* Negotiate auth requested but GSS-API support not compiled in"
-                                );
-                            }
+                    Some(AuthMethod::Negotiate) if verbose => {
+                        #[allow(clippy::print_stderr)]
+                        {
+                            eprintln!(
+                                "* Negotiate auth requested but GSS-API support not compiled in"
+                            );
                         }
                     }
                     Some(AuthMethod::Basic) => {
@@ -6323,7 +6504,23 @@ async fn do_single_request(
             return crate::protocol::ldap::search(url, tls_config, use_tls, ldap_use_ssl).await;
         }
         "ws" | "wss" => {
-            return crate::protocol::ws::connect(url, headers, tls_config).await;
+            // Full curl-style WebSocket transfer: upgrade, send any upload
+            // data as BINARY frames, stream received payloads as the body.
+            let upload = if method == "PUT" || method == "POST" { body } else { None };
+            let ws_options = crate::protocol::ws::WsConnectOptions {
+                proxy,
+                proxy_auth: proxy_credentials.map(|c| (c.username.as_str(), c.password.as_str())),
+                connect_timeout,
+            };
+            return crate::protocol::ws::transfer(
+                url,
+                headers,
+                tls_config,
+                upload,
+                deadline,
+                &ws_options,
+            )
+            .await;
         }
         "telnet" => {
             return crate::protocol::telnet::transfer(url, body, deadline).await;

--- a/crates/liburlx/src/protocol/ws.rs
+++ b/crates/liburlx/src/protocol/ws.rs
@@ -806,32 +806,80 @@ async fn write_frame_masked<S: AsyncWrite + Unpin>(
     Ok(())
 }
 
-/// Generate the WebSocket handshake key.
-#[must_use]
-pub fn generate_ws_key() -> String {
-    use base64::Engine;
+/// Fill `buf` with random bytes for WebSocket key/mask generation.
+///
+/// When the `CURL_ENTROPY` environment variable is set, produces the same
+/// deterministic sequence as curl's debug builds (curl compat: WebSocket
+/// tests pin `Sec-WebSocket-Key` and frame masks via `CURL_ENTROPY`):
+/// the seed is the first four bytes of the variable interpreted big-endian,
+/// each subsequent draw increments it, and every 32-bit value is serialized
+/// least-significant byte first (see curl's `lib/rand.c`).
+fn ws_rand_fill(buf: &mut [u8]) {
     use std::sync::atomic::{AtomicU64, Ordering};
     use std::time::{SystemTime, UNIX_EPOCH};
 
     static COUNTER: AtomicU64 = AtomicU64::new(0);
 
+    if let Ok(entropy) = std::env::var("CURL_ENTROPY") {
+        ws_rand_fill_deterministic(&entropy, buf);
+        return;
+    }
+
     let nanos = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_nanos();
     let count = COUNTER.fetch_add(1, Ordering::Relaxed);
 
     #[allow(clippy::cast_possible_truncation)]
-    let bytes: [u8; 16] = {
-        let mut buf = [0u8; 16];
-        // Mix timestamp into first 8 bytes
-        for (i, b) in buf[..8].iter_mut().enumerate() {
-            *b = ((nanos >> (i * 8)) & 0xFF) as u8;
-        }
-        // Mix counter into last 8 bytes for uniqueness within the same nanosecond
-        for (i, b) in buf[8..].iter_mut().enumerate() {
-            *b = ((count >> (i * 8)) & 0xFF) as u8;
-        }
-        buf
-    };
+    for (i, b) in buf.iter_mut().enumerate() {
+        let mixed = (nanos >> ((i % 8) * 8)) as u8 ^ (count >> ((i % 8) * 8)) as u8;
+        *b = mixed ^ (i as u8).wrapping_mul(0x9D);
+    }
+}
 
+/// Fill `buf` from the deterministic `CURL_ENTROPY` sequence: one 32-bit
+/// value per 4 output bytes, serialized LSB-first like curl's
+/// `Curl_rand_bytes` (see `lib/rand.c`).
+// significant_drop_tightening false positive: the mutex guard is used by the
+// seeding branch and every loop iteration, so it cannot be dropped earlier.
+#[allow(clippy::significant_drop_tightening)]
+fn ws_rand_fill_deterministic(entropy: &str, buf: &mut [u8]) {
+    use std::sync::Mutex;
+
+    // Deterministic state shared by all keys and masks in the process,
+    // mirroring curl's static randseed.
+    static ENTROPY_STATE: Mutex<Option<u32>> = Mutex::new(None);
+
+    let n_words = buf.len().div_ceil(4);
+    let mut words = Vec::with_capacity(n_words);
+    {
+        let mut state = ENTROPY_STATE.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        if state.is_none() {
+            let mut seed_bytes = [0u8; 4];
+            for (dst, src) in seed_bytes.iter_mut().zip(entropy.bytes()) {
+                *dst = src;
+            }
+            *state = Some(u32::from_be_bytes(seed_bytes));
+        }
+        for _ in 0..n_words {
+            let word = state.unwrap_or(0);
+            *state = Some(word.wrapping_add(1));
+            words.push(word);
+        }
+    }
+    for (chunk, word) in buf.chunks_mut(4).zip(words) {
+        #[allow(clippy::cast_possible_truncation)]
+        for (i, b) in chunk.iter_mut().enumerate() {
+            *b = (word >> (i * 8)) as u8;
+        }
+    }
+}
+
+/// Generate the WebSocket handshake key.
+#[must_use]
+pub fn generate_ws_key() -> String {
+    use base64::Engine;
+
+    let mut bytes = [0u8; 16];
+    ws_rand_fill(&mut bytes);
     base64::engine::general_purpose::STANDARD.encode(bytes)
 }
 
@@ -851,17 +899,17 @@ pub fn compute_accept_key(key: &str) -> String {
 }
 
 /// Generate a masking key for client frames.
+///
+/// Honors `CURL_ENTROPY` (deterministic sequence) and `CURL_WS_FORCE_ZERO_MASK`
+/// (zeroes the mask bytes after drawing them, so the entropy sequence still
+/// advances — curl compat: WebSocket tests 2700+).
 fn generate_mask_key() -> [u8; 4] {
-    use std::time::{SystemTime, UNIX_EPOCH};
-    let nanos = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_nanos();
-
-    #[allow(clippy::cast_possible_truncation)]
-    [
-        (nanos & 0xFF) as u8,
-        ((nanos >> 8) & 0xFF) as u8,
-        ((nanos >> 16) & 0xFF) as u8,
-        ((nanos >> 24) & 0xFF) as u8,
-    ]
+    let mut key = [0u8; 4];
+    ws_rand_fill(&mut key);
+    if std::env::var_os("CURL_WS_FORCE_ZERO_MASK").is_some() {
+        key = [0u8; 4];
+    }
+    key
 }
 
 /// Minimal SHA-1 implementation (RFC 3174).
@@ -934,12 +982,67 @@ fn sha1_hash(data: &[u8]) -> [u8; 20] {
     result
 }
 
+/// Frame-type flags for [`WsConnection`] send and receive operations.
+///
+/// The values match libcurl's `CURLWS_*` constants so the FFI layer can pass
+/// them through unchanged.
+pub mod ws_flags {
+    /// Text frame payload.
+    pub const TEXT: u32 = 1 << 0;
+    /// Binary frame payload.
+    pub const BINARY: u32 = 1 << 1;
+    /// This is a fragment of a larger message (not the final fragment).
+    pub const CONT: u32 = 1 << 2;
+    /// Close frame.
+    pub const CLOSE: u32 = 1 << 3;
+    /// Ping frame.
+    pub const PING: u32 = 1 << 4;
+    /// The frame length is declared up front (send only; not yet supported).
+    pub const OFFSET: u32 = 1 << 5;
+    /// Pong frame.
+    pub const PONG: u32 = 1 << 6;
+}
+
+/// Options for [`WsConnection`] behavior (libcurl `CURLOPT_WS_OPTIONS` bits).
+pub mod ws_options {
+    /// Deliver and accept raw frame bytes instead of decoded payloads.
+    pub const RAW_MODE: u32 = 1 << 0;
+    /// Do not automatically reply to PING frames with a PONG.
+    pub const NO_AUTO_PONG: u32 = 1 << 1;
+}
+
+/// Metadata describing the frame chunk returned by [`WsConnection::recv`].
+///
+/// Mirrors libcurl's `struct curl_ws_frame`.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct WsFrameMeta {
+    /// Frame-type flags ([`ws_flags`] bits).
+    pub flags: u32,
+    /// Offset of this chunk within the frame payload.
+    pub offset: u64,
+    /// Payload bytes of this frame still to be delivered after this chunk.
+    pub bytesleft: u64,
+    /// Number of bytes in this chunk.
+    pub len: usize,
+}
+
+/// Transport requirements for a WebSocket connection stream.
+///
+/// `Sync` is required so that holding a [`WsConnection`] does not strip
+/// `Sync` from containing types (e.g. `Easy`).
+pub trait WsTransport: AsyncRead + AsyncWrite + Unpin + Send + Sync {}
+impl<T: AsyncRead + AsyncWrite + Unpin + Send + Sync> WsTransport for T {}
+
+/// A boxed transport carrying an upgraded WebSocket connection.
+pub type BoxedWsTransport = Box<dyn WsTransport>;
+
 /// Perform a WebSocket handshake and return the upgrade response.
 ///
 /// Connects to the server at the given URL (ws:// or wss://), sends an HTTP
 /// upgrade request, and returns a response with the server's handshake reply.
 /// The response body is empty; the connection status is reported via the HTTP
-/// status code (101 = success).
+/// status code (101 = success). The upgraded connection is dropped — use
+/// [`connect_stream`] to keep it.
 ///
 /// # Errors
 ///
@@ -950,65 +1053,257 @@ pub async fn connect(
     headers: &[(String, String)],
     tls_config: &crate::tls::TlsConfig,
 ) -> Result<crate::protocol::http::response::Response, Error> {
-    let (host, port) = url.host_and_port()?;
-    let is_tls = url.scheme() == "wss";
+    let (response, _stream) =
+        connect_stream(url, headers, tls_config, &WsConnectOptions::default()).await?;
+    Ok(response)
+}
 
-    // Build the WebSocket key
-    let ws_key = generate_ws_key();
-    let expected_accept = compute_accept_key(&ws_key);
+/// Connection-establishment options for the WebSocket handshake.
+#[derive(Debug, Default)]
+pub struct WsConnectOptions<'a> {
+    /// Proxy to route the connection through. Supported schemes: `http`
+    /// (CONNECT tunnel — curl always tunnels WebSocket through HTTP
+    /// proxies), `socks4`, `socks4a`, `socks5`, `socks5h`.
+    pub proxy: Option<&'a crate::url::Url>,
+    /// Username/password for proxy authentication.
+    pub proxy_auth: Option<(&'a str, &'a str)>,
+    /// Timeout covering TCP connect, proxy handshake, and TLS negotiation
+    /// (curl `--connect-timeout`).
+    pub connect_timeout: Option<std::time::Duration>,
+}
 
-    // Build the HTTP upgrade request
-    let path = if url.path().is_empty() { "/" } else { url.path() };
-    let query = url.query().map_or(String::new(), |q| format!("?{q}"));
+/// Establish the TCP transport to the target, directly or via a proxy.
+async fn establish_transport(
+    target_host: &str,
+    target_port: u16,
+    options: &WsConnectOptions<'_>,
+) -> Result<tokio::net::TcpStream, Error> {
+    let Some(proxy) = options.proxy else {
+        return tokio::net::TcpStream::connect(format!("{target_host}:{target_port}"))
+            .await
+            .map_err(Error::Connect);
+    };
 
-    let mut request = format!(
-        "GET {path}{query} HTTP/1.1\r\n\
-         Host: {host}\r\n\
-         Upgrade: websocket\r\n\
-         Connection: Upgrade\r\n\
-         Sec-WebSocket-Key: {ws_key}\r\n\
-         Sec-WebSocket-Version: 13\r\n"
-    );
-    for (key, val) in headers {
-        use std::fmt::Write;
-        let _ = write!(request, "{key}: {val}\r\n");
-    }
-    request.push_str("\r\n");
-
-    // Connect via TCP
-    let tcp_stream = tokio::net::TcpStream::connect(format!("{host}:{port}"))
+    let (proxy_host, proxy_port) = proxy.host_and_port()?;
+    let tcp = tokio::net::TcpStream::connect(format!("{proxy_host}:{proxy_port}"))
         .await
-        .map_err(|e| Error::Http(format!("WebSocket connect error: {e}")))?;
+        .map_err(Error::Connect)?;
 
-    if is_tls {
-        let connector = crate::tls::TlsConnector::new_no_alpn(tls_config)?;
-        let (mut tls_stream, _alpn) = connector.connect(tcp_stream, &host).await?;
-
-        tokio::io::AsyncWriteExt::write_all(&mut tls_stream, request.as_bytes())
-            .await
-            .map_err(|e| Error::Http(format!("WebSocket write error: {e}")))?;
-        tokio::io::AsyncWriteExt::flush(&mut tls_stream)
-            .await
-            .map_err(|e| Error::Http(format!("WebSocket flush error: {e}")))?;
-
-        parse_upgrade_response(&mut tls_stream, &expected_accept, url.as_str()).await
-    } else {
-        let mut tcp_stream = tcp_stream;
-        tokio::io::AsyncWriteExt::write_all(&mut tcp_stream, request.as_bytes())
-            .await
-            .map_err(|e| Error::Http(format!("WebSocket write error: {e}")))?;
-        tokio::io::AsyncWriteExt::flush(&mut tcp_stream)
-            .await
-            .map_err(|e| Error::Http(format!("WebSocket flush error: {e}")))?;
-
-        parse_upgrade_response(&mut tcp_stream, &expected_accept, url.as_str()).await
+    match proxy.scheme() {
+        "socks5" | "socks5h" => {
+            crate::proxy::socks::connect_socks5(tcp, target_host, target_port, options.proxy_auth)
+                .await
+        }
+        "socks4" | "socks4a" => {
+            let user_id = options.proxy_auth.map_or("", |(user, _)| user);
+            crate::proxy::socks::connect_socks4(tcp, target_host, target_port, user_id).await
+        }
+        "http" => ws_http_connect_tunnel(tcp, target_host, target_port, options.proxy_auth).await,
+        other => Err(Error::Http(format!(
+            "WebSocket: proxy scheme '{other}' is not supported for ws/wss"
+        ))),
     }
 }
 
+/// Establish an HTTP CONNECT tunnel to the target through a proxy.
+async fn ws_http_connect_tunnel(
+    mut stream: tokio::net::TcpStream,
+    target_host: &str,
+    target_port: u16,
+    proxy_auth: Option<(&str, &str)>,
+) -> Result<tokio::net::TcpStream, Error> {
+    use std::fmt::Write;
+
+    let mut request = format!(
+        "CONNECT {target_host}:{target_port} HTTP/1.1\r\n\
+         Host: {target_host}:{target_port}\r\n"
+    );
+    if let Some((user, pass)) = proxy_auth {
+        use base64::Engine;
+        let encoded = base64::engine::general_purpose::STANDARD.encode(format!("{user}:{pass}"));
+        let _ = write!(request, "Proxy-Authorization: Basic {encoded}\r\n");
+    }
+    request.push_str("Proxy-Connection: Keep-Alive\r\n\r\n");
+
+    stream
+        .write_all(request.as_bytes())
+        .await
+        .map_err(|e| Error::Http(format!("proxy CONNECT write error: {e}")))?;
+
+    // Read the CONNECT response headers byte-by-byte so no tunneled bytes
+    // are consumed.
+    let mut buf = Vec::with_capacity(256);
+    loop {
+        let mut byte = [0u8; 1];
+        let n = stream
+            .read(&mut byte)
+            .await
+            .map_err(|e| Error::Http(format!("proxy CONNECT read error: {e}")))?;
+        if n == 0 {
+            return Err(Error::Http("proxy closed connection during CONNECT".to_string()));
+        }
+        buf.push(byte[0]);
+        if buf.len() >= 4 && buf[buf.len() - 4..] == *b"\r\n\r\n" {
+            break;
+        }
+        if buf.len() > 8192 {
+            return Err(Error::Http("proxy CONNECT response too large".to_string()));
+        }
+    }
+    let response = String::from_utf8_lossy(&buf);
+    let status: u16 = response.split_whitespace().nth(1).and_then(|s| s.parse().ok()).unwrap_or(0);
+    if !(200..300).contains(&status) {
+        return Err(Error::Http(format!("proxy CONNECT refused: HTTP {status}")));
+    }
+    Ok(stream)
+}
+
+/// Perform a WebSocket handshake and return the upgrade response together
+/// with the upgraded transport stream.
+///
+/// This is the connection-retaining variant of [`connect`]: on a `101
+/// Switching Protocols` response the returned stream is positioned exactly
+/// past the response headers, ready for WebSocket frame I/O (wrap it in a
+/// [`WsConnection`]).
+///
+/// # Errors
+///
+/// Returns an error if the connection fails, TLS negotiation fails, or the
+/// handshake response cannot be parsed.
+pub async fn connect_stream(
+    url: &crate::url::Url,
+    headers: &[(String, String)],
+    tls_config: &crate::tls::TlsConfig,
+    options: &WsConnectOptions<'_>,
+) -> Result<(crate::protocol::http::response::Response, BoxedWsTransport), Error> {
+    use std::fmt::Write;
+
+    // Headers handled by dedicated slots below (a custom Connection value is
+    // merged into the final Connection header like curl), and headers that
+    // only make sense for HTTP bodies (a WS upgrade request never carries
+    // one).
+    const SKIP: &[&str] =
+        &["host", "user-agent", "connection", "content-length", "transfer-encoding", "expect"];
+
+    let (host, port) = url.host_and_port()?;
+    let is_tls = url.scheme() == "wss";
+
+    // Build the HTTP upgrade request. Header order matches curl: request
+    // line, Host, User-Agent, Accept, custom headers, then the upgrade
+    // headers with Connection: Upgrade last (curl compat: test 2300). Like
+    // curl, user-supplied Upgrade/Sec-WebSocket-*/Connection headers
+    // override the generated ones.
+    let path = if url.path().is_empty() { "/" } else { url.path() };
+    let query = url.query().map_or(String::new(), |q| format!("?{q}"));
+
+    let has_custom =
+        |name: &str| headers.iter().any(|(k, v)| k.eq_ignore_ascii_case(name) && !v.is_empty());
+
+    let mut request = format!("GET {path}{query} HTTP/1.1\r\n");
+
+    // Host: custom override, suppression sentinel, or derived from the URL.
+    let custom_host = headers.iter().find(|(k, _)| k.eq_ignore_ascii_case("host"));
+    match custom_host {
+        Some((_, v)) if v == "\x01REMOVE\x01" => {}
+        Some((_, v)) if !v.is_empty() => {
+            let _ = write!(request, "Host: {v}\r\n");
+        }
+        _ => {
+            // Includes the port when it is not the scheme default (curl compat).
+            let host_header = url.host_header_value();
+            let _ = write!(request, "Host: {host_header}\r\n");
+        }
+    }
+
+    // User-Agent: custom value from the caller, or curl-compatible default.
+    // An empty value suppresses the header (curl compat).
+    let custom_ua = headers.iter().find(|(k, _)| k.eq_ignore_ascii_case("user-agent"));
+    match custom_ua {
+        Some((_, v)) if v.is_empty() => {}
+        Some((k, v)) => {
+            let _ = write!(request, "{k}: {v}\r\n");
+        }
+        None => {
+            request.push_str(concat!("User-Agent: curl/", env!("CARGO_PKG_VERSION"), "\r\n"));
+        }
+    }
+
+    // Default Accept unless the caller supplied one (emitted below in order).
+    if !headers.iter().any(|(k, _)| k.eq_ignore_ascii_case("accept")) {
+        request.push_str("Accept: */*\r\n");
+    }
+
+    for (key, val) in headers {
+        if SKIP.iter().any(|s| key.eq_ignore_ascii_case(s)) {
+            continue;
+        }
+        if val.is_empty() {
+            // Empty value = suppression sentinel for default headers.
+            continue;
+        }
+        // Auto-generated Basic credentials are stored under an internal
+        // marker name; emit them as a real Authorization header (matches
+        // the HTTP/1.1 serializer).
+        let emit_key =
+            if key.eq_ignore_ascii_case("_auto_authorization") { "Authorization" } else { key };
+        let _ = write!(request, "{emit_key}: {val}\r\n");
+    }
+
+    // Generated upgrade headers, skipped when the caller supplied its own
+    // (curl compat: Curl_ws_request only adds headers not already present).
+    if !has_custom("upgrade") {
+        request.push_str("Upgrade: websocket\r\n");
+    }
+    if !has_custom("sec-websocket-version") {
+        request.push_str("Sec-WebSocket-Version: 13\r\n");
+    }
+    if !has_custom("sec-websocket-key") {
+        let ws_key = generate_ws_key();
+        let _ = write!(request, "Sec-WebSocket-Key: {ws_key}\r\n");
+    }
+    // Connection is emitted last; a custom value is merged with Upgrade
+    // (curl compat: http_add_connection_hd).
+    match headers.iter().find(|(k, v)| k.eq_ignore_ascii_case("connection") && !v.is_empty()) {
+        Some((_, v)) => {
+            let _ = write!(request, "Connection: {v}, Upgrade\r\n\r\n");
+        }
+        None => request.push_str("Connection: Upgrade\r\n\r\n"),
+    }
+
+    // Establish the transport (TCP, optionally via proxy, then TLS) within
+    // the connect timeout (curl --connect-timeout semantics).
+    let setup = async {
+        let tcp_stream = establish_transport(&host, port, options).await?;
+        let stream: BoxedWsTransport = if is_tls {
+            let connector = crate::tls::TlsConnector::new_no_alpn(tls_config)?;
+            let (tls_stream, _alpn) = connector.connect(tcp_stream, &host).await?;
+            Box::new(tls_stream)
+        } else {
+            Box::new(tcp_stream)
+        };
+        Ok::<_, Error>(stream)
+    };
+    let mut stream = match options.connect_timeout {
+        Some(t) => tokio::time::timeout(t, setup).await.map_err(|_| Error::Timeout(t))??,
+        None => setup.await?,
+    };
+
+    stream
+        .write_all(request.as_bytes())
+        .await
+        .map_err(|e| Error::Http(format!("WebSocket write error: {e}")))?;
+    stream.flush().await.map_err(|e| Error::Http(format!("WebSocket flush error: {e}")))?;
+
+    let response = parse_upgrade_response(&mut stream, url.as_str()).await?;
+    Ok((response, stream))
+}
+
 /// Parse the HTTP upgrade response from the server.
-async fn parse_upgrade_response<S: AsyncRead + Unpin>(
+///
+/// Reads byte-by-byte so no frame data past the header terminator is
+/// consumed from the stream.
+async fn parse_upgrade_response<S: AsyncRead + Unpin + ?Sized>(
     stream: &mut S,
-    expected_accept: &str,
     url_str: &str,
 ) -> Result<crate::protocol::http::response::Response, Error> {
     // Read response bytes until we see \r\n\r\n
@@ -1053,22 +1348,697 @@ async fn parse_upgrade_response<S: AsyncRead + Unpin>(
         }
     }
 
-    // Validate the accept key for 101 responses
-    if status_code == 101 {
-        if let Some(accept) = resp_headers.get("sec-websocket-accept") {
-            if accept != expected_accept {
-                return Err(Error::Http(format!(
-                    "WebSocket: invalid Sec-WebSocket-Accept (got {accept}, expected {expected_accept})"
-                )));
-            }
-        }
-    }
-
+    // Note: curl deliberately does not validate Sec-WebSocket-Accept (see
+    // curl's lib/ws.c) and its test suite sends handshakes that would fail
+    // the RFC 6455 check, so we match curl and skip validation (curl compat:
+    // test 2300).
     Ok(crate::protocol::http::response::Response::new(
         status_code,
         resp_headers,
         Vec::new(),
         url_str.to_string(),
+    ))
+}
+
+/// A frame currently being delivered to the caller in chunks.
+///
+/// Control-frame payloads (at most 125 bytes) are buffered; data-frame
+/// payloads are streamed from the wire as the caller consumes them, so a
+/// frame declaring a huge length never causes a matching allocation.
+struct RecvFrame {
+    flags: u32,
+    /// Total payload length from the frame header.
+    total: u64,
+    /// Payload bytes already delivered to the caller.
+    delivered: u64,
+    /// Buffered payload (control frames only); `None` streams from the wire.
+    buffered: Option<Vec<u8>>,
+}
+
+/// An established WebSocket connection retained after the HTTP upgrade.
+///
+/// Created from the stream returned by [`connect_stream`]. Provides
+/// frame-level send/receive with libcurl-compatible semantics (chunked
+/// delivery with [`WsFrameMeta`], automatic PONG replies to PINGs, curl's
+/// inbound validation rules) plus message-level convenience methods.
+pub struct WsConnection {
+    stream: BoxedWsTransport,
+    response: crate::protocol::http::response::Response,
+    auto_pong: bool,
+    raw_mode: bool,
+    /// Inbound frame currently being delivered in chunks.
+    recv_frame: Option<RecvFrame>,
+    /// Flags of the fragmented message in progress (0 = none), mirroring
+    /// curl's decoder `cont_flags` state.
+    recv_cont_flags: u32,
+    /// Whether an outbound fragmented message is in progress.
+    send_cont: bool,
+    /// Total complete frames received (including control frames).
+    frames_received: u64,
+    /// Metadata of the most recent chunk returned by [`recv`](Self::recv).
+    last_meta: WsFrameMeta,
+}
+
+impl std::fmt::Debug for WsConnection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WsConnection")
+            .field("status", &self.response.status())
+            .field("auto_pong", &self.auto_pong)
+            .field("raw_mode", &self.raw_mode)
+            .field("frames_received", &self.frames_received)
+            .finish_non_exhaustive()
+    }
+}
+
+impl WsConnection {
+    /// Wrap an upgraded transport stream in a WebSocket connection.
+    ///
+    /// `options` is a bitmask of [`ws_options`] flags.
+    #[must_use]
+    pub fn new(
+        stream: BoxedWsTransport,
+        response: crate::protocol::http::response::Response,
+        options: u32,
+    ) -> Self {
+        Self {
+            stream,
+            response,
+            auto_pong: options & ws_options::NO_AUTO_PONG == 0,
+            raw_mode: options & ws_options::RAW_MODE != 0,
+            recv_frame: None,
+            recv_cont_flags: 0,
+            send_cont: false,
+            frames_received: 0,
+            last_meta: WsFrameMeta::default(),
+        }
+    }
+
+    /// The HTTP handshake response that established this connection.
+    #[must_use]
+    pub const fn response(&self) -> &crate::protocol::http::response::Response {
+        &self.response
+    }
+
+    /// Metadata of the most recent chunk returned by [`recv`](Self::recv).
+    #[must_use]
+    pub const fn last_meta(&self) -> &WsFrameMeta {
+        &self.last_meta
+    }
+
+    /// Total complete frames received so far (including control frames).
+    #[must_use]
+    pub const fn frames_received(&self) -> u64 {
+        self.frames_received
+    }
+
+    /// Send one WebSocket frame (or message fragment).
+    ///
+    /// `flags` is a combination of [`ws_flags`] bits with libcurl
+    /// `curl_ws_send` semantics: `TEXT`/`BINARY` send an unfragmented
+    /// message, `TEXT | CONT` starts or continues a fragmented message, and
+    /// a final call without `CONT` finishes it. Control frames (`PING`,
+    /// `PONG`, `CLOSE`) must not carry `CONT` and are limited to 125
+    /// payload bytes. In raw mode (`flags == 0` required) the payload is
+    /// written to the wire verbatim.
+    ///
+    /// Returns the number of payload bytes consumed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error on invalid flag combinations (maps to
+    /// `CURLE_BAD_FUNCTION_ARGUMENT`), oversized control payloads (maps to
+    /// `CURLE_TOO_LARGE`), or write failures.
+    pub async fn send(&mut self, payload: &[u8], flags: u32) -> Result<usize, Error> {
+        const FIN: u8 = 0x80;
+
+        if self.raw_mode {
+            if flags != 0 {
+                return Err(Error::Transfer {
+                    code: 43, // CURLE_BAD_FUNCTION_ARGUMENT
+                    message: "WebSocket raw mode does not accept frame flags".to_string(),
+                });
+            }
+            self.stream.write_all(payload).await.map_err(|e| ws_send_io_error(&e))?;
+            self.stream.flush().await.map_err(|e| ws_send_io_error(&e))?;
+            return Ok(payload.len());
+        }
+
+        let is_control = flags & (ws_flags::PING | ws_flags::PONG | ws_flags::CLOSE) != 0;
+        if is_control && payload.len() > 125 {
+            return Err(Error::Transfer {
+                code: 100, // CURLE_TOO_LARGE
+                message: "WebSocket control frame payload exceeds 125 bytes".to_string(),
+            });
+        }
+
+        // Map flags to the frame first byte, mirroring curl's
+        // ws_frame_flags2firstbyte() (lib/ws.c).
+        let (first_byte, next_send_cont) = match flags & !ws_flags::OFFSET {
+            // Final continuation fragment; curl leaves its contfragment
+            // state unchanged here (it only updates on TEXT/BINARY flags).
+            0 if self.send_cont => (FIN, self.send_cont),
+            f if f == ws_flags::CONT && self.send_cont => (0x00, true),
+            f if f == ws_flags::TEXT => {
+                if self.send_cont {
+                    (FIN, false)
+                } else {
+                    (FIN | 0x01, false)
+                }
+            }
+            f if f == ws_flags::TEXT | ws_flags::CONT => {
+                if self.send_cont {
+                    (0x00, true)
+                } else {
+                    (0x01, true)
+                }
+            }
+            f if f == ws_flags::BINARY => {
+                if self.send_cont {
+                    (FIN, false)
+                } else {
+                    (FIN | 0x02, false)
+                }
+            }
+            f if f == ws_flags::BINARY | ws_flags::CONT => {
+                if self.send_cont {
+                    (0x00, true)
+                } else {
+                    (0x02, true)
+                }
+            }
+            f if f == ws_flags::CLOSE => (FIN | 0x08, false),
+            f if f == ws_flags::PING => (FIN | 0x09, false),
+            f if f == ws_flags::PONG => (FIN | 0x0A, false),
+            _ => {
+                return Err(Error::Transfer {
+                    code: 43, // CURLE_BAD_FUNCTION_ARGUMENT
+                    message: format!("invalid WebSocket frame flags: {flags:#x}"),
+                });
+            }
+        };
+        // Control frames do not disturb an in-progress fragmented send.
+        if !is_control {
+            self.send_cont = next_send_cont;
+        }
+
+        let encoded = encode_frame_bytes(first_byte, payload);
+        self.stream.write_all(&encoded).await.map_err(|e| ws_send_io_error(&e))?;
+        self.stream.flush().await.map_err(|e| ws_send_io_error(&e))?;
+        Ok(payload.len())
+    }
+
+    /// Send an unfragmented text message.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the write fails.
+    pub async fn send_text(&mut self, text: &str) -> Result<(), Error> {
+        let _n = self.send(text.as_bytes(), ws_flags::TEXT).await?;
+        Ok(())
+    }
+
+    /// Send an unfragmented binary message.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the write fails.
+    pub async fn send_binary(&mut self, data: &[u8]) -> Result<(), Error> {
+        let _n = self.send(data, ws_flags::BINARY).await?;
+        Ok(())
+    }
+
+    /// Send a ping frame.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the write fails.
+    pub async fn send_ping(&mut self, data: &[u8]) -> Result<(), Error> {
+        let _n = self.send(data, ws_flags::PING).await?;
+        Ok(())
+    }
+
+    /// Send a pong frame.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the write fails.
+    pub async fn send_pong(&mut self, data: &[u8]) -> Result<(), Error> {
+        let _n = self.send(data, ws_flags::PONG).await?;
+        Ok(())
+    }
+
+    /// Send a close frame with a status code and reason.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the write fails.
+    pub async fn send_close(&mut self, code: u16, reason: &str) -> Result<(), Error> {
+        let mut payload = Vec::with_capacity(2 + reason.len());
+        payload.extend_from_slice(&code.to_be_bytes());
+        payload.extend_from_slice(reason.as_bytes());
+        let _n = self.send(&payload, ws_flags::CLOSE).await?;
+        Ok(())
+    }
+
+    /// Receive the next chunk of WebSocket payload data.
+    ///
+    /// Fills `buf` with up to one frame's worth of payload bytes and returns
+    /// the byte count plus frame metadata, with libcurl `curl_ws_recv`
+    /// semantics: large frames are delivered across multiple calls (tracked
+    /// via [`WsFrameMeta::offset`]/[`WsFrameMeta::bytesleft`]), PING frames
+    /// are answered with a PONG and never surfaced (unless auto-pong is
+    /// disabled), and zero-length frames produce one zero-length chunk.
+    /// Returns `Ok(None)` when the server has closed the connection at a
+    /// frame boundary (libcurl: `CURLE_GOT_NOTHING`).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error on protocol violations (masked server frames,
+    /// oversized or fragmented control frames, reserved bits or opcodes,
+    /// stray continuations) and on read failures.
+    pub async fn recv(&mut self, buf: &mut [u8]) -> Result<Option<(usize, WsFrameMeta)>, Error> {
+        loop {
+            // Continue delivering the frame in progress. Data-frame payloads
+            // stream straight from the wire into the caller's buffer, so a
+            // frame's declared length never drives an allocation.
+            if let Some(ref mut cur) = self.recv_frame {
+                let remaining = cur.total - cur.delivered;
+                let n = if let Some(ref payload) = cur.buffered {
+                    // Buffered control-frame payload (<= 125 bytes).
+                    #[allow(clippy::cast_possible_truncation)]
+                    let start = cur.delivered as usize;
+                    let n = (payload.len() - start).min(buf.len());
+                    buf[..n].copy_from_slice(&payload[start..start + n]);
+                    n
+                } else {
+                    #[allow(clippy::cast_possible_truncation)]
+                    let want = remaining.min(buf.len() as u64) as usize;
+                    if want == 0 {
+                        0
+                    } else {
+                        let n = self
+                            .stream
+                            .read(&mut buf[..want])
+                            .await
+                            .map_err(|e| Error::Http(format!("WebSocket read error: {e}")))?;
+                        if n == 0 {
+                            // Connection closed mid-frame: curl treats any
+                            // EOF as the normal end of the websocket data
+                            // (CURLE_GOT_NOTHING in connect-only mode).
+                            self.recv_frame = None;
+                            return Ok(None);
+                        }
+                        n
+                    }
+                };
+                let meta = WsFrameMeta {
+                    flags: cur.flags,
+                    offset: cur.delivered,
+                    bytesleft: remaining - n as u64,
+                    len: n,
+                };
+                cur.delivered += n as u64;
+                if cur.delivered >= cur.total {
+                    self.recv_frame = None;
+                }
+                self.last_meta = meta;
+                return Ok(Some((n, meta)));
+            }
+
+            // Read the next frame header from the wire.
+            let Some((first_byte, payload_len)) = self.read_frame_header().await? else {
+                return Ok(None);
+            };
+            self.frames_received += 1;
+
+            let flags = self.first_byte_to_flags(first_byte)?;
+
+            if first_byte & 0x0F >= 0x8 {
+                // Control frame: the payload is at most 125 bytes (already
+                // validated), so read it fully — PINGs are answered with
+                // their exact payload.
+                #[allow(clippy::cast_possible_truncation)]
+                let mut payload = vec![0u8; payload_len as usize];
+                match self.stream.read_exact(&mut payload).await {
+                    Ok(_) => {}
+                    // EOF is the normal end of the websocket data (curl compat).
+                    Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+                    Err(e) => return Err(Error::Http(format!("WebSocket read error: {e}"))),
+                }
+
+                // Auto-reply to PING with an identical-payload PONG; the
+                // PING is never surfaced to the caller (curl compat).
+                if flags == ws_flags::PING && self.auto_pong {
+                    let _n = self.send(&payload, ws_flags::PONG).await?;
+                    continue;
+                }
+                self.recv_frame = Some(RecvFrame {
+                    flags,
+                    total: payload_len,
+                    delivered: 0,
+                    buffered: Some(payload),
+                });
+                continue;
+            }
+
+            // Data frame: update the fragmented-message state machine; the
+            // payload streams to the caller from the wire.
+            self.recv_cont_flags = if flags & ws_flags::CONT == 0 { 0 } else { flags };
+            self.recv_frame =
+                Some(RecvFrame { flags, total: payload_len, delivered: 0, buffered: None });
+        }
+    }
+
+    /// Receive and reassemble one complete WebSocket message.
+    ///
+    /// Fragmented text/binary messages are reassembled; control frames are
+    /// returned as their own [`Message`] values. PING frames are auto-ponged
+    /// and not returned unless auto-pong is disabled.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error on protocol violations, read failures, or if the
+    /// connection closes mid-message. A clean connection close at a message
+    /// boundary yields `Error::Transfer` with code 52 (`CURLE_GOT_NOTHING`).
+    pub async fn recv_message(&mut self) -> Result<Message, Error> {
+        let mut assembled: Vec<u8> = Vec::new();
+        let mut msg_flags: u32 = 0;
+        let mut mid_message = false;
+        let mut buf = vec![0u8; 65536];
+        loop {
+            let Some((n, meta)) = self.recv(&mut buf).await? else {
+                return Err(Error::Transfer {
+                    code: 52, // CURLE_GOT_NOTHING
+                    message: "WebSocket connection closed".to_string(),
+                });
+            };
+            if meta.flags & ws_flags::CLOSE != 0 {
+                let payload = &buf[..n];
+                let code =
+                    (payload.len() >= 2).then(|| u16::from_be_bytes([payload[0], payload[1]]));
+                let reason = (payload.len() > 2)
+                    .then(|| String::from_utf8_lossy(&payload[2..]).into_owned());
+                return Ok(Message::Close(code, reason));
+            }
+            if meta.flags & (ws_flags::PING | ws_flags::PONG) != 0 {
+                // A control frame interleaved inside a fragmented message
+                // must not discard the fragments assembled so far — skip it
+                // and keep assembling.
+                if mid_message {
+                    continue;
+                }
+                if meta.flags & ws_flags::PING != 0 {
+                    return Ok(Message::Ping(buf[..n].to_vec()));
+                }
+                return Ok(Message::Pong(buf[..n].to_vec()));
+            }
+            mid_message = true;
+            assembled.extend_from_slice(&buf[..n]);
+            if meta.flags & (ws_flags::TEXT | ws_flags::BINARY) != 0 {
+                msg_flags = meta.flags;
+            }
+            // Message complete when the frame is fully delivered and it was
+            // a final (non-CONT) data frame.
+            if meta.bytesleft == 0 && meta.flags & ws_flags::CONT == 0 {
+                if msg_flags & ws_flags::TEXT != 0 {
+                    return String::from_utf8(assembled)
+                        .map(Message::Text)
+                        .map_err(|e| Error::Http(format!("invalid UTF-8 in text message: {e}")));
+                }
+                return Ok(Message::Binary(assembled));
+            }
+        }
+    }
+
+    /// Read one frame header from the wire: `(first_byte, payload_len)`.
+    ///
+    /// Returns `Ok(None)` on a clean connection close at a frame boundary.
+    /// Applies curl's inbound validation rules. The payload is NOT read —
+    /// it is streamed (data frames) or read separately (control frames).
+    async fn read_frame_header(&mut self) -> Result<Option<(u8, u64)>, Error> {
+        // First header byte: EOF here is a clean close.
+        let mut first = [0u8; 1];
+        let n = self
+            .stream
+            .read(&mut first)
+            .await
+            .map_err(|e| Error::Http(format!("WebSocket read error: {e}")))?;
+        if n == 0 {
+            return Ok(None);
+        }
+        let first_byte = first[0];
+
+        let mut second = [0u8; 1];
+        match self.stream.read_exact(&mut second).await {
+            Ok(_) => {}
+            // EOF is the normal end of the websocket data (curl compat).
+            Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+            Err(e) => return Err(Error::Http(format!("WebSocket read error: {e}"))),
+        }
+
+        // Server-to-client frames must not be masked (curl compat: rejected
+        // with CURLE_RECV_ERROR).
+        if second[0] & 0x80 != 0 {
+            return Err(Error::Http("WebSocket: received masked frame from server".to_string()));
+        }
+
+        // Control frames (opcode >= 0x8) must be unfragmented and small
+        // enough to declare their length in the 7-bit field. Like curl, the
+        // check is on the raw length byte, so extended-length encodings
+        // (126/127) are rejected for control frames even when the actual
+        // length would fit.
+        let opcode = first_byte & 0x0F;
+        let len7 = second[0] & 0x7F;
+        if opcode >= 0x8 {
+            if len7 > 125 {
+                return Err(Error::Http(
+                    "WebSocket: control frame payload exceeds 125 bytes".to_string(),
+                ));
+            }
+            if first_byte & 0x80 == 0 {
+                return Err(Error::Http("WebSocket: fragmented control frame".to_string()));
+            }
+        }
+
+        let payload_len = match len7 {
+            126 => {
+                let mut ext = [0u8; 2];
+                match self.stream.read_exact(&mut ext).await {
+                    Ok(_) => {}
+                    Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+                    Err(e) => return Err(Error::Http(format!("WebSocket read error: {e}"))),
+                }
+                u64::from(u16::from_be_bytes(ext))
+            }
+            127 => {
+                let mut ext = [0u8; 8];
+                match self.stream.read_exact(&mut ext).await {
+                    Ok(_) => {}
+                    Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+                    Err(e) => return Err(Error::Http(format!("WebSocket read error: {e}"))),
+                }
+                let len = u64::from_be_bytes(ext);
+                if len > i64::MAX as u64 {
+                    return Err(Error::Http("WebSocket: frame length too large".to_string()));
+                }
+                len
+            }
+            len => u64::from(len),
+        };
+
+        Ok(Some((first_byte, payload_len)))
+    }
+
+    /// Map a frame first byte to [`ws_flags`] bits, mirroring curl's
+    /// `ws_frame_firstbyte2flags()` validation (lib/ws.c).
+    fn first_byte_to_flags(&self, first_byte: u8) -> Result<u32, Error> {
+        const FIN: u8 = 0x80;
+        let cont = self.recv_cont_flags;
+        let flags = match first_byte {
+            // Intermediate fragment of a TEXT/BINARY message.
+            0x00 => {
+                if cont & ws_flags::CONT == 0 {
+                    return Err(Error::Http(
+                        "WebSocket: no ongoing fragmented message to resume".to_string(),
+                    ));
+                }
+                cont | ws_flags::CONT
+            }
+            // Final fragment.
+            0x80 => {
+                if cont & ws_flags::CONT == 0 {
+                    return Err(Error::Http(
+                        "WebSocket: no ongoing fragmented message to resume".to_string(),
+                    ));
+                }
+                cont & !ws_flags::CONT
+            }
+            0x01 | 0x02 => {
+                if cont & ws_flags::CONT != 0 {
+                    return Err(Error::Http(
+                        "WebSocket: fragmented message interrupted by new message".to_string(),
+                    ));
+                }
+                let base = if first_byte == 0x01 { ws_flags::TEXT } else { ws_flags::BINARY };
+                base | ws_flags::CONT
+            }
+            b if b == FIN | 0x01 || b == FIN | 0x02 => {
+                if cont & ws_flags::CONT != 0 {
+                    return Err(Error::Http(
+                        "WebSocket: fragmented message interrupted by new message".to_string(),
+                    ));
+                }
+                if b == FIN | 0x01 {
+                    ws_flags::TEXT
+                } else {
+                    ws_flags::BINARY
+                }
+            }
+            b if b == FIN | 0x08 => ws_flags::CLOSE,
+            b if b == FIN | 0x09 => ws_flags::PING,
+            b if b == FIN | 0x0A => ws_flags::PONG,
+            b => {
+                let detail = if b & 0x70 != 0 { "reserved bits" } else { "invalid opcode" };
+                return Err(Error::Http(format!("WebSocket: {detail} in frame: {b:#04x}")));
+            }
+        };
+        Ok(flags)
+    }
+}
+
+/// Map a send-side I/O failure (maps to `CURLE_SEND_ERROR`).
+fn ws_send_io_error(e: &std::io::Error) -> Error {
+    Error::Transfer {
+        code: 55, // CURLE_SEND_ERROR
+        message: format!("WebSocket write error: {e}"),
+    }
+}
+
+/// Encode a client frame (header + masked payload) for the wire.
+///
+/// The mask key honors `CURL_ENTROPY` and `CURL_WS_FORCE_ZERO_MASK`.
+fn encode_frame_bytes(first_byte: u8, payload: &[u8]) -> Vec<u8> {
+    let mut buf = encode_raw_frame_header_masked(first_byte, payload.len(), true);
+    let mask_key = generate_mask_key();
+    buf.extend_from_slice(&mask_key);
+    for (i, &byte) in payload.iter().enumerate() {
+        buf.push(byte ^ mask_key[i % 4]);
+    }
+    buf
+}
+
+/// Encode a frame header with the given first byte, length, and mask bit.
+fn encode_raw_frame_header_masked(first_byte: u8, len: usize, mask: bool) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(14);
+    buf.push(first_byte);
+    let mask_bit: u8 = if mask { 0x80 } else { 0x00 };
+    if len < 126 {
+        #[allow(clippy::cast_possible_truncation)]
+        buf.push(mask_bit | len as u8);
+    } else if len <= 65535 {
+        buf.push(mask_bit | 0x7E);
+        #[allow(clippy::cast_possible_truncation)]
+        {
+            buf.push((len >> 8) as u8);
+            buf.push(len as u8);
+        }
+    } else {
+        buf.push(mask_bit | 0x7F);
+        for i in (0..8).rev() {
+            #[allow(clippy::cast_possible_truncation)]
+            buf.push((len >> (i * 8)) as u8);
+        }
+    }
+    buf
+}
+
+/// Perform a complete curl-style WebSocket transfer (the default CLI mode).
+///
+/// Performs the upgrade handshake, optionally sends `upload` data as masked
+/// BINARY frames, then receives frames until the server closes the
+/// connection. Payload bytes of TEXT, BINARY, PONG, and CLOSE frames are
+/// collected as the response body (curl writes them to stdout); PINGs are
+/// answered automatically and never surfaced. The transfer does not stop at
+/// a CLOSE frame — it ends when the server closes the connection.
+///
+/// # Errors
+///
+/// Returns `Error::Transfer` with code 22 (`CURLE_HTTP_RETURNED_ERROR`)
+/// when the server refuses the upgrade, code 52 (`CURLE_GOT_NOTHING`) when
+/// the connection closes without a single frame after the 101 (curl compat:
+/// test 2300), and protocol/IO errors otherwise.
+pub async fn transfer(
+    url: &crate::url::Url,
+    headers: &[(String, String)],
+    tls_config: &crate::tls::TlsConfig,
+    upload: Option<&[u8]>,
+    deadline: Option<tokio::time::Instant>,
+    options: &WsConnectOptions<'_>,
+) -> Result<crate::protocol::http::response::Response, Error> {
+    let handshake = async { connect_stream(url, headers, tls_config, options).await };
+    let (response, stream) = match deadline {
+        Some(d) => tokio::time::timeout_at(d, handshake)
+            .await
+            .map_err(|_| Error::Timeout(std::time::Duration::from_secs(0)))??,
+        None => handshake.await?,
+    };
+
+    if response.status() != 101 {
+        return Err(Error::Transfer {
+            code: 22, // CURLE_HTTP_RETURNED_ERROR
+            message: format!("Refused WebSocket upgrade: {}", response.status()),
+        });
+    }
+
+    let mut conn = WsConnection::new(stream, response.clone(), 0);
+
+    // Send upload data as unfragmented BINARY frames, one per 64 KiB chunk
+    // (curl sends one frame per read-callback chunk).
+    if let Some(data) = upload {
+        for chunk in data.chunks(65536) {
+            if chunk.is_empty() {
+                continue;
+            }
+            let _n = conn.send(chunk, ws_flags::BINARY).await?;
+        }
+    }
+
+    // Receive until the server closes the connection.
+    let mut body: Vec<u8> = Vec::new();
+    let mut buf = vec![0u8; 65536];
+    loop {
+        let read = conn.recv(&mut buf);
+        let result = match deadline {
+            Some(d) => tokio::time::timeout_at(d, read)
+                .await
+                .map_err(|_| Error::Timeout(std::time::Duration::from_secs(0)))?,
+            None => read.await,
+        };
+        match result? {
+            Some((n, _meta)) => {
+                // TEXT/BINARY/PONG/CLOSE payloads all flow to the body; the
+                // CLOSE payload includes its 2-byte status code (curl compat).
+                body.extend_from_slice(&buf[..n]);
+            }
+            None => break,
+        }
+    }
+
+    // Server closed right after the 101 without a single frame: curl deducts
+    // the 1xx header bytes and reports an empty reply (curl compat: test
+    // 2300 expects exit code 52).
+    if conn.frames_received() == 0 {
+        return Err(Error::Transfer {
+            code: 52, // CURLE_GOT_NOTHING
+            message: "Empty reply from server".to_string(),
+        });
+    }
+
+    Ok(crate::protocol::http::response::Response::new(
+        response.status(),
+        response.headers().clone(),
+        body,
+        url.as_str().to_string(),
     ))
 }
 
@@ -1545,7 +2515,7 @@ mod tests {
              \r\n"
         );
         let mut cursor = std::io::Cursor::new(response.into_bytes());
-        let resp = parse_upgrade_response(&mut cursor, &accept, "ws://example.com").await.unwrap();
+        let resp = parse_upgrade_response(&mut cursor, "ws://example.com").await.unwrap();
         assert_eq!(resp.status(), 101);
         assert_eq!(resp.header("upgrade"), Some("websocket"));
     }
@@ -1556,23 +2526,23 @@ mod tests {
              Content-Length: 0\r\n\
              \r\n";
         let mut cursor = std::io::Cursor::new(response.to_vec());
-        let resp =
-            parse_upgrade_response(&mut cursor, "ignored", "ws://example.com").await.unwrap();
+        let resp = parse_upgrade_response(&mut cursor, "ws://example.com").await.unwrap();
         assert_eq!(resp.status(), 403);
     }
 
     #[tokio::test]
-    async fn parse_upgrade_response_invalid_accept() {
+    async fn parse_upgrade_response_mismatched_accept_tolerated() {
+        // curl does not validate Sec-WebSocket-Accept (its own test suite
+        // sends mismatched values), so neither do we (curl compat: test 2300).
         let response = b"HTTP/1.1 101 Switching Protocols\r\n\
              Upgrade: websocket\r\n\
              Connection: Upgrade\r\n\
              Sec-WebSocket-Accept: wrong_value\r\n\
              \r\n";
         let mut cursor = std::io::Cursor::new(response.to_vec());
-        let result = parse_upgrade_response(&mut cursor, "correct_value", "ws://example.com").await;
-        assert!(result.is_err());
-        let err_msg = result.unwrap_err().to_string();
-        assert!(err_msg.contains("invalid Sec-WebSocket-Accept"));
+        let resp = parse_upgrade_response(&mut cursor, "ws://example.com").await.unwrap();
+        assert_eq!(resp.status(), 101);
+        assert_eq!(resp.header("sec-websocket-accept"), Some("wrong_value"));
     }
 
     #[tokio::test]

--- a/crates/liburlx/src/proxy/socks.rs
+++ b/crates/liburlx/src/proxy/socks.rs
@@ -219,6 +219,13 @@ pub async fn connect_socks4(
     target_port: u16,
     user_id: &str,
 ) -> Result<TcpStream, Error> {
+    // The SOCKS4 protocol has no user-id length limit, but curl rejects
+    // names over 255 bytes (the SOCKS5 field limit) as likely mistakes or
+    // malicious input (curl compat: test 729).
+    if user_id.len() > 255 {
+        return Err(proxy_err("SOCKS4: user name is too long".to_string()));
+    }
+
     let mut request = Vec::new();
     request.push(0x04); // SOCKS4 version
     request.push(0x01); // CONNECT command

--- a/crates/liburlx/tests/ws_curl_compat.rs
+++ b/crates/liburlx/tests/ws_curl_compat.rs
@@ -1,0 +1,571 @@
+//! Regression tests for recently fixed WebSocket curl-compatibility bugs.
+//!
+//! Each test pins one fix against curl's reference behavior (lib/ws.c and
+//! lib/http.c): handshake header emission (auto-auth marker rewriting,
+//! user-supplied upgrade headers, Connection merging), connect timeouts,
+//! HTTP CONNECT proxy tunneling, curl's fragmented-send quirk for
+//! `flags == 0`, EOF-mid-frame semantics, the raw 7-bit control-frame
+//! length check, and Easy connect-only bookkeeping.
+//!
+//! Conventions follow `ws_e2e.rs`: async tests use `#[tokio::test]` with
+//! tokio mock servers; Easy tests are sync (`Easy::perform` spawns its own
+//! runtime) and use std-thread servers. Every await is wrapped in a timeout
+//! so a bug cannot hang CI.
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    unused_results,
+    clippy::significant_drop_tightening
+)]
+
+use std::time::Duration;
+
+use liburlx::protocol::ws::{connect_stream, transfer, ws_flags, WsConnectOptions, WsConnection};
+use liburlx::{Error, TlsConfig, Url};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+/// Upper bound on every await so a bug cannot hang CI.
+const TIMEOUT: Duration = Duration::from_secs(10);
+
+/// A minimal 101 upgrade response (curl's test servers do not send a valid
+/// `Sec-WebSocket-Accept` either; curl skips validating it).
+const HANDSHAKE_101: &[u8] = b"HTTP/1.1 101 Switching Protocols\r\n\
+    Upgrade: websocket\r\n\
+    Connection: Upgrade\r\n\
+    Sec-WebSocket-Accept: HkPsVga7+8LuxM4RGQ5p9tZHeYs=\r\n\r\n";
+
+// --- Helpers ---
+
+/// Await `fut` with the standard test timeout.
+async fn within<T, F: std::future::Future<Output = T>>(fut: F) -> T {
+    tokio::time::timeout(TIMEOUT, fut).await.expect("test future timed out")
+}
+
+/// URL for the mock server on `port`.
+fn test_url(port: u16) -> Url {
+    Url::parse(&format!("ws://127.0.0.1:{port}/test")).unwrap()
+}
+
+/// Read one HTTP request (upgrade or CONNECT) through the terminating blank
+/// line so no request bytes are mistaken for later data.
+async fn read_request(stream: &mut TcpStream) -> Vec<u8> {
+    let mut request = Vec::new();
+    let mut byte = [0u8; 1];
+    loop {
+        let n = tokio::time::timeout(TIMEOUT, stream.read(&mut byte))
+            .await
+            .expect("request read timed out")
+            .unwrap();
+        assert!(n > 0, "client closed before completing the request");
+        request.push(byte[0]);
+        if request.ends_with(b"\r\n\r\n") {
+            break;
+        }
+    }
+    request
+}
+
+/// Spawn a one-connection mock server. The upgrade request is consumed
+/// before `script` receives the socket; dropping the socket ends the
+/// connection. Returns the listening port and the script's output handle.
+async fn spawn_server<F, Fut, T>(script: F) -> (u16, tokio::task::JoinHandle<T>)
+where
+    F: FnOnce(TcpStream) -> Fut + Send + 'static,
+    Fut: std::future::Future<Output = T> + Send,
+    T: Send + 'static,
+{
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let handle = tokio::spawn(async move {
+        let (mut stream, _addr) = tokio::time::timeout(TIMEOUT, listener.accept())
+            .await
+            .expect("accept timed out")
+            .unwrap();
+        let _request = read_request(&mut stream).await;
+        script(stream).await
+    });
+    (port, handle)
+}
+
+/// Spawn a one-connection server that captures the client's upgrade request,
+/// replies with a plain 101, and returns the captured request bytes.
+async fn spawn_capture_server() -> (u16, tokio::task::JoinHandle<Vec<u8>>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let handle = tokio::spawn(async move {
+        let (mut stream, _addr) = tokio::time::timeout(TIMEOUT, listener.accept())
+            .await
+            .expect("accept timed out")
+            .unwrap();
+        let request = read_request(&mut stream).await;
+        stream.write_all(HANDSHAKE_101).await.unwrap();
+        request
+    });
+    (port, handle)
+}
+
+/// XOR `payload` in place with a 4-byte client mask key.
+fn unmask(mask: [u8; 4], payload: &mut [u8]) {
+    for (i, byte) in payload.iter_mut().enumerate() {
+        *byte ^= mask[i % 4];
+    }
+}
+
+/// Build an unmasked server-to-client frame.
+fn server_frame(first_byte: u8, payload: &[u8]) -> Vec<u8> {
+    let mut buf = vec![first_byte];
+    match payload.len() {
+        n if n < 126 => buf.push(u8::try_from(n).unwrap()),
+        n if n <= 65535 => {
+            buf.push(126);
+            buf.extend_from_slice(&u16::try_from(n).unwrap().to_be_bytes());
+        }
+        n => {
+            buf.push(127);
+            buf.extend_from_slice(&u64::try_from(n).unwrap().to_be_bytes());
+        }
+    }
+    buf.extend_from_slice(payload);
+    buf
+}
+
+/// Read one masked client frame server-side: `(first_byte, unmasked payload)`.
+async fn read_client_frame(stream: &mut TcpStream) -> (u8, Vec<u8>) {
+    let mut header = [0u8; 2];
+    stream.read_exact(&mut header).await.unwrap();
+    assert_eq!(header[1] & 0x80, 0x80, "client frames must be masked (RFC 6455)");
+    let mut len = u64::from(header[1] & 0x7F);
+    if len == 126 {
+        let mut ext = [0u8; 2];
+        stream.read_exact(&mut ext).await.unwrap();
+        len = u64::from(u16::from_be_bytes(ext));
+    } else if len == 127 {
+        let mut ext = [0u8; 8];
+        stream.read_exact(&mut ext).await.unwrap();
+        len = u64::from_be_bytes(ext);
+    }
+    let mut mask = [0u8; 4];
+    stream.read_exact(&mut mask).await.unwrap();
+    let mut payload = vec![0u8; usize::try_from(len).unwrap()];
+    stream.read_exact(&mut payload).await.unwrap();
+    unmask(mask, &mut payload);
+    (header[0], payload)
+}
+
+/// Open a `WsConnection` to the mock server on `port` with default options.
+async fn ws_connection(port: u16) -> WsConnection {
+    let (response, stream) = within(connect_stream(
+        &test_url(port),
+        &[],
+        &TlsConfig::default(),
+        &WsConnectOptions::default(),
+    ))
+    .await
+    .unwrap();
+    assert_eq!(response.status(), 101);
+    WsConnection::new(stream, response, 0)
+}
+
+/// Destructure an `Error::Transfer` into its code and message.
+fn transfer_error(err: &Error) -> (u32, &str) {
+    match err {
+        Error::Transfer { code, message } => (*code, message.as_str()),
+        other => unreachable!("expected Error::Transfer, got: {other:?}"),
+    }
+}
+
+/// Count non-overlapping occurrences of `needle` in `haystack`.
+fn count_occurrences(haystack: &str, needle: &str) -> usize {
+    haystack.matches(needle).count()
+}
+
+// --- Handshake: the internal auto-auth marker never reaches the wire ---
+
+#[tokio::test]
+async fn auth_marker_rewritten() {
+    let (port, server) = spawn_capture_server().await;
+
+    let headers = [("_auto_Authorization".to_string(), "Basic dXNlcjpwYXNz".to_string())];
+    let (response, _stream) = within(connect_stream(
+        &test_url(port),
+        &headers,
+        &TlsConfig::default(),
+        &WsConnectOptions::default(),
+    ))
+    .await
+    .unwrap();
+    assert_eq!(response.status(), 101);
+
+    let request = String::from_utf8(within(server).await.unwrap()).unwrap();
+    assert!(
+        request.contains("\r\nAuthorization: Basic dXNlcjpwYXNz\r\n"),
+        "auto-generated credentials must be sent as a real Authorization \
+         header:\n{request}"
+    );
+    assert!(
+        !request.contains("_auto_Authorization"),
+        "the internal marker name must never reach the wire:\n{request}"
+    );
+}
+
+// --- Handshake: user-supplied upgrade headers override the generated ones ---
+
+#[tokio::test]
+async fn user_handshake_header_overrides() {
+    let (port, server) = spawn_capture_server().await;
+
+    let headers = [
+        ("Sec-WebSocket-Key".to_string(), "dGhlIHNhbXBsZSBub25jZQ==".to_string()),
+        ("Upgrade".to_string(), "custom-proto".to_string()),
+        ("Sec-WebSocket-Version".to_string(), "14".to_string()),
+        ("Connection".to_string(), "keep-alive".to_string()),
+    ];
+    let (response, _stream) = within(connect_stream(
+        &test_url(port),
+        &headers,
+        &TlsConfig::default(),
+        &WsConnectOptions::default(),
+    ))
+    .await
+    .unwrap();
+    assert_eq!(response.status(), 101);
+
+    let request = String::from_utf8(within(server).await.unwrap()).unwrap();
+
+    // The pinned key is used verbatim and no second key is generated.
+    assert!(
+        request.contains("\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"),
+        "the user-pinned key must be sent verbatim:\n{request}"
+    );
+    assert_eq!(
+        count_occurrences(&request, "Sec-WebSocket-Key:"),
+        1,
+        "exactly one Sec-WebSocket-Key line:\n{request}"
+    );
+
+    // Custom Upgrade replaces the generated `Upgrade: websocket`.
+    assert!(
+        request.contains("\r\nUpgrade: custom-proto\r\n"),
+        "custom Upgrade value must be sent:\n{request}"
+    );
+    assert_eq!(
+        count_occurrences(&request, "\r\nUpgrade:"),
+        1,
+        "exactly one Upgrade line:\n{request}"
+    );
+
+    // Custom version replaces the generated `Sec-WebSocket-Version: 13`.
+    assert!(
+        request.contains("\r\nSec-WebSocket-Version: 14\r\n"),
+        "custom Sec-WebSocket-Version must be sent:\n{request}"
+    );
+    assert_eq!(
+        count_occurrences(&request, "Sec-WebSocket-Version:"),
+        1,
+        "exactly one Sec-WebSocket-Version line:\n{request}"
+    );
+
+    // curl merges a custom Connection value with Upgrade and emits it last
+    // (curl compat: http_add_connection_hd in lib/http.c).
+    assert!(
+        request.ends_with("Connection: keep-alive, Upgrade\r\n\r\n"),
+        "the request must end with the merged Connection header:\n{request}"
+    );
+    assert_eq!(
+        request.matches("Connection:").count(),
+        1,
+        "exactly one Connection header (curl merges the custom value)"
+    );
+}
+
+// --- Handshake: --connect-timeout covers the TCP connect ---
+
+#[tokio::test]
+async fn connect_timeout_applies() {
+    // 10.255.255.1:81 is a blackhole for the SYN on typical networks: the
+    // connect attempt hangs until the configured timeout fires.
+    let url = Url::parse("ws://10.255.255.1:81/").unwrap();
+    let options = WsConnectOptions {
+        connect_timeout: Some(Duration::from_millis(300)),
+        ..WsConnectOptions::default()
+    };
+
+    let start = std::time::Instant::now();
+    let result = within(connect_stream(&url, &[], &TlsConfig::default(), &options)).await;
+    let elapsed = start.elapsed();
+    let Err(err) = result else { unreachable!("connect to a blackhole address must not succeed") };
+
+    assert!(matches!(err, Error::Timeout(_)), "expected Error::Timeout, got: {err:?}");
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "300ms connect timeout must fire well under 10s, took {elapsed:?}"
+    );
+}
+
+// --- Handshake: HTTP CONNECT proxy tunnel with proxy auth ---
+
+#[tokio::test]
+async fn http_connect_proxy_tunnel() {
+    // Reserve a target port with nothing listening on it: all traffic must
+    // flow through the proxy, never to the target directly.
+    let fake_target_port = {
+        let reserved = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        reserved.local_addr().unwrap().port()
+    };
+
+    let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let proxy_port = proxy_listener.local_addr().unwrap().port();
+
+    let server = tokio::spawn(async move {
+        let (mut stream, _addr) = tokio::time::timeout(TIMEOUT, proxy_listener.accept())
+            .await
+            .expect("proxy accept timed out")
+            .unwrap();
+        // (a) The CONNECT request for the tunnel.
+        let connect_request = read_request(&mut stream).await;
+        // (b) Grant the tunnel.
+        stream.write_all(b"HTTP/1.1 200 Connection established\r\n\r\n").await.unwrap();
+        // (c) Act as the WebSocket server on the same socket.
+        let _upgrade = read_request(&mut stream).await;
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(HANDSHAKE_101);
+        bytes.extend_from_slice(&server_frame(0x81, b"via-proxy"));
+        stream.write_all(&bytes).await.unwrap();
+        connect_request
+    });
+
+    let url = Url::parse(&format!("ws://127.0.0.1:{fake_target_port}/")).unwrap();
+    let proxy_url = Url::parse(&format!("http://127.0.0.1:{proxy_port}")).unwrap();
+    let options = WsConnectOptions {
+        proxy: Some(&proxy_url),
+        proxy_auth: Some(("u", "p")),
+        connect_timeout: None,
+    };
+
+    let (response, stream) =
+        within(connect_stream(&url, &[], &TlsConfig::default(), &options)).await.unwrap();
+    assert_eq!(response.status(), 101);
+
+    let mut conn = WsConnection::new(stream, response, 0);
+    let mut buf = [0u8; 64];
+    let (n, meta) = within(conn.recv(&mut buf)).await.unwrap().expect("tunneled frame");
+    assert_eq!(&buf[..n], b"via-proxy");
+    assert_eq!(meta.flags, ws_flags::TEXT);
+
+    let connect_request = String::from_utf8(within(server).await.unwrap()).unwrap();
+    assert!(
+        connect_request.starts_with(&format!("CONNECT 127.0.0.1:{fake_target_port} HTTP/1.1\r\n")),
+        "tunnel must target the origin host:port:\n{connect_request}"
+    );
+    // base64("u:p") == "dTpw".
+    assert!(
+        connect_request.contains("\r\nProxy-Authorization: Basic dTpw\r\n"),
+        "proxy credentials must be sent on the CONNECT:\n{connect_request}"
+    );
+}
+
+// --- Send: curl's contfragment quirk for flags == 0 ---
+
+#[tokio::test]
+async fn send_cont_flags_zero_curl_quirk() {
+    let (port, server) = spawn_server(|mut stream| async move {
+        stream.write_all(HANDSHAKE_101).await.unwrap();
+        let first = read_client_frame(&mut stream).await;
+        let second = read_client_frame(&mut stream).await;
+        let third = read_client_frame(&mut stream).await;
+        (first, second, third)
+    })
+    .await;
+
+    let mut conn = ws_connection(port).await;
+    assert_eq!(within(conn.send(b"a", ws_flags::TEXT | ws_flags::CONT)).await.unwrap(), 1);
+    assert_eq!(within(conn.send(b"b", 0)).await.unwrap(), 1);
+    // curl's ws_frame_flags2firstbyte() leaves its contfragment state
+    // unchanged for flags == 0, so another flags-0 send emits another final
+    // continuation instead of failing — intentional curl fidelity.
+    assert_eq!(within(conn.send(b"c", 0)).await.unwrap(), 1);
+
+    let ((first_byte, first_payload), (second_byte, second_payload), (third_byte, third_payload)) =
+        within(server).await.unwrap();
+    assert_eq!(first_byte, 0x01, "TEXT|CONT starts a fragmented message (no FIN)");
+    assert_eq!(first_payload, b"a");
+    assert_eq!(second_byte, 0x80, "flags 0 mid-fragmentation sends a FIN continuation");
+    assert_eq!(second_payload, b"b");
+    assert_eq!(
+        third_byte, 0x80,
+        "contfragment state must be unchanged by a flags-0 send (curl quirk)"
+    );
+    assert_eq!(third_payload, b"c");
+}
+
+// --- Recv: EOF mid-frame is a clean close, not an error ---
+
+/// A 101 handshake followed by a TEXT frame declaring 10 payload bytes but
+/// delivering only 3 before the connection closes.
+fn truncated_frame_bytes() -> Vec<u8> {
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(HANDSHAKE_101);
+    bytes.extend_from_slice(&[0x81, 0x0A]); // FIN TEXT, declared length 10
+    bytes.extend_from_slice(b"abc"); // only 3 of the 10 payload bytes
+    bytes
+}
+
+#[tokio::test]
+async fn eof_mid_frame_is_clean_close() {
+    // WsConnection::recv: the available bytes are delivered first, then the
+    // EOF surfaces as Ok(None) — curl treats any EOF as the normal end of
+    // the websocket data.
+    let (port, server) = spawn_server(|mut stream| async move {
+        stream.write_all(&truncated_frame_bytes()).await.unwrap();
+        stream.shutdown().await.unwrap();
+    })
+    .await;
+
+    let mut conn = ws_connection(port).await;
+    let mut buf = [0u8; 64];
+    let (n, meta) = within(conn.recv(&mut buf)).await.unwrap().expect("partial payload first");
+    assert_eq!(&buf[..n], b"abc");
+    assert_eq!(meta.flags, ws_flags::TEXT);
+    assert_eq!((meta.len, meta.offset, meta.bytesleft), (3, 0, 7));
+
+    assert!(
+        within(conn.recv(&mut buf)).await.unwrap().is_none(),
+        "EOF mid-frame must be a clean close, not an error"
+    );
+    within(server).await.unwrap();
+
+    // transfer() over the same wire bytes: Ok with the 3 bytes as body.
+    let (port, server) = spawn_server(|mut stream| async move {
+        stream.write_all(&truncated_frame_bytes()).await.unwrap();
+        stream.shutdown().await.unwrap();
+    })
+    .await;
+
+    let response = within(transfer(
+        &test_url(port),
+        &[],
+        &TlsConfig::default(),
+        None,
+        None,
+        &WsConnectOptions::default(),
+    ))
+    .await
+    .unwrap();
+    assert_eq!(response.status(), 101);
+    assert_eq!(response.body(), b"abc");
+    within(server).await.unwrap();
+}
+
+// --- Recv: control frames must use the 7-bit length form ---
+
+#[tokio::test]
+async fn control_frame_extended_length_rejected() {
+    // PING declaring its 5-byte payload via the 16-bit extended-length form.
+    // curl validates the raw 7-bit length byte (126 > 125) before decoding
+    // the extension, so this is rejected even though 5 <= 125.
+    let (port, _server) = spawn_server(|mut stream| async move {
+        stream.write_all(HANDSHAKE_101).await.unwrap();
+        stream.write_all(&[0x89, 0x7E, 0x00, 0x05]).await.unwrap();
+        stream.write_all(b"hello").await.unwrap();
+        // Hold the socket open so the failure is the validation, not EOF.
+        let mut sink = [0u8; 16];
+        let _ = stream.read(&mut sink).await;
+    })
+    .await;
+
+    let mut conn = ws_connection(port).await;
+    let mut buf = [0u8; 64];
+    let err = within(conn.recv(&mut buf)).await.unwrap_err();
+    assert!(err.to_string().contains("control frame payload"), "got: {err}");
+}
+
+// --- Easy connect-only (sync; servers on std threads) ---
+
+/// Read the upgrade request from a std stream through the blank line.
+fn read_upgrade_request_sync(stream: &mut std::net::TcpStream) -> Vec<u8> {
+    use std::io::Read as _;
+    let mut request = Vec::new();
+    let mut byte = [0u8; 1];
+    loop {
+        let n = stream.read(&mut byte).unwrap();
+        assert!(n > 0, "client closed before completing the upgrade request");
+        request.push(byte[0]);
+        if request.ends_with(b"\r\n\r\n") {
+            break;
+        }
+    }
+    request
+}
+
+#[test]
+fn refused_upgrade_records_response() {
+    use std::io::Write as _;
+
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let server = std::thread::spawn(move || {
+        let (mut stream, _addr) = listener.accept().unwrap();
+        stream.set_read_timeout(Some(TIMEOUT)).unwrap();
+        read_upgrade_request_sync(&mut stream);
+        stream.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n").unwrap();
+    });
+
+    let mut easy = liburlx::Easy::new();
+    easy.url(&format!("ws://127.0.0.1:{port}/")).unwrap();
+    easy.set_connect_only(2);
+
+    let err = easy.perform().unwrap_err();
+    assert_eq!(transfer_error(&err).0, 22, "CURLE_HTTP_RETURNED_ERROR");
+
+    // The refused handshake response must still be recorded so
+    // CURLINFO_RESPONSE_CODE reflects the 200 (curl compat: test 2303).
+    let last = easy.last_response().expect("refused upgrade must record the response");
+    assert_eq!(last.status(), 200);
+
+    server.join().unwrap();
+}
+
+#[test]
+fn stale_connection_cleared_after_failed_perform() {
+    use std::io::{Read as _, Write as _};
+
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let server = std::thread::spawn(move || {
+        let (mut stream, _addr) = listener.accept().unwrap();
+        stream.set_read_timeout(Some(TIMEOUT)).unwrap();
+        read_upgrade_request_sync(&mut stream);
+        stream.write_all(HANDSHAKE_101).unwrap();
+        // Hold the connection open until the client abandons it.
+        let mut sink = [0u8; 64];
+        let _ = stream.read(&mut sink);
+    });
+
+    let mut easy = liburlx::Easy::new();
+    easy.url(&format!("ws://127.0.0.1:{port}/")).unwrap();
+    easy.set_connect_only(2);
+    let response = easy.perform().unwrap();
+    assert_eq!(response.status(), 101);
+
+    // Re-perform against a port with nothing listening: the perform fails,
+    // and it must also drop the previously retained connection.
+    let closed_port = {
+        let reserved = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        reserved.local_addr().unwrap().port()
+    };
+    easy.url(&format!("ws://127.0.0.1:{closed_port}/")).unwrap();
+    easy.perform().unwrap_err();
+
+    // The old (still open server-side!) connection must not be reachable.
+    let err = easy.ws_send(b"x", ws_flags::TEXT).unwrap_err();
+    assert_eq!(
+        transfer_error(&err).0,
+        55,
+        "CURLE_SEND_ERROR: ws_send must not reuse the superseded connection"
+    );
+
+    drop(easy);
+    server.join().unwrap();
+}

--- a/crates/liburlx/tests/ws_e2e.rs
+++ b/crates/liburlx/tests/ws_e2e.rs
@@ -1,0 +1,719 @@
+//! End-to-end WebSocket connection tests.
+//!
+//! Exercises `connect_stream`, `transfer`, `WsConnection` send/recv, and the
+//! Easy connect-only API against real TCP mock servers, modeled on curl's
+//! WebSocket test scenarios (tests 2300-2304 and the 2700 series).
+//!
+//! The async `WsConnection` tests use `#[tokio::test]` with tokio mock
+//! servers. The Easy tests are sync (`Easy::perform` spawns its own runtime)
+//! and use std-thread servers instead.
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    unused_results,
+    clippy::significant_drop_tightening
+)]
+
+use std::time::Duration;
+
+use liburlx::protocol::ws::{
+    connect_stream, transfer, ws_flags, ws_options, Message, WsConnectOptions, WsConnection,
+};
+use liburlx::{Error, TlsConfig, Url};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+/// Upper bound on every await so a bug cannot hang CI.
+const TIMEOUT: Duration = Duration::from_secs(10);
+
+/// A minimal 101 upgrade response (curl's test servers do not send a valid
+/// `Sec-WebSocket-Accept` either; curl skips validating it).
+const HANDSHAKE_101: &[u8] = b"HTTP/1.1 101 Switching Protocols\r\n\
+    Upgrade: websocket\r\n\
+    Connection: Upgrade\r\n\
+    Sec-WebSocket-Accept: HkPsVga7+8LuxM4RGQ5p9tZHeYs=\r\n\r\n";
+
+// --- Helpers ---
+
+/// Await `fut` with the standard test timeout.
+async fn within<T, F: std::future::Future<Output = T>>(fut: F) -> T {
+    tokio::time::timeout(TIMEOUT, fut).await.expect("test future timed out")
+}
+
+/// URL for the mock server on `port`.
+fn test_url(port: u16) -> Url {
+    Url::parse(&format!("ws://127.0.0.1:{port}/test")).unwrap()
+}
+
+/// Read the client's upgrade request through the terminating blank line so
+/// no request bytes are mistaken for frame data.
+async fn read_upgrade_request(stream: &mut TcpStream) -> Vec<u8> {
+    let mut request = Vec::new();
+    let mut byte = [0u8; 1];
+    loop {
+        let n = tokio::time::timeout(TIMEOUT, stream.read(&mut byte))
+            .await
+            .expect("upgrade request read timed out")
+            .unwrap();
+        assert!(n > 0, "client closed before completing the upgrade request");
+        request.push(byte[0]);
+        if request.ends_with(b"\r\n\r\n") {
+            break;
+        }
+    }
+    request
+}
+
+/// Spawn a one-connection mock server. The upgrade request is consumed
+/// before `script` receives the socket; dropping the socket ends the
+/// connection. Returns the listening port and the script's output handle.
+async fn spawn_server<F, Fut, T>(script: F) -> (u16, tokio::task::JoinHandle<T>)
+where
+    F: FnOnce(TcpStream) -> Fut + Send + 'static,
+    Fut: std::future::Future<Output = T> + Send,
+    T: Send + 'static,
+{
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let handle = tokio::spawn(async move {
+        let (mut stream, _addr) = tokio::time::timeout(TIMEOUT, listener.accept())
+            .await
+            .expect("accept timed out")
+            .unwrap();
+        let _request = read_upgrade_request(&mut stream).await;
+        script(stream).await
+    });
+    (port, handle)
+}
+
+/// XOR `payload` in place with a 4-byte client mask key.
+fn unmask(mask: [u8; 4], payload: &mut [u8]) {
+    for (i, byte) in payload.iter_mut().enumerate() {
+        *byte ^= mask[i % 4];
+    }
+}
+
+/// Build an unmasked server-to-client frame.
+fn server_frame(first_byte: u8, payload: &[u8]) -> Vec<u8> {
+    let mut buf = vec![first_byte];
+    match payload.len() {
+        n if n < 126 => buf.push(u8::try_from(n).unwrap()),
+        n if n <= 65535 => {
+            buf.push(126);
+            buf.extend_from_slice(&u16::try_from(n).unwrap().to_be_bytes());
+        }
+        n => {
+            buf.push(127);
+            buf.extend_from_slice(&u64::try_from(n).unwrap().to_be_bytes());
+        }
+    }
+    buf.extend_from_slice(payload);
+    buf
+}
+
+/// Read one masked client frame server-side: `(first_byte, unmasked payload)`.
+async fn read_client_frame(stream: &mut TcpStream) -> (u8, Vec<u8>) {
+    let mut header = [0u8; 2];
+    stream.read_exact(&mut header).await.unwrap();
+    assert_eq!(header[1] & 0x80, 0x80, "client frames must be masked (RFC 6455)");
+    let mut len = u64::from(header[1] & 0x7F);
+    if len == 126 {
+        let mut ext = [0u8; 2];
+        stream.read_exact(&mut ext).await.unwrap();
+        len = u64::from(u16::from_be_bytes(ext));
+    } else if len == 127 {
+        let mut ext = [0u8; 8];
+        stream.read_exact(&mut ext).await.unwrap();
+        len = u64::from_be_bytes(ext);
+    }
+    let mut mask = [0u8; 4];
+    stream.read_exact(&mut mask).await.unwrap();
+    let mut payload = vec![0u8; usize::try_from(len).unwrap()];
+    stream.read_exact(&mut payload).await.unwrap();
+    unmask(mask, &mut payload);
+    (header[0], payload)
+}
+
+/// Run a curl-style transfer against the mock server on `port`.
+async fn run_transfer(port: u16, upload: Option<&[u8]>) -> Result<liburlx::Response, Error> {
+    within(transfer(
+        &test_url(port),
+        &[],
+        &TlsConfig::default(),
+        upload,
+        None,
+        &WsConnectOptions::default(),
+    ))
+    .await
+}
+
+/// Open a `WsConnection` to the mock server on `port`.
+async fn ws_connection(port: u16, options: u32) -> WsConnection {
+    let (response, stream) = within(connect_stream(
+        &test_url(port),
+        &[],
+        &TlsConfig::default(),
+        &WsConnectOptions::default(),
+    ))
+    .await
+    .unwrap();
+    assert_eq!(response.status(), 101);
+    WsConnection::new(stream, response, options)
+}
+
+/// Destructure an `Error::Transfer` into its code and message.
+fn transfer_error(err: &Error) -> (u32, &str) {
+    match err {
+        Error::Transfer { code, message } => (*code, message.as_str()),
+        other => unreachable!("expected Error::Transfer, got: {other:?}"),
+    }
+}
+
+// --- transfer(): curl test 2700 analog (frame types) ---
+
+#[tokio::test]
+async fn transfer_collects_frame_payloads_and_auto_pongs_ping() {
+    let (port, server) = spawn_server(|mut stream| async move {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(HANDSHAKE_101);
+        bytes.extend_from_slice(&server_frame(0x81, b"txt")); // TEXT
+        bytes.extend_from_slice(&server_frame(0x82, b"bin")); // BINARY
+        bytes.extend_from_slice(&server_frame(0x89, b"ping")); // PING
+        bytes.extend_from_slice(&server_frame(0x8A, b"pong")); // PONG
+        bytes.extend_from_slice(&server_frame(0x88, b"\x03\xe8close")); // CLOSE 1000
+        stream.write_all(&bytes).await.unwrap();
+        // The client must answer the PING with a masked PONG before we
+        // close the connection.
+        read_client_frame(&mut stream).await
+    })
+    .await;
+
+    let response = run_transfer(port, None).await.unwrap();
+    assert_eq!(response.status(), 101);
+
+    // TEXT + BINARY + PONG + CLOSE payloads flow to the body; the PING is
+    // auto-ponged and never surfaced; the CLOSE payload keeps its 2-byte
+    // status code (curl compat: test 2700 stdout).
+    let mut expected = Vec::new();
+    expected.extend_from_slice(b"txt");
+    expected.extend_from_slice(b"bin");
+    expected.extend_from_slice(b"pong");
+    expected.extend_from_slice(b"\x03\xe8close");
+    assert_eq!(response.body(), expected.as_slice());
+
+    let (first_byte, payload) = within(server).await.unwrap();
+    assert_eq!(first_byte, 0x8A, "auto-reply must be an unfragmented PONG");
+    assert_eq!(payload, b"ping", "auto-PONG must echo the PING payload");
+}
+
+// --- transfer(): curl test 2300 analog (close without frames) ---
+
+#[tokio::test]
+async fn transfer_close_after_upgrade_is_empty_reply() {
+    let (port, server) = spawn_server(|mut stream| async move {
+        stream.write_all(HANDSHAKE_101).await.unwrap();
+        stream.shutdown().await.unwrap();
+    })
+    .await;
+
+    let err = run_transfer(port, None).await.unwrap_err();
+    let (code, message) = transfer_error(&err);
+    assert_eq!(code, 52, "CURLE_GOT_NOTHING");
+    assert_eq!(message, "Empty reply from server");
+    within(server).await.unwrap();
+}
+
+// --- transfer(): curl test 2303 analog (200 instead of 101) ---
+
+#[tokio::test]
+async fn transfer_refused_upgrade_reports_http_error() {
+    let (port, server) = spawn_server(|mut stream| async move {
+        stream
+            .write_all(
+                b"HTTP/1.1 200 Oblivious\r\n\
+                  Server: test-server/fake\r\n\
+                  Content-Length: 6\r\n\r\nhello\n",
+            )
+            .await
+            .unwrap();
+        stream.shutdown().await.unwrap();
+    })
+    .await;
+
+    let err = run_transfer(port, None).await.unwrap_err();
+    let (code, message) = transfer_error(&err);
+    assert_eq!(code, 22, "CURLE_HTTP_RETURNED_ERROR");
+    assert!(message.contains("Refused WebSocket upgrade: 200"), "unexpected message: {message}");
+    within(server).await.unwrap();
+}
+
+// --- transfer(): upload data sent as one masked BINARY frame ---
+
+#[tokio::test]
+async fn transfer_upload_sends_masked_binary_frame() {
+    let (port, server) = spawn_server(|mut stream| async move {
+        stream.write_all(HANDSHAKE_101).await.unwrap();
+        let frame = read_client_frame(&mut stream).await;
+        // Send one frame so the transfer does not fail with 52, then close.
+        stream.write_all(&server_frame(0x81, b"ok")).await.unwrap();
+        frame
+    })
+    .await;
+
+    let response = run_transfer(port, Some(b"upload-payload")).await.unwrap();
+    assert_eq!(response.body(), b"ok");
+
+    let (first_byte, payload) = within(server).await.unwrap();
+    assert_eq!(first_byte, 0x82, "upload must go out as an unfragmented BINARY frame");
+    assert_eq!(payload, b"upload-payload");
+}
+
+// --- WsConnection: fragmentation (curl tests 2719/2720 analogs) ---
+
+#[tokio::test]
+async fn recv_reports_fragment_flags_and_recv_message_reassembles() {
+    let (port, server) = spawn_server(|mut stream| async move {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(HANDSHAKE_101);
+        // Message 1: TEXT in five fragments, with empty first, middle, and
+        // last fragments (curl test 2720 exercises empty fragments).
+        bytes.extend_from_slice(&server_frame(0x01, b"")); // TEXT, no FIN
+        bytes.extend_from_slice(&server_frame(0x00, b"Hello")); // CONT
+        bytes.extend_from_slice(&server_frame(0x00, b"")); // empty CONT
+        bytes.extend_from_slice(&server_frame(0x00, b" World")); // CONT
+        bytes.extend_from_slice(&server_frame(0x80, b"")); // final CONT, empty
+                                                           // Message 2: TEXT in three fragments for recv_message reassembly.
+        bytes.extend_from_slice(&server_frame(0x01, b"foo"));
+        bytes.extend_from_slice(&server_frame(0x00, b"bar"));
+        bytes.extend_from_slice(&server_frame(0x80, b"baz"));
+        stream.write_all(&bytes).await.unwrap();
+    })
+    .await;
+
+    let mut conn = ws_connection(port, 0).await;
+    let mut buf = [0u8; 256];
+
+    // Non-final fragments carry TEXT|CONT; the final fragment TEXT alone.
+    let expectations: &[(&[u8], u32)] = &[
+        (b"", ws_flags::TEXT | ws_flags::CONT),
+        (b"Hello", ws_flags::TEXT | ws_flags::CONT),
+        (b"", ws_flags::TEXT | ws_flags::CONT),
+        (b" World", ws_flags::TEXT | ws_flags::CONT),
+        (b"", ws_flags::TEXT),
+    ];
+    for (expected_payload, expected_flags) in expectations {
+        let (n, meta) = within(conn.recv(&mut buf)).await.unwrap().expect("frame expected");
+        assert_eq!(&buf[..n], *expected_payload);
+        assert_eq!(meta.flags, *expected_flags, "payload {expected_payload:?}");
+        assert_eq!(meta.len, expected_payload.len());
+        assert_eq!(meta.offset, 0);
+        assert_eq!(meta.bytesleft, 0);
+    }
+
+    // Message 2 reassembles into the concatenated text.
+    let message = within(conn.recv_message()).await.unwrap();
+    assert_eq!(message, Message::Text("foobarbaz".to_string()));
+
+    within(server).await.unwrap();
+}
+
+// --- WsConnection: invalid inbound frames (curl tests 2701-2706, 2713-2718, 2722 analogs) ---
+
+/// Connect, feed `bad` after the 101, and return the resulting recv error.
+/// The server holds its socket open so the failure is the frame validation,
+/// never a surprise EOF.
+async fn recv_rejects(bad: &'static [u8]) -> Error {
+    let (port, _server) = spawn_server(move |mut stream| async move {
+        stream.write_all(HANDSHAKE_101).await.unwrap();
+        stream.write_all(bad).await.unwrap();
+        let mut sink = [0u8; 16];
+        let _ = stream.read(&mut sink).await;
+    })
+    .await;
+
+    let mut conn = ws_connection(port, 0).await;
+    let mut buf = [0u8; 64];
+    within(conn.recv(&mut buf)).await.unwrap_err()
+}
+
+#[tokio::test]
+async fn recv_rejects_reserved_opcode() {
+    // Opcode 0x3 is reserved (curl test 2704 analog).
+    let err = recv_rejects(&[0x83, 0x00]).await;
+    assert!(err.to_string().contains("invalid opcode"), "got: {err}");
+}
+
+#[tokio::test]
+async fn recv_rejects_rsv_bits() {
+    // RSV1 set without a negotiated extension (curl test 2705 analog).
+    let err = recv_rejects(&[0xC1, 0x00]).await;
+    assert!(err.to_string().contains("reserved bits"), "got: {err}");
+}
+
+#[tokio::test]
+async fn recv_rejects_masked_server_frame() {
+    // Server-to-client frames must not be masked.
+    let err = recv_rejects(&[0x81, 0x83]).await;
+    assert!(err.to_string().contains("masked frame"), "got: {err}");
+}
+
+#[tokio::test]
+async fn recv_rejects_oversized_control_frame() {
+    // PING with a declared 126-byte payload (curl test 2702 analog).
+    let err = recv_rejects(&[0x89, 0x7E, 0x00, 0x7E]).await;
+    assert!(err.to_string().contains("control frame payload"), "got: {err}");
+}
+
+#[tokio::test]
+async fn recv_rejects_fragmented_control_frame() {
+    // PING without FIN (curl test 2703 analog).
+    let err = recv_rejects(&[0x09, 0x00]).await;
+    assert!(err.to_string().contains("fragmented control frame"), "got: {err}");
+}
+
+#[tokio::test]
+async fn recv_rejects_stray_continuation() {
+    // CONT with no fragmented message in progress (curl test 2706 analog).
+    let err = recv_rejects(&[0x00, 0x01, b'x']).await;
+    assert!(err.to_string().contains("no ongoing fragmented message"), "got: {err}");
+}
+
+#[tokio::test]
+async fn recv_rejects_new_message_mid_fragment() {
+    // A new TEXT frame while a fragmented message is open (2707 analog).
+    let (port, _server) = spawn_server(|mut stream| async move {
+        stream.write_all(HANDSHAKE_101).await.unwrap();
+        stream.write_all(&server_frame(0x01, b"a")).await.unwrap(); // TEXT, no FIN
+        stream.write_all(&server_frame(0x81, b"b")).await.unwrap(); // new final TEXT
+        let mut sink = [0u8; 16];
+        let _ = stream.read(&mut sink).await;
+    })
+    .await;
+
+    let mut conn = ws_connection(port, 0).await;
+    let mut buf = [0u8; 64];
+    let (n, meta) = within(conn.recv(&mut buf)).await.unwrap().expect("first fragment");
+    assert_eq!(&buf[..n], b"a");
+    assert_eq!(meta.flags, ws_flags::TEXT | ws_flags::CONT);
+
+    let err = within(conn.recv(&mut buf)).await.unwrap_err();
+    assert!(err.to_string().contains("interrupted by new message"), "got: {err}");
+}
+
+// --- WsConnection: unsolicited PONG + zero-length frames (2710 analog) ---
+
+#[tokio::test]
+async fn recv_surfaces_unsolicited_pong_and_zero_length_frames() {
+    let (port, server) = spawn_server(|mut stream| async move {
+        stream.write_all(HANDSHAKE_101).await.unwrap();
+        stream.write_all(&server_frame(0x8A, b"tag")).await.unwrap(); // PONG
+        stream.write_all(&server_frame(0x81, b"")).await.unwrap(); // empty TEXT
+    })
+    .await;
+
+    let mut conn = ws_connection(port, 0).await;
+    let mut buf = [0u8; 64];
+
+    let (n, meta) = within(conn.recv(&mut buf)).await.unwrap().expect("PONG expected");
+    assert_eq!(&buf[..n], b"tag");
+    assert_eq!(meta.flags, ws_flags::PONG);
+
+    // A zero-length frame yields exactly one zero-length chunk.
+    let (n, meta) = within(conn.recv(&mut buf)).await.unwrap().expect("empty TEXT expected");
+    assert_eq!(n, 0);
+    assert_eq!(meta.flags, ws_flags::TEXT);
+    assert_eq!((meta.len, meta.offset, meta.bytesleft), (0, 0, 0));
+
+    // Server closed: clean end of connection.
+    assert!(within(conn.recv(&mut buf)).await.unwrap().is_none());
+    assert_eq!(conn.frames_received(), 2);
+
+    within(server).await.unwrap();
+}
+
+// --- WsConnection: NO_AUTO_PONG option ---
+
+#[tokio::test]
+async fn no_auto_pong_surfaces_ping_and_sends_no_pong() {
+    let (port, server) = spawn_server(|mut stream| async move {
+        stream.write_all(HANDSHAKE_101).await.unwrap();
+        stream.write_all(&server_frame(0x89, b"hi")).await.unwrap(); // PING
+                                                                     // The next client frame must be the TEXT the test sends afterwards:
+                                                                     // TCP ordering proves no PONG was emitted before it.
+        read_client_frame(&mut stream).await
+    })
+    .await;
+
+    let mut conn = ws_connection(port, ws_options::NO_AUTO_PONG).await;
+    let mut buf = [0u8; 64];
+
+    let (n, meta) = within(conn.recv(&mut buf)).await.unwrap().expect("PING expected");
+    assert_eq!(&buf[..n], b"hi");
+    assert_eq!(meta.flags, ws_flags::PING, "PING must be surfaced when auto-pong is off");
+
+    within(conn.send(b"done", ws_flags::TEXT)).await.unwrap();
+
+    let (first_byte, payload) = within(server).await.unwrap();
+    assert_eq!(first_byte, 0x81, "no PONG may precede the client TEXT frame");
+    assert_eq!(payload, b"done");
+}
+
+// --- WsConnection: chunked delivery of a large frame ---
+
+#[tokio::test]
+async fn recv_delivers_large_frame_in_chunks_with_meta() {
+    let payload: Vec<u8> = (0..200u8).collect();
+    let frame = server_frame(0x82, &payload);
+    let (port, server) = spawn_server(move |mut stream| async move {
+        stream.write_all(HANDSHAKE_101).await.unwrap();
+        stream.write_all(&frame).await.unwrap();
+    })
+    .await;
+
+    let mut conn = ws_connection(port, 0).await;
+    let mut buf = [0u8; 64];
+    let mut reassembled = Vec::new();
+    let expected_meta = [(64, 0, 136), (64, 64, 72), (64, 128, 8), (8, 192, 0)];
+    for (expected_len, expected_offset, expected_bytesleft) in expected_meta {
+        let (n, meta) = within(conn.recv(&mut buf)).await.unwrap().expect("chunk expected");
+        assert_eq!(n, expected_len);
+        assert_eq!(meta.len, expected_len);
+        assert_eq!(meta.offset, expected_offset);
+        assert_eq!(meta.bytesleft, expected_bytesleft);
+        assert_eq!(meta.flags, ws_flags::BINARY, "every chunk carries the frame flags");
+        reassembled.extend_from_slice(&buf[..n]);
+    }
+    assert_eq!(reassembled, payload);
+
+    // last_meta reflects the final chunk.
+    assert_eq!(conn.last_meta().offset, 192);
+    assert_eq!(conn.last_meta().bytesleft, 0);
+
+    within(server).await.unwrap();
+}
+
+// --- WsConnection: send flag validation + fragmented send ---
+
+#[tokio::test]
+async fn send_validates_flags_and_fragments_messages() {
+    let (port, server) = spawn_server(|mut stream| async move {
+        stream.write_all(HANDSHAKE_101).await.unwrap();
+        let first = read_client_frame(&mut stream).await;
+        let second = read_client_frame(&mut stream).await;
+        (first, second)
+    })
+    .await;
+
+    let mut conn = ws_connection(port, 0).await;
+
+    // Control frame with CONT: invalid flag combination.
+    let err = within(conn.send(b"x", ws_flags::PING | ws_flags::CONT)).await.unwrap_err();
+    assert_eq!(transfer_error(&err).0, 43, "CURLE_BAD_FUNCTION_ARGUMENT");
+
+    // Control payload over 125 bytes.
+    let err = within(conn.send(&[0u8; 126], ws_flags::PING)).await.unwrap_err();
+    assert_eq!(transfer_error(&err).0, 100, "CURLE_TOO_LARGE");
+
+    // Flags 0 outside a fragmented send.
+    let err = within(conn.send(b"x", 0)).await.unwrap_err();
+    assert_eq!(transfer_error(&err).0, 43, "CURLE_BAD_FUNCTION_ARGUMENT");
+
+    // Fragmented send: TEXT|CONT starts the message, final TEXT ends it.
+    assert_eq!(within(conn.send(b"Hello", ws_flags::TEXT | ws_flags::CONT)).await.unwrap(), 5);
+    assert_eq!(within(conn.send(b"World", ws_flags::TEXT)).await.unwrap(), 5);
+
+    let ((first_byte, first_payload), (second_byte, second_payload)) =
+        within(server).await.unwrap();
+    assert_eq!(first_byte, 0x01, "first fragment: TEXT without FIN");
+    assert_eq!(first_payload, b"Hello");
+    assert_eq!(second_byte, 0x80, "final fragment: FIN continuation");
+    assert_eq!(second_payload, b"World");
+}
+
+// --- connect_stream: frames arriving in the same packet as the 101 ---
+
+#[tokio::test]
+async fn connect_stream_leaves_frame_bytes_after_pipelined_101() {
+    let (port, server) = spawn_server(|mut stream| async move {
+        // Headers and the first frame in ONE write: the handshake parser
+        // must not consume any frame bytes.
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(HANDSHAKE_101);
+        bytes.extend_from_slice(&server_frame(0x81, b"hi"));
+        stream.write_all(&bytes).await.unwrap();
+        let mut sink = [0u8; 16];
+        let _ = stream.read(&mut sink).await;
+    })
+    .await;
+
+    let (response, stream) = within(connect_stream(
+        &test_url(port),
+        &[],
+        &TlsConfig::default(),
+        &WsConnectOptions::default(),
+    ))
+    .await
+    .unwrap();
+    assert_eq!(response.status(), 101);
+
+    let mut conn = WsConnection::new(stream, response, 0);
+    assert_eq!(conn.response().status(), 101);
+
+    let mut buf = [0u8; 64];
+    let (n, meta) = within(conn.recv(&mut buf)).await.unwrap().expect("pipelined frame");
+    assert_eq!(&buf[..n], b"hi");
+    assert_eq!(meta.flags, ws_flags::TEXT);
+
+    drop(conn);
+    within(server).await.unwrap();
+}
+
+// --- transfer(): 101 response headers preserved ---
+
+#[tokio::test]
+async fn transfer_preserves_response_status_and_headers() {
+    let (port, server) = spawn_server(|mut stream| async move {
+        stream
+            .write_all(
+                b"HTTP/1.1 101 Switching Protocols\r\n\
+                  Server: ws-mock/1\r\n\
+                  Upgrade: websocket\r\n\
+                  Connection: Upgrade\r\n\
+                  Sec-WebSocket-Accept: HkPsVga7+8LuxM4RGQ5p9tZHeYs=\r\n\r\n",
+            )
+            .await
+            .unwrap();
+        stream.write_all(&server_frame(0x81, b"x")).await.unwrap();
+    })
+    .await;
+
+    let response = run_transfer(port, None).await.unwrap();
+    assert_eq!(response.status(), 101);
+    assert_eq!(response.header("server"), Some("ws-mock/1"));
+    assert_eq!(response.header("upgrade"), Some("websocket"));
+    assert_eq!(response.body(), b"x");
+
+    within(server).await.unwrap();
+}
+
+// --- Easy connect-only API (sync; server on a std thread) ---
+
+/// Read the upgrade request from a std stream through the blank line.
+fn read_upgrade_request_sync(stream: &mut std::net::TcpStream) -> Vec<u8> {
+    use std::io::Read as _;
+    let mut request = Vec::new();
+    let mut byte = [0u8; 1];
+    loop {
+        let n = stream.read(&mut byte).unwrap();
+        assert!(n > 0, "client closed before completing the upgrade request");
+        request.push(byte[0]);
+        if request.ends_with(b"\r\n\r\n") {
+            break;
+        }
+    }
+    request
+}
+
+/// Read one masked client frame from a std stream: `(first_byte, payload)`.
+fn read_client_frame_sync(stream: &mut std::net::TcpStream) -> (u8, Vec<u8>) {
+    use std::io::Read as _;
+    let mut header = [0u8; 2];
+    stream.read_exact(&mut header).unwrap();
+    assert_eq!(header[1] & 0x80, 0x80, "client frames must be masked (RFC 6455)");
+    let mut len = u64::from(header[1] & 0x7F);
+    if len == 126 {
+        let mut ext = [0u8; 2];
+        stream.read_exact(&mut ext).unwrap();
+        len = u64::from(u16::from_be_bytes(ext));
+    } else if len == 127 {
+        let mut ext = [0u8; 8];
+        stream.read_exact(&mut ext).unwrap();
+        len = u64::from_be_bytes(ext);
+    }
+    let mut mask = [0u8; 4];
+    stream.read_exact(&mut mask).unwrap();
+    let mut payload = vec![0u8; usize::try_from(len).unwrap()];
+    stream.read_exact(&mut payload).unwrap();
+    unmask(mask, &mut payload);
+    (header[0], payload)
+}
+
+#[test]
+fn easy_connect_only_ws_round_trip() {
+    use std::io::Write as _;
+
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let server = std::thread::spawn(move || {
+        let (mut stream, _addr) = listener.accept().unwrap();
+        stream.set_read_timeout(Some(TIMEOUT)).unwrap();
+        read_upgrade_request_sync(&mut stream);
+        stream.write_all(HANDSHAKE_101).unwrap();
+        let frame = read_client_frame_sync(&mut stream);
+        stream.write_all(&server_frame(0x81, b"world")).unwrap();
+        // Dropping the stream closes the connection.
+        frame
+    });
+
+    let mut easy = liburlx::Easy::new();
+    easy.url(&format!("ws://127.0.0.1:{port}/chat")).unwrap();
+    easy.set_connect_only(2);
+    let response = easy.perform().unwrap();
+    assert_eq!(response.status(), 101);
+
+    assert_eq!(easy.ws_send(b"hello", ws_flags::TEXT).unwrap(), 5);
+
+    let mut buf = [0u8; 64];
+    let (n, meta) = easy.ws_recv(&mut buf).unwrap().expect("server frame expected");
+    assert_eq!(&buf[..n], b"world");
+    assert_eq!(meta.flags, ws_flags::TEXT);
+    assert_eq!((meta.len, meta.offset, meta.bytesleft), (5, 0, 0));
+
+    // ws_meta reports the same chunk metadata.
+    let stored = easy.ws_meta().expect("meta after ws_recv");
+    assert_eq!(stored.flags, meta.flags);
+    assert_eq!(stored.len, meta.len);
+    assert_eq!(stored.offset, meta.offset);
+    assert_eq!(stored.bytesleft, meta.bytesleft);
+
+    // Server closed after its reply: clean end of connection.
+    assert!(easy.ws_recv(&mut buf).unwrap().is_none());
+
+    let (first_byte, payload) = server.join().unwrap();
+    assert_eq!(first_byte, 0x81, "client TEXT frame expected");
+    assert_eq!(payload, b"hello");
+}
+
+#[test]
+fn easy_ws_send_without_connection_fails() {
+    let mut easy = liburlx::Easy::new();
+    // curl_ws_send without a connection fails with CURLE_SEND_ERROR (55);
+    // curl_ws_recv fails with CURLE_UNSUPPORTED_PROTOCOL (1).
+    let err = easy.ws_send(b"x", ws_flags::TEXT).unwrap_err();
+    assert_eq!(transfer_error(&err).0, 55, "CURLE_SEND_ERROR");
+
+    let mut buf = [0u8; 8];
+    let err = easy.ws_recv(&mut buf).unwrap_err();
+    assert_eq!(transfer_error(&err).0, 1, "CURLE_UNSUPPORTED_PROTOCOL");
+}
+
+#[test]
+fn easy_connect_only_mode_one_fails_not_built_in() {
+    // Mode 1 (raw connect-only) is unsupported even for ws URLs; the check
+    // happens before any connection so no server is needed.
+    let mut easy = liburlx::Easy::new();
+    easy.url("ws://127.0.0.1:1/").unwrap();
+    easy.set_connect_only(1);
+    let err = easy.perform().unwrap_err();
+    assert_eq!(transfer_error(&err).0, 4, "CURLE_NOT_BUILT_IN");
+}
+
+#[test]
+fn easy_connect_only_ws_mode_on_http_url_fails_not_built_in() {
+    let mut easy = liburlx::Easy::new();
+    easy.url("http://127.0.0.1:1/").unwrap();
+    easy.set_connect_only(2);
+    let err = easy.perform().unwrap_err();
+    assert_eq!(transfer_error(&err).0, 4, "CURLE_NOT_BUILT_IN");
+}

--- a/crates/liburlx/tests/ws_entropy.rs
+++ b/crates/liburlx/tests/ws_entropy.rs
@@ -1,0 +1,60 @@
+//! Deterministic WebSocket entropy tests (`CURL_ENTROPY` /
+//! `CURL_WS_FORCE_ZERO_MASK`).
+//!
+//! This file must stay a separate integration test with exactly ONE test:
+//! the entropy variables seed process-global once-latched state in liburlx,
+//! so any other test in the same binary would observe (or disturb) the
+//! deterministic sequence.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, unused_results)]
+
+use std::collections::HashMap;
+
+use liburlx::protocol::ws::{generate_ws_key, ws_flags, WsConnection};
+use liburlx::Response;
+use tokio::io::AsyncReadExt;
+
+#[test]
+fn curl_entropy_pins_ws_key_and_frame_masks() {
+    // Must happen before any key/mask generation: the seed is latched on
+    // first use (curl compat: lib/rand.c static randseed).
+    std::env::set_var("CURL_ENTROPY", "12345678");
+
+    // Draws 1-4 (16 key bytes): the deterministic Sec-WebSocket-Key that
+    // curl test 2300 pins for CURL_ENTROPY=12345678.
+    assert_eq!(generate_ws_key(), "NDMyMTUzMjE2MzIxNzMyMQ==");
+
+    let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+    rt.block_on(async {
+        let (client, mut server) = tokio::io::duplex(4096);
+        let response = Response::new(101, HashMap::new(), Vec::new(), "ws://test/".to_string());
+        let mut conn = WsConnection::new(Box::new(client), response, 0);
+
+        // Draw 5: the first frame mask after the key. Seed 0x31323334
+        // ("1234" big-endian) has advanced four times; the fifth value
+        // 0x31323338 serializes LSB-first as b"8321".
+        assert_eq!(conn.send(b"hey", ws_flags::TEXT).await.unwrap(), 3);
+        let mut wire = [0u8; 9];
+        server.read_exact(&mut wire).await.unwrap();
+        assert_eq!(wire[0], 0x81, "FIN + TEXT");
+        assert_eq!(wire[1], 0x80 | 3, "mask bit + length 3");
+        assert_eq!(&wire[2..6], b"8321", "deterministic mask key (fifth draw)");
+        let mut payload = [wire[6], wire[7], wire[8]];
+        for (i, byte) in payload.iter_mut().enumerate() {
+            *byte ^= wire[2 + (i % 4)];
+        }
+        assert_eq!(&payload, b"hey", "payload must be XOR-masked with the key");
+
+        // CURL_WS_FORCE_ZERO_MASK zeroes the mask bytes but keeps the mask
+        // bit set (curl compat: tests 2700+), so the payload rides the wire
+        // verbatim.
+        std::env::set_var("CURL_WS_FORCE_ZERO_MASK", "1");
+        assert_eq!(conn.send(b"zero", ws_flags::BINARY).await.unwrap(), 4);
+        let mut wire = [0u8; 10];
+        server.read_exact(&mut wire).await.unwrap();
+        assert_eq!(wire[0], 0x82, "FIN + BINARY");
+        assert_eq!(wire[1], 0x80 | 4, "mask bit still set with a zero mask");
+        assert_eq!(&wire[2..6], &[0, 0, 0, 0], "four zero mask bytes");
+        assert_eq!(&wire[6..], b"zero", "zero mask leaves the payload unchanged");
+    });
+}

--- a/crates/urlx-cli/src/args.rs
+++ b/crates/urlx-cli/src/args.rs
@@ -440,10 +440,8 @@ pub fn parse_args(args: &[String]) -> ParseResult {
             "-h" | "--help" => return ParseResult::Help,
             "-V" | "--version" => return ParseResult::Version,
             // --engine list: print available engines and exit (curl compat: test 307)
-            "--engine" => {
-                if expanded.get(idx + 1).map(String::as_str) == Some("list") {
-                    return ParseResult::EngineList;
-                }
+            "--engine" if expanded.get(idx + 1).map(String::as_str) == Some("list") => {
+                return ParseResult::EngineList;
             }
             _ => {}
         }

--- a/crates/urlx-cli/src/transfer.rs
+++ b/crates/urlx-cli/src/transfer.rs
@@ -1967,7 +1967,7 @@ pub fn run(args: &[String]) -> ExitCode {
                     );
                 }
                 if !opts.silent || opts.show_error {
-                    eprintln!("curl: (22) The requested URL returned error: {}", response.status(),);
+                    eprintln!("curl: (22) The requested URL returned error: {}", response.status());
                 }
                 return ExitCode::from(22);
             }
@@ -1982,7 +1982,7 @@ pub fn run(args: &[String]) -> ExitCode {
                 if cl_exceeded {
                     // Content-Length known upfront: error without output
                     if !opts.silent || opts.show_error {
-                        eprintln!("curl: maximum file size exceeded",);
+                        eprintln!("curl: maximum file size exceeded");
                     }
                     return ExitCode::from(63);
                 }
@@ -2006,7 +2006,7 @@ pub fn run(args: &[String]) -> ExitCode {
                         false, // don't suppress body
                     );
                     if !opts.silent || opts.show_error {
-                        eprintln!("curl: (63) Maximum file size exceeded",);
+                        eprintln!("curl: (63) Maximum file size exceeded");
                     }
                     return ExitCode::from(63);
                 }
@@ -2245,7 +2245,7 @@ pub fn run(args: &[String]) -> ExitCode {
             // --fail-with-body: output body first, then return error exit code
             if opts.fail_with_body && response.status() >= 400 {
                 if !opts.silent || opts.show_error {
-                    eprintln!("curl: (22) The requested URL returned error: {}", response.status(),);
+                    eprintln!("curl: (22) The requested URL returned error: {}", response.status());
                 }
                 return ExitCode::from(22);
             }

--- a/scripts/urlx-as-curl
+++ b/scripts/urlx-as-curl
@@ -11,7 +11,25 @@ VERSION=$("$URLX" --version 2>&1 | head -1 | awk '{print $2}')
 if [ "$1" = "--version" ]; then
     # Get urlx version and translate branding to curl-compatible format
     # for the test runner (runtests.pl expects "curl <ver> ... libcurl/<ver> ...")
-    "$URLX" --version 2>&1 | sed -e 's/^urlx /curl /' -e 's/liburlx\//libcurl\//'
+    #
+    # URLX_EXTRA_FEATURES optionally injects extra feature words into the
+    # Features line. Used to advertise "Debug" when running the WebSocket
+    # tests (urlx honors CURL_ENTROPY/CURL_WS_FORCE_ZERO_MASK regardless of
+    # build type, but curl gates those tests on a debug build). Off by
+    # default because advertising Debug un-skips ~35 unrelated tests that
+    # need other curl debug-build env-var behaviors.
+    extra_sed=()
+    if [ -n "${URLX_EXTRA_FEATURES:-}" ]; then
+        case "$URLX_EXTRA_FEATURES" in
+            *[!A-Za-z0-9\ _-]*)
+                echo "urlx-as-curl: ignoring URLX_EXTRA_FEATURES with unsafe characters" >&2
+                ;;
+            *)
+                extra_sed=(-e "s/^Features: /Features: ${URLX_EXTRA_FEATURES} /")
+                ;;
+        esac
+    fi
+    "$URLX" --version 2>&1 | sed -e 's/^urlx /curl /' -e 's/liburlx\//libcurl\//' "${extra_sed[@]}"
     exit 0
 fi
 

--- a/tests/excluded-tests.txt
+++ b/tests/excluded-tests.txt
@@ -44,3 +44,38 @@ test:555:libcurl C API test — NTLM proxy auth with POST via multi interface (l
 test:560:libcurl C API test — HTTPS GET with multi interface (lib560)
 test:590:libcurl C API test — proxy Negotiate+NTLM selection (lib590)
 test:694:libcurl C API test — NTLM twice, CURLINFO_HTTPAUTH_USED (lib694)
+
+# WebSocket libcurl C API tests — run C tool programs (lib2301/lib2302/
+# lib2304/lib2700) against libcurl's curl_ws_send/curl_ws_recv API. urlx
+# implements that API in liburlx-ffi (covered by Rust integration tests in
+# crates/liburlx/tests/ws_e2e.rs and liburlx-ffi tests), but the C tools
+# cannot be run against the urlx CLI. Test 2300 — the only CLI-driven WS
+# test — passes (run with URLX_EXTRA_FEATURES=Debug, see scripts/urlx-as-curl).
+test:2301:libcurl C API test — WebSocket raw mode + curl_ws_send (lib2301)
+test:2302:libcurl C API test — WebSocket frame mode callback + curl_ws_send (lib2302)
+test:2303:libcurl C API test — WebSocket upgrade refused with 200 (lib2302)
+test:2304:libcurl C API test — curl_ws_recv on closed connection (lib2304)
+test:2700:libcurl C API test — ws: Frame types (lib2700)
+test:2701:libcurl C API test — ws: Invalid opcode 0x3 (lib2700)
+test:2702:libcurl C API test — ws: Invalid opcode 0xB (lib2700)
+test:2703:libcurl C API test — ws: Invalid reserved bit RSV1 (lib2700)
+test:2704:libcurl C API test — ws: Invalid reserved bit RSV2 (lib2700)
+test:2705:libcurl C API test — ws: Invalid reserved bit RSV3 (lib2700)
+test:2706:libcurl C API test — ws: Invalid masked server message (lib2700)
+test:2707:libcurl C API test — ws: Peculiar frame sizes (lib2700)
+test:2708:libcurl C API test — ws: Automatic PONG (lib2700)
+test:2709:libcurl C API test — ws: No automatic PONG (lib2700)
+test:2710:libcurl C API test — ws: Unsolicited PONG (lib2700)
+test:2711:libcurl C API test — ws: Empty PING/PONG/CLOSE (lib2700)
+test:2712:libcurl C API test — ws: Max sized PING/PONG/CLOSE (lib2700)
+test:2713:libcurl C API test — ws: Invalid oversized PING (lib2700)
+test:2714:libcurl C API test — ws: Invalid oversized PONG (lib2700)
+test:2715:libcurl C API test — ws: Invalid oversized CLOSE (lib2700)
+test:2716:libcurl C API test — ws: Invalid fragmented PING (lib2700)
+test:2717:libcurl C API test — ws: Invalid fragmented PONG (lib2700)
+test:2718:libcurl C API test — ws: Invalid fragmented CLOSE (lib2700)
+test:2719:libcurl C API test — ws: Fragmented messages (lib2700)
+test:2720:libcurl C API test — ws: Fragmented messages with empty fragments (lib2700)
+test:2721:libcurl C API test — ws: Fragmented messages with interleaved pong (lib2700)
+test:2722:libcurl C API test — ws: Invalid fragmented message without initial frame (lib2700)
+test:2723:libcurl C API test — ws: Invalid fragmented message without final frame (lib2700)


### PR DESCRIPTION
Closes #139.

## What

WebSocket support is now implemented end to end instead of dropping the upgraded connection after the 101 handshake:

**liburlx (core)**
- `ws::connect_stream()` returns the handshake `Response` together with the live upgraded stream (`connect()` remains as the handshake-only compatibility wrapper).
- New `WsConnection`: libcurl-fidelity frame I/O — chunked `recv` with `WsFrameMeta` (flags/offset/bytesleft, matching `struct curl_ws_frame`), `send` with `curl_ws_send` flag semantics (fragmentation via `CONT`, control-frame rules, raw mode), automatic PONG replies, curl's inbound validation rules (masked server frames, oversized/fragmented/extended-length control frames, RSV bits, reserved opcodes, stray continuations), and message-level `recv_message`/`send_text`/... conveniences. Data-frame payloads stream from the wire, so a hostile frame length can't drive a huge allocation.
- `ws::transfer()`: curl's CLI transfer semantics — upload data sent as masked BINARY frames, TEXT/BINARY/PONG/CLOSE payloads (incl. the 2-byte close code) collected as the body, PINGs auto-ponged and never surfaced, transfer ends at server EOF, "Empty reply from server" (52) when the server closes after the 101 with zero frames, "Refused WebSocket upgrade" (22) on a non-101 response.
- Handshake matches curl byte for byte: header order (`Upgrade`, `Sec-WebSocket-Version`, `Sec-WebSocket-Key`, `Connection: Upgrade` last), user-supplied handshake headers override the generated ones (custom `Connection` values merge as `<custom>, Upgrade`), auto-generated Basic credentials are emitted as a real `Authorization` header, and `Sec-WebSocket-Accept` is deliberately not validated (curl never validates it and curl's own test data uses non-matching values).
- ws/wss connections honor `--connect-timeout` and route through HTTP CONNECT and SOCKS4/4a/5/5h proxies (silently bypassing a configured proxy was a review finding).
- `CURL_ENTROPY` and `CURL_WS_FORCE_ZERO_MASK` produce curl's exact deterministic key/mask sequences (needed by the curl test suite).
- `Easy`: `set_connect_only(2)` + `perform()` retains the connection (with a persistent runtime) for sync `ws_send`/`ws_recv`/`ws_meta`; `ws_connection()`/`take_ws_connection()` for async use. A new perform drops any stale retained connection.

**liburlx-ffi**
- `curl_ws_send`, `curl_ws_recv`, `curl_ws_meta` exports with `struct curl_ws_frame`, all `CURLWS_*` flag constants, `CURLOPT_CONNECT_ONLY` (141, range-validated like libcurl) and `CURLOPT_WS_OPTIONS` (320); `CURLE_NOT_BUILT_IN`/`CURLE_TOO_LARGE` added to `CURLcode`. All entry points follow the crate's catch_unwind + null-check + `// SAFETY:` conventions; error codes match libcurl (`CURLE_GOT_NOTHING` on close, `CURLE_SEND_ERROR` for send failures, etc.). Header regenerated via cbindgen.

**CLI**
- `urlx ws://…` performs a full curl-style transfer with curl's exit codes; `-T .` is accepted as stdin upload (curl's non-blocking stdin form; currently read up-front like `-T -`).

## curl test suite

- **Test 2300 (`WebSockets upgrade only`) passes** — the only WS test that drives the plain CLI: `URLX_EXTRA_FEATURES=Debug ./scripts/run-curl-tests.sh 2300`. The `Debug` feature is injected opt-in by the wrapper because advertising it globally would un-skip ~35 unrelated tests requiring curl debug-build env vars.
- Tests 2301-2304 and 2700-2723 run C `<tool>` programs against libcurl's C API and are permanently excluded with rationale (consistent with existing policy); their scenarios are covered by the new Rust suites.
- **Full regression: 1,304/1,304 (100%) on tests 1-1400.** That includes a fix for test 729 (`SOCKS4 with long proxy username`), which was failing on `main` before this branch (urlx lacked curl's >255-byte SOCKS4 user-name rejection).

## Tests

- `crates/liburlx/tests/ws_e2e.rs` — 22 end-to-end tests over real sockets mirroring the 2300/2700-series scenarios (frame types, fragmentation incl. empty fragments, all invalid-frame cases, auto/no-auto PONG, chunked delivery metadata, connect-only Easy round trip, exit-code semantics).
- `crates/liburlx/tests/ws_entropy.rs` — deterministic `CURL_ENTROPY` key (`NDMyMTUzMjE2MzIxNzMyMQ==`) and mask sequence, plus `CURL_WS_FORCE_ZERO_MASK`.
- `crates/liburlx/tests/ws_curl_compat.rs` — regression tests for the adversarial-review fixes (auth header rewrite, handshake-header overrides, connect timeout, CONNECT proxy tunnel, `flags==0` contfragment quirk, EOF-mid-frame semantics, extended-length control rejection, refused-upgrade response recording, stale-connection clearing).
- 7 new FFI unit tests incl. a full `CONNECT_ONLY=2` C-API round trip against a mock server.

An adversarial multi-agent review of the diff produced 26 confirmed findings; all behavior-critical ones are fixed in this branch, and the remaining architectural deviations are filed as follow-up issues: #140 (FFI `CURLE_AGAIN` non-blocking semantics + `curl_ws_meta` inside write callbacks), #141 (streaming stdin uploads), #142 (SOCKS4 user-name percent-decoding). #143 tracks a pre-existing flake in test 339 (`--etag-save`) that reproduces on pristine main.

## Guardrails

`cargo fmt --check`, `cargo clippy --workspace --all-targets` (0 warnings — includes fixing pre-existing clippy 1.95 breakage on main), `cargo test --workspace` (2,891 passed / 0 failed), `cargo doc`, and `cargo deny check` all clean. The deny advisories required bumping russh 0.58 → 0.62 (RUSTSEC-2026-0153 and the libcrux chain); SSH tests pass unchanged.
